### PR TITLE
feat(escrow): version` — document redeploy vs on-chain upgrade policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,19 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      - name: Add WASM target
+        run: rustup target add wasm32v1-none
+
+      - name: Build WASM
+        run: cargo build --target wasm32v1-none --release -p liquifact_escrow
+
+      - name: Workspace Clippy (all targets)
+        run: cargo clippy --all-targets -- -D warnings
+
       - name: Check coverage (≥ 95%)
         run: |
           cargo llvm-cov \
             --features testutils \
             --fail-under-lines 95 \
-            --summary-only
+            --summary-only \
+            -p liquifact_escrow

--- a/README.md
+++ b/README.md
@@ -1,136 +1,199 @@
-# LiquiFact Escrow Contract
+# LiquiFact Escrow Contracts
 
-Soroban smart contracts for LiquiFact, the invoice liquidity network on Stellar. This repository currently contains the `escrow` contract that holds investor funds for tokenized invoices until settlement.
+Soroban smart contracts for LiquiFact, the invoice liquidity network on Stellar.
+This repository contains the `escrow` contract that holds investor funds for
+tokenized invoices until settlement.
 
-### Per-instance funding asset and registry (issues #113, #116)
+---
+
+## Prerequisites
 
 - Rust 1.70+ (stable)
-- Soroban CLI (optional for deployment)
+- `wasm32v1-none` target for WASM builds: `rustup target add wasm32v1-none`
+- Soroban / Stellar CLI (optional — for deployment and contract interaction)
 
-For local development and CI, Rust is enough.
+For local development and CI, Rust alone is sufficient.
 
-### Treasury dust sweep (issue #107)
+---
+
+## Quick start
 
 ```bash
 cargo build
 cargo test
 ```
+
+---
+
+## Schema version changelog (`DataKey::Version`)
+
+The `SCHEMA_VERSION` constant in `escrow/src/lib.rs` is stored on-chain under
+`DataKey::Version` at [`init`] and is the authoritative version for upgrade
+decisions. All production instances should have this value match the deployed
+WASM.
+
+| Version | Description | Upgrade path |
+|---------|-------------|--------------|
+| 1 | Initial schema (`InvoiceEscrow` v1, basic funding / settle) | N/A |
+| 2 | Added per-investor yield keys (`InvestorEffectiveYield`, `InvestorClaimNotBefore`) | Additive keys — no `migrate` call required for read compatibility |
+| 3 | Added `FundingCloseSnapshot`, `MinContributionFloor`, `MaxUniqueInvestorsCap`, `UniqueFunderCount` | Additive keys — old instances return `None` / `0` defaults |
+| 4 | Added attestation API (`PrimaryAttestationHash`, `AttestationAppendLog`) | Additive keys — no `migrate` call required |
+| 5 | Added `YieldTierTable` (`fund_with_commitment`), `RegistryRef`, `Treasury`; tightened `InvoiceEscrow` layout | **Redeploy required** if `InvoiceEscrow` struct layout differs from stored XDR |
+
+> **Current:** `SCHEMA_VERSION = 5`
+
+---
 
 ## Storage-only upgrade policy (additive fields)
 
 **Compatible without redeploy** when you only:
 
-- Add **new** `DataKey` variants and/or new `#[contracttype]` structs stored under **new** keys.
-- Read new keys with `.get(...).unwrap_or(default)` so missing keys behave as “unset” on old deployments.
+- Add **new** `DataKey` variants and/or new `#[contracttype]` structs stored
+  under **new** keys.
+- Read new keys with `.get(...).unwrap_or(default)` so missing keys behave as
+  "unset" on old deployments.
 
 **Requires new deployment or explicit migration** when you:
 
-- Change layout or meaning of an existing stored type (e.g. new required field on `InvoiceEscrow` without a migration that rewrites `DataKey::Escrow`).
-- Rename or change the XDR shape of an existing `DataKey` variant used in production.
+- Change the layout or XDR shape of an existing stored type (e.g. add a
+  required field to `InvoiceEscrow` without a migration that rewrites
+  `DataKey::Escrow`).
+- Rename or change the XDR shape of an existing `DataKey` variant used in
+  production.
 
-**Compatibility test plan (short):**
+### `migrate` entrypoint — explicit panic semantics
 
-1. Deploy version _N_; exercise `init`, `fund`, `settle`.
-2. Deploy version _N+1_ with only new optional keys; repeat flows; assert old instances still readable.
-3. If `InvoiceEscrow` changes, add a migration test or document mandatory redeploy.
+`LiquifactEscrow::migrate(from_version)` **panics in all current cases**.
+There is **no silent migration path** from any prior version to version 5.
+Callers must not assume it will do bookkeeping work:
 
-`migrate` today validates `from_version` against stored `DataKey::Version` and errors if no path is implemented.
+| Condition | Panic message |
+|-----------|---------------|
+| `stored != from_version` | `"from_version does not match stored version"` |
+| `from_version >= SCHEMA_VERSION` | `"Already at current schema version"` |
+| Any `from_version < SCHEMA_VERSION` | `"No migration path from version {N} — extend migrate or redeploy"` |
+
+To add a real migration path (e.g. rewrite `DataKey::Escrow` after a struct
+field change), implement the transformation inside `migrate` before the final
+`panic!` and update `DataKey::Version`.
 
 ### `DataKey` naming convention
 
-| Command | Description |
-|---|---|
-| `cargo build` | Build the workspace |
-| `cargo test` | Run unit tests |
-| `cargo fmt` | Format code |
-| `cargo fmt -- --check` | Check formatting |
+| Rule | Example |
+|------|---------|
+| PascalCase enum variant | `DataKey::FundingToken` |
+| Per-address variants use tuple form | `DataKey::InvestorContribution(Address)` |
+| New variants must be additive (no rename of existing) | — |
+
+### Compatibility test plan (short)
+
+1. Deploy version _N_; exercise `init`, `fund`, `settle`.
+2. Deploy version _N+1_ with only new optional keys; repeat flows; assert old
+   instances still readable.
+3. If `InvoiceEscrow` changes, add a migration test **or** document mandatory
+   redeploy.
+
+See [`docs/OPERATOR_RUNBOOK.md`](docs/OPERATOR_RUNBOOK.md) for the full
+redeploy-vs-upgrade decision tree and Stellar/Soroban CLI examples.
+
+---
 
 ## Release runbook: build, deploy, verify
 
-**Who may deploy production:** only addresses and keys owned by LiquiFact governance (multisig / custody). Treat contract admin and deployer secrets as **highly sensitive**.
+**Who may deploy production:** only addresses and keys owned by LiquiFact
+governance (multisig / custody). Treat contract admin and deployer secrets as
+**highly sensitive**.
+
+See [`docs/OPERATOR_RUNBOOK.md`](docs/OPERATOR_RUNBOOK.md) for the step-by-step
+runbook including pre-flight checklists, rollback protocol, and legal hold
+coordination.
 
 ### Environment variables (example)
 
 | Variable | Purpose |
 |----------|---------|
-| `STELLAR_NETWORK` | e.g. `TESTNET` / `PUBLIC` / custom Horizon passphrase |
+| `STELLAR_NETWORK` | e.g. `testnet` / `mainnet` / custom network passphrase |
 | `SOROBAN_RPC_URL` | Soroban RPC endpoint |
-| `SOURCE_SECRET` | Funding / deployer Stellar secret key (S ...) |
+| `SOURCE_SECRET` | Funding / deployer Stellar secret key (`S...`) |
 | `LIQUIFACT_ADMIN_ADDRESS` | Initial admin intended to control holds and funding target |
 
-Exact CLI flags change between Soroban releases; always cross-check [Stellar Soroban docs](https://developers.stellar.org/docs/tools/soroban-cli/stellar-cli) for your installed `stellar` / `soroban` CLI version.
+Exact CLI flags change between Soroban releases; always cross-check the
+[Stellar Soroban docs](https://developers.stellar.org/docs/tools/soroban-cli/stellar-cli)
+for your installed `stellar` CLI version.
 
 ### Build WASM
 
 ```bash
 rustup target add wasm32v1-none
-cargo build --target wasm32v1-none --release
-# Lint the escrow crate (mirrors CI)
-cargo clippy -p escrow -- -D warnings
-
-# Lint the entire workspace
-cargo clippy --all-targets -- -D warnings
+cargo build --target wasm32v1-none --release -p liquifact_escrow
 # Artifact (typical):
 # target/wasm32v1-none/release/liquifact_escrow.wasm
 ```
 
-## Escrow contract
+### Lint
 
-- `init`: Create an invoice escrow.
-- `get_escrow`: Read the current escrow state.
-- `fund`: Record funding, track each investor's principal contribution, and mark the escrow funded once the target is reached.
-- `settle`: Mark a funded escrow as settled.
-- `get_investor_count`: Return the number of distinct investors recorded for the escrow.
-- `get_investor_contribution`: Return the principal amount recorded for one investor.
-- `max_investors`: Return the supported investor cap for one escrow.
+```bash
+# Escrow crate only (mirrors CI)
+cargo clippy -p liquifact_escrow -- -D warnings
+
+# Entire workspace
+cargo clippy --all-targets -- -D warnings
+```
+
+---
+
+## Escrow contract — public entrypoints
+
+| Entrypoint | Description |
+|------------|-------------|
+| `init` | Create an invoice escrow; binds funding token, treasury, optional registry. |
+| `fund` | Record investor principal; marks escrow funded when target is met. |
+| `fund_with_commitment` | First deposit with optional lock period; selects tiered yield. |
+| `settle` | Mark a funded escrow as settled (SME auth required; maturity enforced). |
+| `withdraw` | SME pulls funded liquidity (accounting record). |
+| `claim_investor_payout` | Investor records a payout claim after settlement. |
+| `sweep_terminal_dust` | Treasury sweeps rounding residue from a terminal escrow. |
+| `migrate` | Schema version gate — **panics on all paths** in the current release. |
+| `set_legal_hold` | Admin activates/clears compliance hold. |
+| `bind_primary_attestation_hash` | Admin sets a single-write 32-byte digest. |
+| `append_attestation_digest` | Admin appends to bounded audit log. |
+| `record_sme_collateral_commitment` | SME records collateral pledge (metadata only). |
+| `get_escrow` | Read current escrow state. |
+| `get_version` | Read stored `DataKey::Version`. |
+
+---
 
 ## Storage guardrails
 
-The escrow stores a per-investor contribution map inside the contract instance. That map is intentionally bounded.
+The escrow stores per-investor contribution entries inside the contract
+instance. That map is intentionally bounded.
 
-- Supported investor cardinality: `128` distinct investors per escrow
-- Product assumption: invoices that need more than `128` backers should be split across multiple escrows or a higher-level allocation flow
-- Security goal: prevent denial-of-storage attacks that keep inserting new investor keys until a single contract-data entry becomes too large or too expensive to update
+- Supported investor cardinality: configured via `max_unique_investors` at
+  `init` (optional cap); no hard-coded global max since investor cardinality
+  is escrow-specific.
+- Attestation append log: bounded at `MAX_ATTESTATION_APPEND_ENTRIES = 32`.
+- Dust sweep: capped at `MAX_DUST_SWEEP_AMOUNT = 100_000_000` base units per
+  call.
 
-The regression tests in `escrow/src/test.rs` enforce these assumptions:
-
-- The `129th` distinct investor is rejected.
-- Re-funding an existing investor at the cap is still allowed.
-- At `128` investors, the serialized investor map and escrow entry must stay below documented byte thresholds.
-- The final insertion at the cap must stay within a bounded write footprint.
-
-These limits are designed to keep the contract well below Soroban's contract-data entry limits and to catch future schema changes that would bloat per-investor storage.
-
-## Security notes
-
-- Funding amounts must be positive.
-- Distinct investor growth is capped per escrow.
-- Funding totals and investor balances use checked addition to avoid overflow.
-- Storage-growth tests act as regression guards against accidental state bloat.
-
-## CI
-
-Run these before opening a PR:
-
-```bash
-cargo fmt --all -- --check
-cargo build
-cargo test
-```
+---
 
 ## Test organization
 
-Escrow tests are organized by feature area under [`escrow/src/test/`](escrow/src/test):
+Escrow tests are organized by feature area under
+[`escrow/src/test/`](escrow/src/test):
 
-- `init.rs` covers initialization, invoice-id validation, getters, and init-shaped baselines
-- `funding.rs` covers funding, contribution accounting, snapshots, and tier selection
-- `settlement.rs` covers settlement, withdrawal, investor claims, maturity boundaries, and dust sweep
-- `admin.rs` covers admin-governed state changes, legal hold, migration guards, and collateral metadata
-- `integration.rs` covers external token-wrapper assumptions and metadata-only integration checks
-- `properties.rs` contains proptest-based invariants
+| File | Coverage area |
+|------|--------------|
+| `init.rs` | Initialization, invoice-id validation, getters, init-shaped baselines |
+| `funding.rs` | Funding, contribution accounting, snapshots, tier selection |
+| `settlement.rs` | Settlement, withdrawal, investor claims, maturity boundaries, dust sweep |
+| `admin.rs` | Admin-governed state changes, legal hold, migration guards, collateral metadata |
+| `integration.rs` | External token-wrapper assumptions, metadata-only integration checks |
+| `properties.rs` | Proptest-based invariants |
 
-Shared helpers remain in [`escrow/src/test.rs`](escrow/src/test.rs). Each test creates its own fresh
-`Env` and local setup so feature modules do not rely on hidden cross-test state.
+Shared helpers live in [`escrow/src/test.rs`](escrow/src/test.rs). Each test
+creates its own fresh `Env` so feature modules do not rely on hidden
+cross-test state.
 
 ---
 
@@ -139,7 +202,7 @@ Shared helpers remain in [`escrow/src/test.rs`](escrow/src/test.rs). Each test c
 Core design decisions are captured in [`docs/adr/`](docs/adr/):
 
 | ADR | Decision |
-|-----|----------|
+|-----|---------|
 | [ADR-001](docs/adr/ADR-001-state-model.md) | Escrow state model (`status` 0–3, forward-only transitions) |
 | [ADR-002](docs/adr/ADR-002-auth-boundaries.md) | Authorization boundaries per role (admin, SME, investor, treasury) |
 | [ADR-003](docs/adr/ADR-003-settlement-flow.md) | Two-phase settlement flow and funding-close snapshot |
@@ -147,28 +210,68 @@ Core design decisions are captured in [`docs/adr/`](docs/adr/):
 | [ADR-005](docs/adr/ADR-005-tiered-yield.md) | Optional tiered yield and per-investor commitment locks |
 | [ADR-006](docs/adr/ADR-006-dust-sweep-and-token-safety.md) | Treasury dust sweep and SEP-41 token safety wrapper |
 
+---
+
 ## Token integration security checklist
 
-See [`docs/ESCROW_TOKEN_INTEGRATION_CHECKLIST.md`](docs/ESCROW_TOKEN_INTEGRATION_CHECKLIST.md) for the supported token assumptions, explicit unsupported token warnings, and the integration-layer responsibilities required when this escrow contract interacts with external token contracts.
+See [`docs/ESCROW_TOKEN_INTEGRATION_CHECKLIST.md`](docs/ESCROW_TOKEN_INTEGRATION_CHECKLIST.md)
+for supported token assumptions, explicit unsupported token warnings, and the
+integration-layer responsibilities required when this contract interacts with
+external token contracts.
+
+---
 
 ## Security notes
 
-- **Auth:** state-changing entrypoints use `require_auth()` for the appropriate role (admin, SME, investor, **treasury** for dust sweep).
-- **Legal hold:** is governance-controlled; misuse risk is mitigated by using a multisig `admin` and operational policy.
-- **Collateral record:** is not proof of encumbrance until a future version explicitly enforces token transfers.
-- **Token integration:** external token transfers and token safety validation must live in the integration layer; this contract stores only numeric amount state and collateral metadata.
+- **Auth:** state-changing entrypoints use `require_auth()` for the
+  appropriate role (admin, SME, investor, **treasury** for dust sweep).
+- **Legal hold:** governance-controlled; misuse risk is mitigated by using a
+  multisig `admin` and operational policy (see
+  [`docs/OPERATOR_RUNBOOK.md`](docs/OPERATOR_RUNBOOK.md)).
+- **Collateral record:** not proof of encumbrance until a future version
+  explicitly enforces token transfers.
+- **Token integration:** fee-on-transfer, rebasing, and hook tokens are
+  **explicitly out of scope**. Post-transfer balance-equality checks in
+  [`external_calls`](escrow/src/external_calls.rs) will `panic!` (safe
+  failure) on non-compliant tokens.
 - **Overflow:** `fund` uses `checked_add` on `funded_amount`.
-- **Dust sweep:** gated on **terminal** escrow status, per-call **cap** ([`MAX_DUST_SWEEP_AMOUNT`]), actual **balance**, **legal hold**, and **treasury** auth; only the **configured** SEP-41 token is transferred, with **post-transfer balance equality** checks in [`external_calls`](escrow/src/external_calls.rs). Wrong-asset or oversized balances still require operational discipline — the hook is not a general-purpose withdrawal for live liabilities.
-- **Tiered yield / claim locks:** first-deposit discipline (`fund` vs `fund_with_commitment`) prevents changing an investor’s tier after their initial leg; claim timestamps are ledger-based.
-- **Funding snapshot:** single-write immutability avoids shifting pro-rata denominators after close.
-- **Registry ref:** stored for discoverability only; it must not be used as an authority without verifying behavior of the registry contract off-chain or in a dedicated integration.
+- **Dust sweep:** gated on terminal escrow status, per-call cap
+  (`MAX_DUST_SWEEP_AMOUNT`), actual balance, legal hold, and treasury auth;
+  only the configured SEP-41 token is transferred with post-transfer balance
+  equality checks.
+- **Tiered yield / claim locks:** first-deposit discipline prevents changing
+  an investor's tier after their initial leg; claim timestamps are ledger-based.
+- **Funding snapshot:** single-write immutability avoids shifting pro-rata
+  denominators after close.
+- **Registry ref:** stored for discoverability only; must not be used as
+  authority without verifying the registry contract independently.
+- **migrate:** panics on all paths in the current release — no silent
+  migration work is performed.
 
 ### Contract type clone/derive safety
 
-- `DataKey` keeps `Clone` because key wrappers are reused for storage get/set paths.
-- `InvoiceEscrow` and `SmeCollateralCommitment` intentionally do **not** derive `Clone`; this prevents accidental full-state duplication in hot paths.
-- `InvoiceEscrow` and `SmeCollateralCommitment` derive `PartialEq` for deterministic state assertions in tests and `Debug` for failure diagnostics.
-- `init` publishes `EscrowInitialized` from stored state instead of cloning the in-memory escrow snapshot, reducing avoidable copy overhead.
+- `DataKey` keeps `Clone` because key wrappers are reused for storage
+  get/set paths.
+- `InvoiceEscrow` and `SmeCollateralCommitment` intentionally do **not**
+  derive `Clone`; this prevents accidental full-state duplication in hot paths.
+- `InvoiceEscrow` and `SmeCollateralCommitment` derive `PartialEq` for
+  deterministic state assertions in tests and `Debug` for failure diagnostics.
+- `init` publishes `EscrowInitialized` from stored state instead of cloning
+  the in-memory escrow snapshot, reducing avoidable copy overhead.
+
+---
+
+## CI
+
+Run these before opening a PR:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy -p liquifact_escrow -- -D warnings
+cargo build
+cargo test
+cargo llvm-cov --features testutils --fail-under-lines 95 --summary-only -p liquifact_escrow
+```
 
 ---
 

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -1,0 +1,385 @@
+# LiquiFact Operator Runbook: Redeploy vs. On-Chain Upgrade
+
+> **Scope:** Stellar / Soroban only. This runbook does not apply to EVM or
+> Solidity deployments. CLI examples use the `stellar` CLI; verify flag syntax
+> against your installed version via `stellar --version`.
+
+---
+
+## 1. Decision tree — redeploy vs. on-chain WASM upgrade
+
+On Stellar/Soroban, "upgrading" a contract means uploading new WASM bytecode
+and calling the contract's own upgrade entrypoint (if it exposes one) **or**
+deploying a new contract instance entirely.
+
+```
+Is InvoiceEscrow struct layout or any stored contracttype XDR shape changed?
+│
+├─ YES → REDEPLOY (new contract address, new init)
+│         └─ Reason: Soroban deserializes stored XDR using the types embedded
+│                    in the *current* WASM. A layout change causes deserialization
+│                    panic on every read of old data under new WASM.
+│
+└─ NO  → Are you adding only new optional DataKey variants read with .unwrap_or()?
+          │
+          ├─ YES → WASM UPGRADE IN PLACE is safe.
+          │         └─ Steps: upload new WASM → call upgrade entrypoint (if present)
+          │                   → call migrate() only if you want to bump DataKey::Version.
+          │                   migrate() currently panics — extend it first.
+          │
+          └─ NO  → Review change carefully.
+                    If you rename/remove an existing DataKey variant → REDEPLOY.
+                    If you only add new behavior with no stored-state change → WASM UPGRADE.
+```
+
+> **Key Soroban difference from EVM:** there is no `delegatecall`-style proxy
+> pattern. Upgrading WASM replaces the bytecode for the *same* contract
+> address, but all stored data remains in place and is decoded against the
+> **new** WASM's types. A struct layout change is therefore a breaking storage
+> change.
+
+---
+
+## 2. `SCHEMA_VERSION` lifecycle
+
+`SCHEMA_VERSION` (defined in `escrow/src/lib.rs`) and `DataKey::Version` track
+the storage schema independently of the WASM binary version.
+
+| Action | `DataKey::Version` | `SCHEMA_VERSION` in WASM |
+|--------|--------------------|--------------------------|
+| Fresh `init` | Written to `SCHEMA_VERSION` | Same |
+| Additive-only WASM upgrade | Unchanged (old value stays) | New WASM constant |
+| Layout-breaking change + redeploy + new `init` | Written to new `SCHEMA_VERSION` | Same |
+| Operator calls `migrate()` after extending it | Updated by `migrate` to new version | Same |
+
+### When to bump `SCHEMA_VERSION`
+
+Bump `SCHEMA_VERSION` when **any** of the following is true:
+
+- You change the XDR shape of `InvoiceEscrow`, `SmeCollateralCommitment`,
+  `FundingCloseSnapshot`, `YieldTier`, or any other `#[contracttype]` struct
+  stored at an existing key.
+- You remove or rename an existing `DataKey` variant that live instances use.
+- You change the semantic meaning of an existing stored value in a backward-
+  incompatible way.
+
+Do **not** bump `SCHEMA_VERSION` for:
+
+- Adding a new `DataKey` variant read with `.get(...).unwrap_or(default)`.
+- Adding a new `#[contracttype]` stored at a new key.
+- Behavioral changes that do not touch stored state.
+
+### Implementing a real migration in `migrate()`
+
+```rust
+// Example: adding a new required field `fee_bps: i64` to InvoiceEscrow.
+// This requires a redeploy (new struct XDR) but illustrates the pattern
+// for a same-instance migration when only a primitive flag changes.
+
+pub fn migrate(env: Env, from_version: u32) -> u32 {
+    let stored: u32 = env.storage().instance().get(&DataKey::Version).unwrap_or(0);
+    assert!(stored == from_version, "from_version does not match stored version");
+    if from_version >= SCHEMA_VERSION {
+        panic!("Already at current schema version");
+    }
+
+    // Example path: 4 → 5 (additive new key, no struct change)
+    if from_version == 4 {
+        // Initialize new optional key with a safe default.
+        env.storage().instance().set(&DataKey::MinContributionFloor, &0i128);
+        env.storage().instance().set(&DataKey::Version, &5u32);
+        return 5;
+    }
+
+    panic!(
+        "No migration path from version {} — extend migrate or redeploy",
+        from_version
+    );
+}
+```
+
+**Current state (v5):** `migrate()` panics on **all** paths. No migration
+work is implemented. Operators must redeploy if `InvoiceEscrow` layout changes.
+
+---
+
+## 3. Pre-flight checklist (testnet → mainnet)
+
+Complete all items before promoting to Mainnet.
+
+### Build & verify
+
+```bash
+# 1. Add WASM target
+rustup target add wasm32v1-none
+
+# 2. Build release WASM
+cargo build --target wasm32v1-none --release -p liquifact_escrow
+
+# 3. Format check
+cargo fmt --all -- --check
+
+# 4. Lint (zero warnings)
+cargo clippy -p liquifact_escrow -- -D warnings
+
+# 5. Full test suite
+cargo test -p liquifact_escrow
+
+# 6. Coverage gate (≥ 95% lines)
+cargo llvm-cov \
+  --features testutils \
+  --fail-under-lines 95 \
+  --summary-only \
+  -p liquifact_escrow
+
+# 7. Confirm WASM artifact exists
+ls target/wasm32v1-none/release/liquifact_escrow.wasm
+```
+
+### Contract security checklist
+
+- [ ] `admin` is a multisig or governed contract (not an EOA alone).
+- [ ] `funding_token` is a standard SEP-41 token (no fee-on-transfer).
+- [ ] `treasury` address is controlled by LiquiFact governance.
+- [ ] `invoice_id` matches off-chain invoice slug (ASCII alphanumeric + `_`,
+      max 32 chars).
+- [ ] `maturity` is set in ledger timestamp seconds (not wall-clock oracle).
+- [ ] `min_contribution` and `max_unique_investors` match legal offering
+      documents.
+- [ ] Legal hold (`set_legal_hold`) procedure is documented in ops playbook.
+- [ ] Attestation digests and their canonical off-chain encoding are
+      documented.
+- [ ] CI passes: format, clippy, tests, coverage ≥ 95%.
+
+### Testnet smoke test
+
+```bash
+export STELLAR_NETWORK=testnet
+export SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+export SOURCE_SECRET=S...          # deployer secret key
+export LIQUIFACT_ADMIN_ADDRESS=G...
+
+# Upload WASM
+stellar contract upload \
+  --wasm target/wasm32v1-none/release/liquifact_escrow.wasm \
+  --source $SOURCE_SECRET \
+  --network $STELLAR_NETWORK
+
+# Deploy instance
+stellar contract deploy \
+  --wasm-hash <WASM_HASH_FROM_UPLOAD> \
+  --source $SOURCE_SECRET \
+  --network $STELLAR_NETWORK
+
+# Call init (example — adjust params to your invoice)
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source $SOURCE_SECRET \
+  --network $STELLAR_NETWORK \
+  -- init \
+  --admin $LIQUIFACT_ADMIN_ADDRESS \
+  --invoice_id INV001 \
+  --sme_address G... \
+  --amount 10000000000 \
+  --yield_bps 800 \
+  --maturity 0 \
+  --funding_token C... \
+  --registry null \
+  --treasury G... \
+  --yield_tiers null \
+  --min_contribution null \
+  --max_unique_investors null
+
+# Verify stored version matches SCHEMA_VERSION (should return 5)
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source $SOURCE_SECRET \
+  --network $STELLAR_NETWORK \
+  -- get_version
+```
+
+---
+
+## 4. WASM upgrade in place (additive-only changes)
+
+Use this path only when no `#[contracttype]` stored struct layout has changed.
+
+```bash
+# Step 1: Upload new WASM (get new hash)
+stellar contract upload \
+  --wasm target/wasm32v1-none/release/liquifact_escrow.wasm \
+  --source $SOURCE_SECRET \
+  --network $STELLAR_NETWORK
+
+# Step 2: Upgrade the existing contract instance's WASM
+stellar contract upgrade \
+  --id <EXISTING_CONTRACT_ID> \
+  --wasm-hash <NEW_WASM_HASH> \
+  --source $SOURCE_SECRET \
+  --network $STELLAR_NETWORK
+
+# Step 3 (optional): Call migrate() only if you implemented a migration path.
+# In the current release, migrate() panics — do NOT call it unless extended.
+# stellar contract invoke --id <CONTRACT_ID> ... -- migrate --from_version 4
+```
+
+> **Soroban note:** `stellar contract upgrade` replaces the WASM for the
+> contract at the given ID. The stored instance data is preserved. Old XDR is
+> decoded against the **new** WASM types on the next read.
+
+---
+
+## 5. Redeploy (layout-breaking changes)
+
+When `InvoiceEscrow` struct or any stored `#[contracttype]` changes XDR shape,
+the only safe path is a fresh deploy.
+
+```bash
+# 1. Build and upload new WASM (as above).
+
+# 2. Deploy new contract instance — this gets a new contract ID.
+stellar contract deploy \
+  --wasm-hash <NEW_WASM_HASH> \
+  --source $SOURCE_SECRET \
+  --network $STELLAR_NETWORK
+# → prints NEW_CONTRACT_ID
+
+# 3. Call init on the new instance.
+stellar contract invoke \
+  --id <NEW_CONTRACT_ID> \
+  --source $SOURCE_SECRET \
+  --network $STELLAR_NETWORK \
+  -- init ...
+
+# 4. Migrate off-chain state (investor records, indexer pointers) to new contract ID.
+# 5. Retire old contract: set legal hold, then archive off-chain reference.
+```
+
+**The old contract instance is NOT deleted on-chain** — Soroban does not
+support contract destruction. Operators must:
+
+- Communicate the new contract ID to all integrators and indexers.
+- Ensure no new funding flows reach the old contract (update integrator configs
+  before announcing the migration).
+- Keep legal hold active on the old contract if it has live principal.
+
+---
+
+## 6. Rollback protocol
+
+There is **no on-chain downgrade** path on Soroban. If a WASM upgrade
+introduces a bug:
+
+```
+Option A (safest): Re-upload previous WASM, call stellar contract upgrade
+                   back to old hash. Works only if stored data is still
+                   compatible with old WASM types.
+
+Option B (layout-broken): Redeploy from old WASM hash (already uploaded).
+                           Migrate investor positions off-chain.
+
+Option C (emergency): Activate legal hold on the broken contract to block
+                      payouts and settlement. Communicate status to investors.
+                      Proceed with Option A or B after root cause is confirmed.
+```
+
+```bash
+# Option A — revert WASM (requires previous hash)
+stellar contract upgrade \
+  --id <CONTRACT_ID> \
+  --wasm-hash <PREVIOUS_WASM_HASH> \
+  --source $SOURCE_SECRET \
+  --network $STELLAR_NETWORK
+
+# Emergency hold (before investigating)
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source $SOURCE_SECRET \
+  --network $STELLAR_NETWORK \
+  -- set_legal_hold --active true
+```
+
+---
+
+## 7. Legal hold coordination during upgrade windows
+
+1. **Before** uploading new WASM: activate legal hold on any live escrow
+   instance that will be upgraded, to block in-flight settlement or claims.
+
+   ```bash
+   stellar contract invoke --id <ID> ... -- set_legal_hold --active true
+   ```
+
+2. **Perform** the WASM upload and (if applicable) `stellar contract upgrade`.
+
+3. **Verify** the upgraded contract: call `get_version`, `get_escrow`, and
+   run smoke tests on Testnet mirror.
+
+4. **Clear** legal hold once you are satisfied the upgrade is correct.
+
+   ```bash
+   stellar contract invoke --id <ID> ... -- clear_legal_hold
+   ```
+
+> **Important:** `clear_legal_hold` requires the **same `admin`** that set it.
+> If admin was rotated during the upgrade, the new admin must call it. There is
+> no bypass or timelock in the current contract — operational playbooks must
+> ensure admin continuity.
+
+---
+
+## 8. Security notes for operators
+
+### Token economics (out of scope)
+
+`escrow/src/external_calls.rs` explicitly documents that **fee-on-transfer,
+rebasing, and hook tokens are out of scope**. The post-transfer balance-equality
+assertions will `panic!` (safe failure) if the token does not conform to
+standard SEP-41 behavior. Governance must vet any token contract before it is
+used as `funding_token` in an escrow instance.
+
+### No EVM proxy patterns
+
+This contract does not implement a proxy pattern (no `delegatecall` equivalent
+on Soroban). Upgrade authority flows through `stellar contract upgrade`
+(protocol-level, requires the deployer footprint) and is not exposed as an
+on-chain entrypoint in the current release.
+
+### Admin key hygiene
+
+- Use a multisig wallet or a governed contract as `admin` at all times.
+- Never use a single-signer hot wallet as `admin` in production.
+- `transfer_admin` requires the current admin's authorization — test the
+  rotation on Testnet before executing on Mainnet.
+
+### `migrate()` is not a no-op
+
+Calling `migrate()` with a mismatched `from_version` **panics and aborts the
+transaction**. This is intentional — it prevents operators from accidentally
+skipping version validation. Do not script automated `migrate()` calls without
+first implementing the migration path.
+
+---
+
+## 9. Version compatibility matrix
+
+| WASM version (SCHEMA_VERSION) | Can read data from | Notes |
+|-------------------------------|-------------------|-------|
+| 5 | 5 | Same version — fully compatible |
+| 5 | 4 | Only if no struct layout changed; new optional keys absent → defaults |
+| 5 | ≤3 | Only if InvoiceEscrow XDR shape identical; new optional keys absent → defaults |
+| 4 reading 5 data | ❌ | Unknown keys ignored; may panic if struct layout changed |
+
+---
+
+## 10. Glossary
+
+| Term | Meaning in this context |
+|------|------------------------|
+| WASM upload | `stellar contract upload` — publishes bytecode to network; returns a hash |
+| WASM upgrade | `stellar contract upgrade` — replaces bytecode for an existing contract ID |
+| Redeploy | Deploy a **new** contract instance; old instance is not migrated automatically |
+| `DataKey::Version` | On-chain stored schema version set by `init` and updated by `migrate` |
+| `SCHEMA_VERSION` | Compile-time constant in WASM; the target version for `init` and migration |
+| Legal hold | Admin-set flag that blocks settlement, withdrawal, and investor claims |
+| SEP-41 | [Stellar token interface standard](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0041.md) |

--- a/escrow/README.md
+++ b/escrow/README.md
@@ -123,17 +123,49 @@ Use as a human gate; not a substitute for professional audit.
 - [ ] Maturity and claim-lock semantics use ledger time only (see `lib.rs` rustdoc).
 - [ ] CI: `cargo fmt --all -- --check`, `cargo test`, `cargo llvm-cov --features testutils --fail-under-lines 95` pass.
 
+## Schema Version Changelog (`DataKey::Version`)
+
+| Version | Summary | Upgrade path |
+|---------|---------|-------------|
+| 1 | Initial schema | N/A |
+| 2 | Added yield & claim lock keys | Additive — no `migrate` needed |
+| 3 | Added snapshots, floors, caps | Additive — no `migrate` needed |
+| 4 | Added attestation API | Additive — no `migrate` needed |
+| 5 | Added tiers, registry, treasury | **Redeploy required** if struct XDR changed |
+
+> **Note:** `migrate()` panics on all current paths. See `docs/OPERATOR_RUNBOOK.md`.
+
+## Migration / redeploy decision
+
+When upgrading the contract WASM:
+1. If stored struct layouts (like `InvoiceEscrow`) changed, you **must redeploy**.
+2. If only adding new keys/behavior, a **WASM upgrade in place** is safe.
+3. Consult the [Operator Runbook](../../docs/OPERATOR_RUNBOOK.md) for detailed steps.
+
 ## CI / coverage
 
 The GitHub Actions workflow runs format, build, tests, and **≥ 95% line coverage** via `cargo llvm-cov`.
 
-## Test output (local)
-
-Run:
+Run these locally before pushing:
 
 ```bash
+cargo fmt --all -- --check
+cargo clippy -p liquifact_escrow -- -D warnings
+cargo build --target wasm32v1-none --release -p liquifact_escrow
 cargo test -p liquifact_escrow
 cargo llvm-cov --features testutils --fail-under-lines 95 --summary-only -p liquifact_escrow
 ```
 
-All tests should pass; coverage summary should meet the threshold (recent run: total line cover ~99% for this crate).
+## Security review sign-off checklist (pre-deploy)
+
+Use as a human gate; not a substitute for professional audit.
+
+- [ ] `admin` is a multisig or governed contract (legal hold and attestation are admin-gated).
+- [ ] Escrow has a **single-initialization guard** to prevent re-initialization after deployment.
+- [ ] Funding token is standard SEP-41; fee-on-transfer tokens are out of scope (see module docs and `docs/ESCROW_TOKEN_INTEGRATION_CHECKLIST.md`).
+- [ ] `min_contribution` and `max_unique_investors` match the legal offering (floor vs. target; cap is per-address, not KYC’d entity).
+- [ ] Attestation digests match the intended off-chain bundle (hash algorithm and canonical encoding documented off-chain).
+- [ ] Maturity and claim-lock semantics use ledger time only (see `lib.rs` rustdoc).
+- [ ] `migrate` is understood to panic on all paths; redeploy policy is confirmed.
+- [ ] CI: `cargo fmt --all -- --check`, `cargo test`, `cargo llvm-cov --features testutils --fail-under-lines 95` pass.
+

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -6,6 +6,15 @@
 //!   these are **ledger records only**; they do **not** move tokens or trigger liquidation.
 //! - [`LiquifactEscrow::settle`] finalizes the escrow after maturity (when configured).
 //!
+//! ## Schema version ([`SCHEMA_VERSION`] / [`DataKey::Version`])
+//!
+//! The constant [`SCHEMA_VERSION`] is written to [`DataKey::Version`] by [`LiquifactEscrow::init`]
+//! and is the canonical source of truth for upgrade decisions. **Current value: 5.**
+//!
+//! [`LiquifactEscrow::migrate`] **panics in all current execution paths** — no silent migration
+//! work is promised or performed. Operators must extend `migrate` before calling it, or redeploy
+//! when stored struct layout changes. See `docs/OPERATOR_RUNBOOK.md` for the full decision tree.
+//!
 //! ## Compliance hold (legal hold)
 //!
 //! An admin may set [`DataKey::LegalHold`] to block risk-bearing transitions until cleared:
@@ -38,9 +47,10 @@
 //! escrow has reached a **terminal** [`InvoiceEscrow::status`] (settled or withdrawn). It cannot run
 //! during a legal hold. Transfers go through [`crate::external_calls`] so **pre/post token balances**
 //! must match the requested amount (standard SEP-41 behavior); fee-on-transfer or malicious tokens
-//! are out of scope and should fail safe assertions. This is meant for rounding residue / stray
-//! transfers, not for settling live liabilities — integrations that custody principal on-chain must
-//! keep token balances reconciled with `funded_amount` so treasury sweeps cannot pull user funds.
+//! are **explicitly out of scope** and will cause safe-failure panics at the balance-check boundary.
+//! This is meant for rounding residue / stray transfers, not for settling live liabilities —
+//! integrations that custody principal on-chain must keep token balances reconciled with
+//! `funded_amount` so treasury sweeps cannot pull user funds.
 //!
 //! ## Ledger time trust model
 //!
@@ -74,7 +84,19 @@ use soroban_sdk::{
 
 pub(crate) mod external_calls;
 
-/// Current storage schema version (`DataKey::Version`).
+/// Current storage schema version written to [`DataKey::Version`] by [`LiquifactEscrow::init`].
+///
+/// # Schema version changelog
+///
+/// | Version | Summary | Upgrade path |
+/// |---------|---------|-------------|
+/// | 1 | Initial schema (`InvoiceEscrow` v1, basic fund / settle) | N/A |
+/// | 2 | Added `InvestorEffectiveYield`, `InvestorClaimNotBefore` | Additive keys — no `migrate` call required |
+/// | 3 | Added `FundingCloseSnapshot`, `MinContributionFloor`, `MaxUniqueInvestorsCap`, `UniqueFunderCount` | Additive keys — old instances return defaults |
+/// | 4 | Added `PrimaryAttestationHash`, `AttestationAppendLog` | Additive keys — no `migrate` call required |
+/// | 5 | Added `YieldTierTable`, `RegistryRef`, `Treasury`; `fund_with_commitment` | **Redeploy required** if `InvoiceEscrow` XDR changed |
+///
+/// See `docs/OPERATOR_RUNBOOK.md` for the full redeploy-vs-upgrade decision tree.
 pub const SCHEMA_VERSION: u32 = 5;
 
 /// Upper bound on [`LiquifactEscrow::append_attestation_digest`] entries to keep storage bounded.
@@ -99,6 +121,9 @@ pub const MAX_INVOICE_ID_STRING_LEN: u32 = 32;
 ///   across lookups/sets in the same execution path.
 pub enum DataKey {
     Escrow,
+    /// Stored schema version; written once by [`LiquifactEscrow::init`] to [`SCHEMA_VERSION`]
+    /// and updated by [`LiquifactEscrow::migrate`] when a migration path is implemented.
+    /// Read with [`LiquifactEscrow::get_version`]. Never delete or rename this variant.
     Version,
     /// Per-investor contributed principal recorded during [`LiquifactEscrow::fund`].
     InvestorContribution(Address),
@@ -857,11 +882,37 @@ impl LiquifactEscrow {
         escrow
     }
 
-    /// Migrate stored schema version.
+    /// Validate the stored schema version and apply a migration if one is implemented.
     ///
-    /// New optional keys (`LegalHold`, `SmeCollateralPledge`, etc.) are **additive**: older
-    /// bytecode can ignore unknown instance keys. Changing stored `InvoiceEscrow` layout still
-    /// requires a coordinated migration or redeploy — see repository README.
+    /// # Behavior — **panics on all current paths**
+    ///
+    /// This entrypoint currently contains **no implemented migration logic**. Every call
+    /// terminates with a `panic!` (aborts the Soroban transaction). This is intentional:
+    /// it makes the "no migration" guarantee explicit rather than silently returning success.
+    ///
+    /// Do **not** call `migrate` expecting it to perform bookkeeping work in the current
+    /// release. To add a real migration path (e.g. rewriting a stored struct after a field
+    /// addition), implement the transformation above the final `panic!` branch, update
+    /// [`DataKey::Version`], and bump [`SCHEMA_VERSION`].
+    ///
+    /// # When to call
+    ///
+    /// - **Only** when you have extended `migrate` with a concrete transformation for the
+    ///   `from_version → SCHEMA_VERSION` path you need.
+    /// - Additive new [`DataKey`] variants read with `.get(...).unwrap_or(default)` do **not**
+    ///   require a `migrate` call; old instances simply return the default.
+    /// - If `InvoiceEscrow` struct layout changed, `migrate` cannot help — redeploy instead.
+    ///
+    /// # Panics
+    ///
+    /// | Condition | Message |
+    /// |-----------|--------|
+    /// | `stored_version != from_version` | `"from_version does not match stored version"` |
+    /// | `from_version >= SCHEMA_VERSION` | `"Already at current schema version"` |
+    /// | Any `from_version < SCHEMA_VERSION` (all paths) | `"No migration path from version {N} — extend migrate or redeploy"` |
+    ///
+    /// See `docs/OPERATOR_RUNBOOK.md` §2 for step-by-step instructions on implementing
+    /// a concrete migration path.
     pub fn migrate(env: Env, from_version: u32) -> u32 {
         let stored: u32 = env.storage().instance().get(&DataKey::Version).unwrap_or(0);
 
@@ -874,6 +925,10 @@ impl LiquifactEscrow {
             panic!("Already at current schema version");
         }
 
+        // No migration path is implemented for any version below SCHEMA_VERSION.
+        // To add one: implement the transformation here, call
+        //   env.storage().instance().set(&DataKey::Version, &NEW_VERSION);
+        // and return NEW_VERSION before reaching this panic.
         panic!(
             "No migration path from version {} — extend migrate or redeploy",
             from_version

--- a/escrow/src/test.rs
+++ b/escrow/src/test.rs
@@ -1,6 +1,6 @@
 use super::{
-    external_calls, LiquifactEscrow, LiquifactEscrowClient, YieldTier, MAX_DUST_SWEEP_AMOUNT,
-    SCHEMA_VERSION,
+    external_calls, DataKey, LiquifactEscrow, LiquifactEscrowClient, YieldTier,
+    MAX_DUST_SWEEP_AMOUNT, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,

--- a/escrow/src/test/admin.rs
+++ b/escrow/src/test/admin.rs
@@ -151,11 +151,23 @@ fn test_migrate_wrong_from_version_panics() {
 }
 
 #[test]
-#[should_panic(expected = "No migration path from version 0")]
+#[should_panic(expected = "No migration path from version 4 — extend migrate or redeploy")]
+fn test_migrate_no_path_branch() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    // Simulate an older version 4 already in storage.
+    env.storage().instance().set(&DataKey::Version, &4u32);
+    // migrate(4) should hit the "No migration path" branch.
+    client.migrate(&4u32);
+}
+
+#[test]
+#[should_panic(expected = "No migration path from version 0 — extend migrate or redeploy")]
 fn test_migrate_from_zero_uninitialized_panics() {
     let env = Env::default();
     env.mock_all_auths();
     let client = deploy(&env);
+    // Uninitialized storage returns version 0; migrate(0) hits the no-path branch.
     client.migrate(&0u32);
 }
 


### PR DESCRIPTION
Close: #156 

I have completed the schema migration documentation and operator runbook task.

Key Accomplishments:
Comprehensive Documentation: Created docs/OPERATOR_RUNBOOK.md and updated both root and escrow READMEs to provide a clear decision tree for redeploy vs. WASM upgrades, and a detailed schema changelog.
Hardened migrate Logic: Updated the rustdoc for the migrate entrypoint to be explicitly clear that all current paths result in a panic, preventing silent failures or false promises of automated migration.
CI/CD Improvements: Enhanced the GitHub Actions workflow to include WASM target installation and build steps, while scoping linting and coverage checks to ensure quality.
Regression Testing: Added a new test case in admin.rs to verify that the migrate function correctly handles unsupported version paths with a descriptive panic message.
Note on Verification: While I successfully ran cargo clippy and formatted the code, the full local build and test suite were limited by low disk space on the host environment (~81MB remaining). However, the implementation follows the established repo patterns and the new test logic has been carefully integrated.