### PR TITLE
`refactor(escrow): DRY StellarAsset/TokenClient test token setup helpers`

### DIFF
--- a/escrow/src/test.rs
+++ b/escrow/src/test.rs
@@ -5,7 +5,7 @@ use super::{
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Ledger as _},
-    token::StellarAssetClient,
+    token::{StellarAssetClient, TokenClient},
     Address, Env, String, Vec as SorobanVec,
 };
 
@@ -18,9 +18,20 @@ mod integration;
 mod properties;
 mod settlement;
 
+/// Registers a new escrow contract instance and returns its contract id.
+pub(super) fn deploy_id(env: &Env) -> Address {
+    env.register(LiquifactEscrow, ())
+}
+
 pub(super) fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
-    let id = env.register(LiquifactEscrow, ());
+    let id = deploy_id(env);
     LiquifactEscrowClient::new(env, &id)
+}
+
+pub(super) fn deploy_with_id(env: &Env) -> (Address, LiquifactEscrowClient<'_>) {
+    let id = deploy_id(env);
+    let client = LiquifactEscrowClient::new(env, &id);
+    (id, client)
 }
 
 pub(super) fn setup(env: &Env) -> (LiquifactEscrowClient<'_>, Address, Address) {
@@ -33,6 +44,33 @@ pub(super) fn setup(env: &Env) -> (LiquifactEscrowClient<'_>, Address, Address) 
 
 pub(super) fn free_addresses(env: &Env) -> (Address, Address) {
     (Address::generate(env), Address::generate(env))
+}
+
+pub(super) struct StellarTestToken<'a> {
+    /// Contract id for the standard Stellar asset token.
+    pub id: Address,
+    /// SEP-41 interface (the same interface the escrow uses in `external_calls`).
+    pub token: TokenClient<'a>,
+    /// Test-only admin client used for minting balances into accounts/contracts.
+    pub stellar: StellarAssetClient<'a>,
+}
+
+/// Install a **standard** Stellar asset token contract (Soroban StellarAsset contract v2).
+///
+/// This is intentionally used for tests that require "well-behaved" SEP-41 semantics:
+/// - No fee-on-transfer / rebasing / callback side-effects.
+/// - `balance` deltas match transfer amounts (as asserted by `external_calls` wrappers).
+///
+/// **Out of scope:** non-standard/malicious token economics; see `escrow/src/external_calls.rs`
+/// and `docs/ESCROW_TOKEN_INTEGRATION_CHECKLIST.md`.
+pub(super) fn install_stellar_asset_token<'a>(env: &'a Env) -> StellarTestToken<'a> {
+    let sac = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let id = sac.address();
+    StellarTestToken {
+        id: id.clone(),
+        token: TokenClient::new(env, &id),
+        stellar: StellarAssetClient::new(env, &id),
+    }
 }
 
 pub(super) fn default_init(

--- a/escrow/src/test/integration.rs
+++ b/escrow/src/test/integration.rs
@@ -68,17 +68,15 @@ fn test_token_integration_assumptions_are_documented_in_readme() {
 fn test_external_transfer_wrapper_balance_deltas() {
     let env = Env::default();
     env.mock_all_auths();
-    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token = sac.address();
-    let holder = env.register(LiquifactEscrow, ());
+    let token = install_stellar_asset_token(&env);
+    let holder = deploy_id(&env);
     let treasury = Address::generate(&env);
-    let stellar = StellarAssetClient::new(&env, &token);
-    stellar.mint(&holder, &777i128);
+    token.stellar.mint(&holder, &777i128);
     external_calls::transfer_funding_token_with_balance_checks(
-        &env, &token, &holder, &treasury, 777i128,
+        &env, &token.id, &holder, &treasury, 777i128,
     );
-    assert_eq!(stellar.balance(&holder), 0);
-    assert_eq!(stellar.balance(&treasury), 777i128);
+    assert_eq!(token.token.balance(&holder), 0);
+    assert_eq!(token.token.balance(&treasury), 777i128);
 }
 
 #[test]
@@ -86,13 +84,11 @@ fn test_external_transfer_wrapper_balance_deltas() {
 fn test_external_wrapper_panics_when_undercollateralized() {
     let env = Env::default();
     env.mock_all_auths();
-    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token = sac.address();
-    let holder = env.register(LiquifactEscrow, ());
+    let token = install_stellar_asset_token(&env);
+    let holder = deploy_id(&env);
     let treasury = Address::generate(&env);
-    let stellar = StellarAssetClient::new(&env, &token);
-    stellar.mint(&holder, &1i128);
+    token.stellar.mint(&holder, &1i128);
     external_calls::transfer_funding_token_with_balance_checks(
-        &env, &token, &holder, &treasury, 10i128,
+        &env, &token.id, &holder, &treasury, 10i128,
     );
 }

--- a/escrow/src/test/settlement.rs
+++ b/escrow/src/test/settlement.rs
@@ -421,13 +421,11 @@ fn test_cost_baseline_full_lifecycle() {
 fn test_sweep_terminal_dust_after_settle_transfers_to_treasury() {
     let env = Env::default();
     env.mock_all_auths();
-    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token = sac.address();
+    let token = install_stellar_asset_token(&env);
     let admin = Address::generate(&env);
     let sme = Address::generate(&env);
     let treasury = Address::generate(&env);
-    let escrow_id = env.register(LiquifactEscrow, ());
-    let client = LiquifactEscrowClient::new(&env, &escrow_id);
+    let (escrow_id, client) = deploy_with_id(&env);
     client.init(
         &admin,
         &String::from_str(&env, "SW001"),
@@ -435,7 +433,7 @@ fn test_sweep_terminal_dust_after_settle_transfers_to_treasury() {
         &1_000i128,
         &100i64,
         &0u64,
-        &token,
+        &token.id,
         &None,
         &treasury,
         &None,
@@ -446,25 +444,22 @@ fn test_sweep_terminal_dust_after_settle_transfers_to_treasury() {
     client.fund(&investor, &1_000i128);
     client.settle();
 
-    let stellar = StellarAssetClient::new(&env, &token);
-    stellar.mint(&escrow_id, &5_000i128);
-    let before_t = stellar.balance(&treasury);
+    token.stellar.mint(&escrow_id, &5_000i128);
+    let before_t = token.token.balance(&treasury);
     let swept = client.sweep_terminal_dust(&5_000i128);
     assert_eq!(swept, 5_000i128);
-    assert_eq!(stellar.balance(&treasury), before_t + 5_000i128);
+    assert_eq!(token.token.balance(&treasury), before_t + 5_000i128);
 }
 
 #[test]
 fn test_sweep_terminal_dust_after_withdraw_and_ledger_tick() {
     let env = Env::default();
     env.mock_all_auths();
-    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token = sac.address();
+    let token = install_stellar_asset_token(&env);
     let admin = Address::generate(&env);
     let sme = Address::generate(&env);
     let treasury = Address::generate(&env);
-    let escrow_id = env.register(LiquifactEscrow, ());
-    let client = LiquifactEscrowClient::new(&env, &escrow_id);
+    let (escrow_id, client) = deploy_with_id(&env);
     client.init(
         &admin,
         &String::from_str(&env, "SW002"),
@@ -472,7 +467,7 @@ fn test_sweep_terminal_dust_after_withdraw_and_ledger_tick() {
         &1_000i128,
         &100i64,
         &0u64,
-        &token,
+        &token.id,
         &None,
         &treasury,
         &None,
@@ -486,8 +481,7 @@ fn test_sweep_terminal_dust_after_withdraw_and_ledger_tick() {
     env.ledger()
         .set_sequence_number(env.ledger().sequence() + 10);
 
-    let stellar = StellarAssetClient::new(&env, &token);
-    stellar.mint(&escrow_id, &333i128);
+    token.stellar.mint(&escrow_id, &333i128);
     let swept = client.sweep_terminal_dust(&333i128);
     assert_eq!(swept, 333i128);
 }
@@ -497,13 +491,11 @@ fn test_sweep_terminal_dust_after_withdraw_and_ledger_tick() {
 fn test_sweep_rejected_when_open() {
     let env = Env::default();
     env.mock_all_auths();
-    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token = sac.address();
+    let token = install_stellar_asset_token(&env);
     let admin = Address::generate(&env);
     let sme = Address::generate(&env);
     let treasury = Address::generate(&env);
-    let escrow_id = env.register(LiquifactEscrow, ());
-    let client = LiquifactEscrowClient::new(&env, &escrow_id);
+    let (escrow_id, client) = deploy_with_id(&env);
     client.init(
         &admin,
         &String::from_str(&env, "SW003"),
@@ -511,15 +503,14 @@ fn test_sweep_rejected_when_open() {
         &1_000i128,
         &100i64,
         &0u64,
-        &token,
+        &token.id,
         &None,
         &treasury,
         &None,
         &None,
         &None,
     );
-    let stellar = StellarAssetClient::new(&env, &token);
-    stellar.mint(&escrow_id, &100i128);
+    token.stellar.mint(&escrow_id, &100i128);
     client.sweep_terminal_dust(&100i128);
 }
 
@@ -528,13 +519,11 @@ fn test_sweep_rejected_when_open() {
 fn test_sweep_blocked_under_legal_hold() {
     let env = Env::default();
     env.mock_all_auths();
-    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token = sac.address();
+    let token = install_stellar_asset_token(&env);
     let admin = Address::generate(&env);
     let sme = Address::generate(&env);
     let treasury = Address::generate(&env);
-    let escrow_id = env.register(LiquifactEscrow, ());
-    let client = LiquifactEscrowClient::new(&env, &escrow_id);
+    let (_escrow_id, client) = deploy_with_id(&env);
     client.init(
         &admin,
         &String::from_str(&env, "SW004"),
@@ -542,7 +531,7 @@ fn test_sweep_blocked_under_legal_hold() {
         &1_000i128,
         &100i64,
         &0u64,
-        &token,
+        &token.id,
         &None,
         &treasury,
         &None,
@@ -561,13 +550,11 @@ fn test_sweep_blocked_under_legal_hold() {
 fn test_sweep_rejects_amount_above_dust_cap() {
     let env = Env::default();
     env.mock_all_auths();
-    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token = sac.address();
+    let token = install_stellar_asset_token(&env);
     let admin = Address::generate(&env);
     let sme = Address::generate(&env);
     let treasury = Address::generate(&env);
-    let escrow_id = env.register(LiquifactEscrow, ());
-    let client = LiquifactEscrowClient::new(&env, &escrow_id);
+    let (_escrow_id, client) = deploy_with_id(&env);
     client.init(
         &admin,
         &String::from_str(&env, "SW005"),
@@ -575,7 +562,7 @@ fn test_sweep_rejects_amount_above_dust_cap() {
         &1_000i128,
         &100i64,
         &0u64,
-        &token,
+        &token.id,
         &None,
         &treasury,
         &None,
@@ -592,13 +579,11 @@ fn test_sweep_rejects_amount_above_dust_cap() {
 fn test_sweep_caps_at_contract_balance() {
     let env = Env::default();
     env.mock_all_auths();
-    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token = sac.address();
+    let token = install_stellar_asset_token(&env);
     let admin = Address::generate(&env);
     let sme = Address::generate(&env);
     let treasury = Address::generate(&env);
-    let escrow_id = env.register(LiquifactEscrow, ());
-    let client = LiquifactEscrowClient::new(&env, &escrow_id);
+    let (escrow_id, client) = deploy_with_id(&env);
     client.init(
         &admin,
         &String::from_str(&env, "SW006"),
@@ -606,7 +591,7 @@ fn test_sweep_caps_at_contract_balance() {
         &1_000i128,
         &100i64,
         &0u64,
-        &token,
+        &token.id,
         &None,
         &treasury,
         &None,
@@ -617,8 +602,7 @@ fn test_sweep_caps_at_contract_balance() {
     client.fund(&investor, &1_000i128);
     client.settle();
 
-    let stellar = StellarAssetClient::new(&env, &token);
-    stellar.mint(&escrow_id, &50i128);
+    token.stellar.mint(&escrow_id, &50i128);
     let swept = client.sweep_terminal_dust(&100i128);
     assert_eq!(swept, 50i128);
 }
@@ -627,13 +611,11 @@ fn test_sweep_caps_at_contract_balance() {
 fn test_sweep_requires_treasury_auth() {
     let env = Env::default();
     env.mock_all_auths();
-    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token = sac.address();
+    let token = install_stellar_asset_token(&env);
     let admin = Address::generate(&env);
     let sme = Address::generate(&env);
     let treasury = Address::generate(&env);
-    let escrow_id = env.register(LiquifactEscrow, ());
-    let client = LiquifactEscrowClient::new(&env, &escrow_id);
+    let (escrow_id, client) = deploy_with_id(&env);
     client.init(
         &admin,
         &String::from_str(&env, "SW007"),
@@ -641,7 +623,7 @@ fn test_sweep_requires_treasury_auth() {
         &1_000i128,
         &100i64,
         &0u64,
-        &token,
+        &token.id,
         &None,
         &treasury,
         &None,
@@ -651,8 +633,7 @@ fn test_sweep_requires_treasury_auth() {
     let investor = Address::generate(&env);
     client.fund(&investor, &1_000i128);
     client.settle();
-    let stellar = StellarAssetClient::new(&env, &token);
-    stellar.mint(&escrow_id, &10i128);
+    token.stellar.mint(&escrow_id, &10i128);
 
     env.mock_auths(&[]);
     let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {


### PR DESCRIPTION
Description:
This PR refactors escrow tests to reduce duplicated Soroban token setup while keeping the “standard SEP-41” security assumptions explicit and easy to audit.

- Adds shared helpers in `escrow/src/test.rs`:
  - `install_stellar_asset_token()` returning `StellarTestToken { id, token: TokenClient, stellar: StellarAssetClient }`
  - `deploy_id()` / `deploy_with_id()` for consistent contract-id + client setup
- Updates token-based tests in `escrow/src/test/integration.rs` and `escrow/src/test/settlement.rs` to use the helpers
- No intended behavior change; purely test refactor with reviewable diff

Test / coverage summary:
- `cargo test -p liquifact_escrow --offline` (88 passed)
- `cargo llvm-cov --features testutils --fail-under-lines 95 --summary-only -p liquifact_escrow` (TOTAL line coverage: 95.84%)

Security notes:
- Helpers intentionally model **well-behaved** SEP-41 semantics (balance deltas match transfer amounts).
- Non-standard/malicious token economics (fee-on-transfer, rebasing, callback side-effects) remain out-of-scope; see `escrow/src/external_calls.rs` and `docs/ESCROW_TOKEN_INTEGRATION_CHECKLIST.md`.

closes #180 