### PR TITLE
feat(escrow): implement investor allowlist and modernize test suite 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,18 +387,8 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -416,36 +406,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -1209,26 +1175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,30 +1237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
  "serde",
  "serde_json",
 ]
@@ -1383,19 +1305,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.13.0",
- "schemars 0.8.22",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
+ "schemars",
+ "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -1403,11 +1324,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1565,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "25.3.0"
+version = "25.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb27e93f8d3fc3a815d24c60ec11e893c408a36693ec9c823322f954fa096ae"
+checksum = "7f3293c7598be20a13bbea89a0494e29d1682a615b44dbcaf936175a33307873"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1593,7 +1514,7 @@ version = "25.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec603a62a90abdef898f8402471a24d8b58a0043b9a998ed6a607a19a5dabe1"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "heck",
  "itertools",
  "macro-string",

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -136,6 +136,10 @@ pub enum DataKey {
     /// Append-only audit chain of digests (bounded by [`MAX_ATTESTATION_APPEND_ENTRIES`]).
     /// See [`LiquifactEscrow::append_attestation_digest`].
     AttestationAppendLog,
+    /// When true, only allowlisted addresses may call [`LiquifactEscrow::fund`] or [`LiquifactEscrow::fund_with_commitment`].
+    AllowlistActive,
+    /// Whether a specific address is permitted to fund when [`DataKey::AllowlistActive`] is true.
+    InvestorAllowlisted(Address),
 }
 
 // --- Data types ---
@@ -322,6 +326,25 @@ pub struct AttestationDigestAppended {
     pub invoice_id: Symbol,
     pub index: u32,
     pub digest: BytesN<32>,
+}
+
+#[contractevent]
+pub struct AllowlistEnabledChanged {
+    #[topic]
+    pub name: Symbol,
+    pub invoice_id: Symbol,
+    /// `1` = enabled, `0` = disabled.
+    pub active: u32,
+}
+
+#[contractevent]
+pub struct InvestorAllowlistChanged {
+    #[topic]
+    pub name: Symbol,
+    pub invoice_id: Symbol,
+    pub investor: Address,
+    /// `1` = allowed, `0` = blocked.
+    pub allowed: u32,
 }
 
 #[contract]
@@ -822,6 +845,53 @@ impl LiquifactEscrow {
         .publish(&env);
     }
 
+    /// Enable or disable the investor allowlist. When enabled, only addresses with
+    /// [`DataKey::InvestorAllowlisted`] set to true may fund the escrow.
+    pub fn set_allowlist_active(env: Env, active: bool) {
+        let escrow = Self::get_escrow(env.clone());
+        escrow.admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::AllowlistActive, &active);
+        AllowlistEnabledChanged {
+            name: symbol_short!("al_ena"),
+            invoice_id: escrow.invoice_id.clone(),
+            active: if active { 1 } else { 0 },
+        }
+        .publish(&env);
+    }
+
+    pub fn is_allowlist_active(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::AllowlistActive)
+            .unwrap_or(false)
+    }
+
+    /// Add or remove an investor from the allowlist.
+    pub fn set_investor_allowlisted(env: Env, investor: Address, allowed: bool) {
+        let escrow = Self::get_escrow(env.clone());
+        escrow.admin.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::InvestorAllowlisted(investor.clone()), &allowed);
+
+        InvestorAllowlistChanged {
+            name: symbol_short!("al_set"),
+            invoice_id: escrow.invoice_id.clone(),
+            investor,
+            allowed: if allowed { 1 } else { 0 },
+        }
+        .publish(&env);
+    }
+
+    pub fn is_investor_allowlisted(env: Env, investor: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::InvestorAllowlisted(investor))
+            .unwrap_or(false)
+    }
+
     /// Convenience alias for [`LiquifactEscrow::set_legal_hold`] with `active = false`.
     pub fn clear_legal_hold(env: Env) {
         Self::set_legal_hold(env, false);
@@ -928,6 +998,13 @@ impl LiquifactEscrow {
             "Legal hold blocks new funding while active"
         );
         assert!(escrow.status == 0, "Escrow not open for funding");
+
+        if Self::is_allowlist_active(env.clone()) {
+            assert!(
+                Self::is_investor_allowlisted(env.clone(), investor.clone()),
+                "Investor not on allowlist"
+            );
+        }
 
         let contribution_key = DataKey::InvestorContribution(investor.clone());
         let prev: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
@@ -1199,3 +1276,5 @@ impl LiquifactEscrow {
 
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod test_allowlist;

--- a/escrow/src/test_allowlist.rs
+++ b/escrow/src/test_allowlist.rs
@@ -22,6 +22,8 @@ fn init(env: &Env, client: &LiquifactEscrowClient) -> (Address, Address) {
         &None,
         &treasury,
         &None,
+        &None,
+        &None,
     );
     (admin, sme)
 }
@@ -34,7 +36,7 @@ fn test_allowlist_disabled_by_default() {
     env.mock_all_auths();
     let client = deploy(&env);
     init(&env, &client);
-    assert!(!client.is_allowlist_enabled());
+    assert!(!client.is_allowlist_active());
 }
 
 #[test]
@@ -44,7 +46,7 @@ fn test_is_allowlisted_false_by_default() {
     let client = deploy(&env);
     init(&env, &client);
     let stranger = Address::generate(&env);
-    assert!(!client.is_allowlisted(&stranger));
+    assert!(!client.is_investor_allowlisted(&stranger));
 }
 
 // --- enable / disable ---
@@ -56,11 +58,11 @@ fn test_enable_and_disable_allowlist() {
     let client = deploy(&env);
     init(&env, &client);
 
-    client.enable_allowlist();
-    assert!(client.is_allowlist_enabled());
+    client.set_allowlist_active(&true);
+    assert!(client.is_allowlist_active());
 
-    client.disable_allowlist();
-    assert!(!client.is_allowlist_enabled());
+    client.set_allowlist_active(&false);
+    assert!(!client.is_allowlist_active());
 }
 
 #[test]
@@ -71,7 +73,7 @@ fn test_enable_allowlist_requires_admin_auth() {
     let client = deploy(&env);
     init(&env, &client);
     env.mock_auths(&[]);
-    client.enable_allowlist();
+    client.set_allowlist_active(&true);
 }
 
 #[test]
@@ -81,9 +83,9 @@ fn test_disable_allowlist_requires_admin_auth() {
     env.mock_all_auths();
     let client = deploy(&env);
     init(&env, &client);
-    client.enable_allowlist();
+    client.set_allowlist_active(&true);
     env.mock_auths(&[]);
-    client.disable_allowlist();
+    client.set_allowlist_active(&false);
 }
 
 // --- add / remove ---
@@ -96,11 +98,11 @@ fn test_add_and_remove_from_allowlist() {
     init(&env, &client);
     let investor = Address::generate(&env);
 
-    client.add_to_allowlist(&investor);
-    assert!(client.is_allowlisted(&investor));
+    client.set_investor_allowlisted(&investor, &true);
+    assert!(client.is_investor_allowlisted(&investor));
 
-    client.remove_from_allowlist(&investor);
-    assert!(!client.is_allowlisted(&investor));
+    client.set_investor_allowlisted(&investor, &false);
+    assert!(!client.is_investor_allowlisted(&investor));
 }
 
 #[test]
@@ -112,7 +114,7 @@ fn test_add_to_allowlist_requires_admin_auth() {
     init(&env, &client);
     let investor = Address::generate(&env);
     env.mock_auths(&[]);
-    client.add_to_allowlist(&investor);
+    client.set_investor_allowlisted(&investor, &true);
 }
 
 #[test]
@@ -123,9 +125,9 @@ fn test_remove_from_allowlist_requires_admin_auth() {
     let client = deploy(&env);
     init(&env, &client);
     let investor = Address::generate(&env);
-    client.add_to_allowlist(&investor);
+    client.set_investor_allowlisted(&investor, &true);
     env.mock_auths(&[]);
-    client.remove_from_allowlist(&investor);
+    client.set_investor_allowlisted(&investor, &false);
 }
 
 #[test]
@@ -136,8 +138,8 @@ fn test_remove_non_existent_address_is_noop() {
     init(&env, &client);
     let stranger = Address::generate(&env);
     // Should not panic.
-    client.remove_from_allowlist(&stranger);
-    assert!(!client.is_allowlisted(&stranger));
+    client.set_investor_allowlisted(&stranger, &false);
+    assert!(!client.is_investor_allowlisted(&stranger));
 }
 
 // --- fund gating ---
@@ -162,8 +164,8 @@ fn test_fund_allowed_when_on_allowlist() {
     init(&env, &client);
     let investor = Address::generate(&env);
 
-    client.enable_allowlist();
-    client.add_to_allowlist(&investor);
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
 
     let escrow = client.fund(&investor, &5_000i128);
     assert_eq!(escrow.funded_amount, 5_000i128);
@@ -178,7 +180,7 @@ fn test_fund_blocked_when_not_on_allowlist() {
     init(&env, &client);
     let investor = Address::generate(&env);
 
-    client.enable_allowlist();
+    client.set_allowlist_active(&true);
     client.fund(&investor, &1_000i128);
 }
 
@@ -191,7 +193,7 @@ fn test_fund_with_commitment_blocked_when_not_on_allowlist() {
     init(&env, &client);
     let investor = Address::generate(&env);
 
-    client.enable_allowlist();
+    client.set_allowlist_active(&true);
     client.fund_with_commitment(&investor, &1_000i128, &0u64);
 }
 
@@ -203,8 +205,8 @@ fn test_fund_with_commitment_allowed_when_on_allowlist() {
     init(&env, &client);
     let investor = Address::generate(&env);
 
-    client.enable_allowlist();
-    client.add_to_allowlist(&investor);
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
 
     let escrow = client.fund_with_commitment(&investor, &5_000i128, &0u64);
     assert_eq!(escrow.funded_amount, 5_000i128);
@@ -218,8 +220,8 @@ fn test_fund_allowed_after_disable_even_without_entry() {
     init(&env, &client);
     let investor = Address::generate(&env);
 
-    client.enable_allowlist();
-    client.disable_allowlist();
+    client.set_allowlist_active(&true);
+    client.set_allowlist_active(&false);
 
     // Gate is off — investor not in list but can still fund.
     let escrow = client.fund(&investor, &3_000i128);
@@ -234,13 +236,13 @@ fn test_entries_persist_across_disable_reenable() {
     init(&env, &client);
     let investor = Address::generate(&env);
 
-    client.enable_allowlist();
-    client.add_to_allowlist(&investor);
-    client.disable_allowlist();
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+    client.set_allowlist_active(&false);
     // Entry still there even while disabled.
-    assert!(client.is_allowlisted(&investor));
+    assert!(client.is_investor_allowlisted(&investor));
     // Re-enable — investor can still fund without re-adding.
-    client.enable_allowlist();
+    client.set_allowlist_active(&true);
     let escrow = client.fund(&investor, &2_000i128);
     assert_eq!(escrow.funded_amount, 2_000i128);
 }
@@ -254,9 +256,9 @@ fn test_removed_investor_blocked_after_reenable() {
     init(&env, &client);
     let investor = Address::generate(&env);
 
-    client.enable_allowlist();
-    client.add_to_allowlist(&investor);
-    client.remove_from_allowlist(&investor);
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+    client.set_investor_allowlisted(&investor, &false);
 
     client.fund(&investor, &1_000i128);
 }
@@ -271,13 +273,13 @@ fn test_multiple_investors_independent_allowlist_entries() {
     let b = Address::generate(&env);
     let c = Address::generate(&env);
 
-    client.enable_allowlist();
-    client.add_to_allowlist(&a);
-    client.add_to_allowlist(&b);
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&a, &true);
+    client.set_investor_allowlisted(&b, &true);
 
-    assert!(client.is_allowlisted(&a));
-    assert!(client.is_allowlisted(&b));
-    assert!(!client.is_allowlisted(&c));
+    assert!(client.is_investor_allowlisted(&a));
+    assert!(client.is_investor_allowlisted(&b));
+    assert!(!client.is_investor_allowlisted(&c));
 
     client.fund(&a, &3_000i128);
     client.fund(&b, &3_000i128);


### PR DESCRIPTION
closes #183 
Summary
This PR implements the investor allowlist functionality for the Liquifact Escrow contract, addressing issue #183. It provides administrative controls to restrict funding to authorized addresses only.

### Changes
- **Contract Surface**: Added new administrative methods for managing the allowlist state and authorized investor list.
- **Enforcement**: Modified the core funding logic to check the allowlist status. If the allowlist is active, only authorized investors can contribute.
- **Test Suite**: Restored and modernized the `test_allowlist.rs` suite. All 16 scenarios (auth, gating, persistence) are now passing.