### PR TITLE
feat(escrow): \get_legal_hold\ false default when key absent (fresh deploy)

### DIFF
--- a/escrow/src/test/admin.rs
+++ b/escrow/src/test/admin.rs
@@ -306,6 +306,17 @@ fn test_legal_hold_blocks_new_funds_when_open() {
     client.fund(&investor, &1i128);
 }
 
+/// Soroban instance storage returns `None` for a key that has never been written.
+/// `legal_hold_active` maps that `None` to `false` via `unwrap_or(false)`, so a
+/// fresh deploy must read `false` without any explicit `set_legal_hold` call.
+#[test]
+fn test_get_legal_hold_defaults_false_on_fresh_deploy() {
+    let env = Env::default();
+    // No init, no set_legal_hold – DataKey::LegalHold is absent from storage.
+    let client = deploy(&env);
+    assert!(!client.get_legal_hold());
+}
+
 #[test]
 fn test_update_funding_target_by_admin_succeeds() {
     let env = Env::default();


### PR DESCRIPTION
## Summary

  - Adds `test_get_legal_hold_defaults_false_on_fresh_deploy` to `escrow/src/test/admin.rs`
  - Verifies `get_legal_hold()` returns `false` on a fresh contract deployment before any `set_legal_hold` call, exercising the `unwrap_or(false)` storage
  default in `legal_hold_active`
  - Adds a doc comment explaining the Soroban instance-storage defaulting behaviour

  ## Security notes

  No auth or transfer code touched. `get_legal_hold` is a read-only getter with no authorization gate — the default-`false` path is reached only when
  `DataKey::LegalHold` has never been written (i.e. pre-`init` or first deploy). Out-of-scope: token economics per `escrow/src/external_calls.rs`.

  ## Test output

  test test::admin::test_get_legal_hold_defaults_false_on_fresh_deploy ... ok

  Closes #190