### PR TITLE
feat(escrow): get_funding_token, get_treasury, get_registry_ref semantics

### DIFF
--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -1,0 +1,165 @@
+# Escrow Read API
+
+Soroban read-only entry points on `LiquifactEscrow`. All functions take `env: Env` and are
+view-only (no state mutation, no auth required).
+
+---
+
+## `get_funding_token() → Address`
+
+**Storage key:** `DataKey::FundingToken`
+
+Returns the SEP-41 token contract address bound to this escrow instance at `init`.
+
+- **Immutable** — set once at `init`; cannot change after deploy.
+- Panics with `"Funding token not set"` if called before `init`.
+- This is the only token that `sweep_terminal_dust` may transfer to the treasury.
+
+---
+
+## `get_treasury() → Address`
+
+**Storage key:** `DataKey::Treasury`
+
+Returns the protocol treasury address that receives terminal dust sweeps.
+
+- **Immutable** — set once at `init`; cannot change after deploy.
+- Panics with `"Treasury not set"` if called before `init`.
+- The treasury must authorize `sweep_terminal_dust`; the admin cannot sweep unless it is also the treasury.
+
+---
+
+## `get_registry_ref() → Option<Address>`
+
+**Storage key:** `DataKey::RegistryRef`
+
+Returns the optional registry contract address supplied at `init`, or `None` when absent.
+
+### Non-authority model
+
+`RegistryRef` is a **read-only discoverability hint** for off-chain indexers only.
+
+- No on-chain logic in this contract reads or calls this address.
+- Its presence **does not** prove registry membership; call the registry contract directly to
+  verify any on-chain claim.
+- `None` is a valid, fully operational state — registry integration is optional.
+- The key is omitted from instance storage entirely when `registry = None` at `init`, so
+  `get_registry_ref()` on an uninitialized contract also returns `None`.
+
+---
+
+## `get_escrow() → InvoiceEscrow`
+
+**Storage key:** `DataKey::Escrow`
+
+Returns the full escrow snapshot. Panics with `"Escrow not initialized"` before `init`.
+
+---
+
+## `get_version() → u32`
+
+**Storage key:** `DataKey::Version`
+
+Returns the current schema version (`SCHEMA_VERSION`). Returns `0` before `init`.
+
+---
+
+## `get_legal_hold() → bool`
+
+**Storage key:** `DataKey::LegalHold`
+
+Returns `true` when a compliance hold is active. Defaults to `false` when the key is absent.
+
+---
+
+## `get_min_contribution_floor() → i128`
+
+**Storage key:** `DataKey::MinContributionFloor`
+
+Returns the per-call funding floor in token base units. `0` means no extra floor.
+
+---
+
+## `get_max_unique_investors_cap() → Option<u32>`
+
+**Storage key:** `DataKey::MaxUniqueInvestorsCap`
+
+Returns the optional cap on distinct investor addresses. `None` means unlimited.
+
+---
+
+## `get_unique_funder_count() → u32`
+
+**Storage key:** `DataKey::UniqueFunderCount`
+
+Returns the count of distinct addresses that have contributed principal. Initialized to `0` at `init`.
+
+---
+
+## `get_contribution(investor: Address) → i128`
+
+**Storage key:** `DataKey::InvestorContribution(investor)`
+
+Returns the cumulative principal contributed by `investor`. `0` when absent.
+
+---
+
+## `get_funding_close_snapshot() → Option<FundingCloseSnapshot>`
+
+**Storage key:** `DataKey::FundingCloseSnapshot`
+
+Returns the pro-rata denominator snapshot captured when the escrow first became **funded** (status 1).
+`None` until that transition. Immutable once written.
+
+---
+
+## `get_investor_yield_bps(investor: Address) → i64`
+
+**Storage key:** `DataKey::InvestorEffectiveYield(investor)`
+
+Returns the effective annualized yield (bps) locked in at the investor's first deposit.
+Falls back to `InvoiceEscrow::yield_bps` when the key is absent (legacy positions).
+
+---
+
+## `get_investor_claim_not_before(investor: Address) → u64`
+
+**Storage key:** `DataKey::InvestorClaimNotBefore(investor)`
+
+Returns the earliest ledger timestamp at which the investor may call `claim_investor_payout`.
+`0` means no extra gate beyond settled status.
+
+---
+
+## `get_sme_collateral_commitment() → Option<SmeCollateralCommitment>`
+
+**Storage key:** `DataKey::SmeCollateralPledge`
+
+Returns the SME collateral pledge metadata, or `None` when never recorded.
+
+**Record-only:** this is not an enforced on-chain asset lock.
+
+---
+
+## `is_investor_claimed(investor: Address) → bool`
+
+**Storage key:** `DataKey::InvestorClaimed(investor)`
+
+Returns `true` when the investor has exercised `claim_investor_payout`. Defaults to `false`.
+
+---
+
+## `get_primary_attestation_hash() → Option<BytesN<32>>`
+
+**Storage key:** `DataKey::PrimaryAttestationHash`
+
+Returns the single-set 32-byte attestation digest, or `None` when unbound.
+
+---
+
+## `get_attestation_append_log() → Vec<BytesN<32>>`
+
+**Storage key:** `DataKey::AttestationAppendLog`
+
+Returns the append-only audit chain of digests. Returns an empty `Vec` when no entries exist.
+Bounded by `MAX_ATTESTATION_APPEND_ENTRIES`.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -527,7 +527,9 @@ impl LiquifactEscrow {
         escrow
     }
 
-    /// Bound funding token (immutable after [`LiquifactEscrow::init`]).
+    /// Returns the SEP-41 funding token bound at [`LiquifactEscrow::init`] ([`DataKey::FundingToken`]).
+    ///
+    /// **Immutable:** set once at init; cannot change after deploy. Panics if called before init.
     pub fn get_funding_token(env: Env) -> Address {
         env.storage()
             .instance()
@@ -535,7 +537,10 @@ impl LiquifactEscrow {
             .unwrap_or_else(|| panic!("Funding token not set"))
     }
 
-    /// Treasury that may receive terminal dust sweeps (immutable after init).
+    /// Returns the protocol treasury address bound at [`LiquifactEscrow::init`] ([`DataKey::Treasury`]).
+    ///
+    /// **Immutable:** set once at init; cannot change after deploy. The treasury is the only
+    /// recipient of [`LiquifactEscrow::sweep_terminal_dust`]. Panics if called before init.
     pub fn get_treasury(env: Env) -> Address {
         env.storage()
             .instance()
@@ -543,7 +548,12 @@ impl LiquifactEscrow {
             .unwrap_or_else(|| panic!("Treasury not set"))
     }
 
-    /// Optional registry contract id (**hint only** — not authority for this escrow).
+    /// Returns the optional off-chain registry hint stored at [`DataKey::RegistryRef`], or [`None`]
+    /// when no registry was supplied at [`LiquifactEscrow::init`].
+    ///
+    /// **Non-authority:** this address is a read-only discoverability hint for off-chain indexers.
+    /// No on-chain logic in this contract consults it. Callers must **not** treat its presence as
+    /// proof of registry membership — query the registry contract directly to verify on-chain state.
     pub fn get_registry_ref(env: Env) -> Option<Address> {
         env.storage().instance().get(&DataKey::RegistryRef)
     }

--- a/escrow/src/test/init.rs
+++ b/escrow/src/test/init.rs
@@ -310,6 +310,29 @@ fn test_init_stores_registry_some_and_getters() {
 }
 
 #[test]
+#[should_panic(expected = "Funding token not set")]
+fn test_get_funding_token_before_init_panics() {
+    let env = Env::default();
+    let client = deploy(&env);
+    client.get_funding_token();
+}
+
+#[test]
+#[should_panic(expected = "Treasury not set")]
+fn test_get_treasury_before_init_panics() {
+    let env = Env::default();
+    let client = deploy(&env);
+    client.get_treasury();
+}
+
+#[test]
+fn test_get_registry_ref_before_init_returns_none() {
+    let env = Env::default();
+    let client = deploy(&env);
+    assert_eq!(client.get_registry_ref(), None);
+}
+
+#[test]
 fn test_init_registry_none_roundtrip() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Cross-check read getters against storage keys, document registry non-authority model, and add absent-key tests.

- `get_funding_token` / `get_treasury`: doc cross-references `DataKey` variant, immutability, and panic behaviour
- `get_registry_ref`: expands non-authority semantics — hint-only, no on-chain consultation, must not be used as proof of registry membership
- New tests: panic before init for `get_funding_token` + `get_treasury`; `None` before init for `get_registry_ref`
- `docs/escrow-read-api.md`: full read API reference with storage keys, defaults, and absent-key behaviour

All 91 tests pass; line coverage 97.02% (≥ 95%).

Closes #158
<img width="2173" height="1095" alt="Screenshot 2026-04-23 004629" src="https://github.com/user-attachments/assets/86f4018b-7538-42b8-8af3-112f320274b3" />
