### PR TITLE
feat(escrow): `fund_with_commitment` — tier selection, effective yield, and InvestorClaimNotBefore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,18 +387,8 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -416,36 +406,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -1209,26 +1175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,30 +1237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
  "serde",
  "serde_json",
 ]
@@ -1383,19 +1305,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.13.0",
- "schemars 0.8.22",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
+ "schemars",
+ "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -1403,11 +1324,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1565,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "25.3.0"
+version = "25.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb27e93f8d3fc3a815d24c60ec11e893c408a36693ec9c823322f954fa096ae"
+checksum = "7f3293c7598be20a13bbea89a0494e29d1682a615b44dbcaf936175a33307873"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1593,7 +1514,7 @@ version = "25.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec603a62a90abdef898f8402471a24d8b58a0043b9a998ed6a607a19a5dabe1"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "heck",
  "itertools",
  "macro-string",

--- a/escrow/src/test/funding.rs
+++ b/escrow/src/test/funding.rs
@@ -509,6 +509,126 @@ fn test_fund_with_commitment_twice_panics() {
 }
 
 #[test]
+#[should_panic(expected = "Additional principal after a tiered first deposit")]
+fn test_fund_then_fund_with_commitment_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "SEQ001"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&inv, &5_000i128);
+    client.fund_with_commitment(&inv, &5_000i128, &10u64);
+}
+
+#[test]
+fn test_tier_selection_ladder() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 200,
+        yield_bps: 1000,
+    });
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "LADDER01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+    );
+
+    let inv_base = Address::generate(&env);
+    let inv_tier1 = Address::generate(&env);
+    let inv_tier2 = Address::generate(&env);
+    let inv_mid = Address::generate(&env);
+
+    // Below first tier -> base
+    client.fund_with_commitment(&inv_base, &1_000i128, &50u64);
+    assert_eq!(client.get_investor_yield_bps(&inv_base), 800);
+
+    // Exactly first tier
+    client.fund_with_commitment(&inv_tier1, &1_000i128, &100u64);
+    assert_eq!(client.get_investor_yield_bps(&inv_tier1), 900);
+
+    // Between tiers -> still first tier
+    client.fund_with_commitment(&inv_mid, &1_000i128, &150u64);
+    assert_eq!(client.get_investor_yield_bps(&inv_mid), 900);
+
+    // Exactly second tier
+    client.fund_with_commitment(&inv_tier2, &1_000i128, &200u64);
+    assert_eq!(client.get_investor_yield_bps(&inv_tier2), 1000);
+}
+
+#[test]
+fn test_fund_with_commitment_zero_lock_behaves_as_fund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "ZERO001"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+    );
+
+    client.fund_with_commitment(&inv, &5_000i128, &0u64);
+    assert_eq!(client.get_investor_yield_bps(&inv), 800);
+    assert_eq!(client.get_investor_claim_not_before(&inv), 0);
+}
+
+#[test]
 #[should_panic(expected = "strictly increasing min_lock_secs")]
 fn test_init_bad_tier_order_panics() {
     let env = Env::default();

--- a/escrow/src/test/settlement.rs
+++ b/escrow/src/test/settlement.rs
@@ -368,6 +368,101 @@ fn test_claim_succeeds_after_commitment_and_settle() {
 }
 
 #[test]
+fn test_claim_gating_exact_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    env.ledger().set_timestamp(1000);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "LOCK003"),
+        &sme,
+        &1_000i128,
+        &400i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+
+    let lock_duration = 500u64;
+    client.fund_with_commitment(&inv, &1_000i128, &lock_duration);
+    client.settle();
+
+    let expiry = 1000 + lock_duration;
+
+    // 1 second before expiry
+    env.ledger().set_timestamp(expiry - 1);
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.claim_investor_payout(&inv);
+    }));
+    assert!(err.is_err(), "Claim should be blocked 1s before expiry");
+
+    // Exact expiry
+    env.ledger().set_timestamp(expiry);
+    client.claim_investor_payout(&inv);
+    assert!(client.is_investor_claimed(&inv));
+}
+
+#[test]
+fn test_claim_gating_with_multiple_investors() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv1 = Address::generate(&env);
+    let inv2 = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    env.ledger().set_timestamp(1000);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "LOCK004"),
+        &sme,
+        &2_000i128,
+        &400i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+
+    client.fund_with_commitment(&inv1, &1_000i128, &100u64); // Expiry 1100
+    client.fund_with_commitment(&inv2, &1_000i128, &200u64); // Expiry 1200
+    client.settle();
+
+    env.ledger().set_timestamp(1150);
+
+    // inv1 can claim
+    client.claim_investor_payout(&inv1);
+    assert!(client.is_investor_claimed(&inv1));
+
+    // inv2 still blocked
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.claim_investor_payout(&inv2);
+    }));
+    assert!(err.is_err(), "inv2 should still be blocked at 1150");
+
+    env.ledger().set_timestamp(1200);
+    client.claim_investor_payout(&inv2);
+    assert!(client.is_investor_claimed(&inv2));
+}
+
+#[test]
 fn test_cost_baseline_settle() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);


### PR DESCRIPTION
closes #147 
### Overview
This PR implements a comprehensive integration test suite for the `fund_with_commitment` path, addressing issue #147. It ensures that the contract correctly handles tiered yield selection and enforces commitment-based withdrawal locks.

### Changes
- **Tier Selection**: Added tests verifying that the correct yield is selected based on the `YieldTierTable` and investor lock duration.
- **Sequential Integrity**: Verified the "first deposit only" rule for commitments, ensuring subsequent funding legs must use the standard `fund` method.
- **Claim Gating**: Implemented detailed tests for `InvestorClaimNotBefore`, verifying that payouts are blocked until the exact ledger timestamp of expiry.
- **Dependency Management**: Updated `Cargo.lock` to ensure compatibility with `rustc 1.87.0` by pinning stable versions of `soroban-sdk` and `serde_with`.
