### PR TITLE
feat(escrow): token host calls and safety narrative for reviewers

### DIFF
--- a/docs/escrow-host-model.md
+++ b/docs/escrow-host-model.md
@@ -1,0 +1,47 @@
+# Escrow Host Call Model (Soroban)
+
+This note explains the escrow contract's token transfer safety model for reviewers, focused on
+Soroban execution semantics and the checks implemented in `escrow/src/external_calls.rs`.
+
+## Short model
+
+- The escrow calls the configured SEP-41 token contract via Soroban host.
+- The token call executes and returns to escrow.
+- Escrow validates post-call balance deltas for both sender and recipient.
+- Any mismatch (fees, rebasing side effects, non-standard behavior) fails closed with panic.
+
+## Transfer + balance-check timeline
+
+```
+Escrow contract
+  -> read from_before, treasury_before
+  -> call token.transfer(from, treasury, amount)
+     -> token contract executes in host
+     -> returns to escrow
+  -> read from_after, treasury_after
+  -> assert (from_before - from_after) == amount
+  -> assert (treasury_after - treasury_before) == amount
+```
+
+## Soroban vs EVM reentrancy framing (contrast only)
+
+- In Soroban, the host call boundary is explicit: escrow logic resumes after the token call returns.
+- This avoids relying on EVM-style "checks-effects-interactions" folklore as the primary argument.
+- The escrow still assumes the token can be adversarial from an accounting perspective, so
+  invariant checks are mandatory after external calls.
+
+## Security assumptions and out-of-scope behavior
+
+The escrow wrapper is intentionally strict and supports standard SEP-41-like token behavior only.
+
+- Assumed: balance deltas exactly match transfer amount.
+- Out of scope: fee-on-transfer, rebasing, or hook-driven token economics.
+- Policy: unsupported behavior should be blocked by allowlisting and integration review.
+- Runtime fallback: if unsupported behavior occurs, transfer checks panic (safe failure).
+
+## Reviewer checklist
+
+- Confirm all token transfers that matter for accounting use the wrapper in
+  `escrow/src/external_calls.rs`.
+- Confirm both sender and recipient deltas are asserted exactly.
+- Confirm out-of-scope token behavior is documented in integration/security docs.

--- a/escrow/src/external_calls.rs
+++ b/escrow/src/external_calls.rs
@@ -27,6 +27,18 @@
 //! host function runs to completion before this contract resumes. **Still** treat the token as
 //! adversarial for **correctness of balances**: always record pre/post balances around transfers so
 //! integration bugs and non-compliant tokens are caught at the host boundary.
+//!
+//! ## Reviewer timeline (host-call boundary)
+//!
+//! `transfer_funding_token_with_balance_checks` follows this sequence:
+//! 1. Read sender/recipient balances before transfer.
+//! 2. Invoke SEP-41 `transfer` on the configured token contract.
+//! 3. Soroban host executes that token call to completion, then returns.
+//! 4. Read sender/recipient balances after transfer.
+//! 5. Assert exact conservation (`spent == amount` and `received == amount`).
+//!
+//! Security takeaway: this is not relying on "non-reentrancy" as a magic property. It enforces
+//! post-call accounting invariants at the external-call boundary where token behavior is observed.
 
 use soroban_sdk::{token::TokenClient, Address, Env, MuxedAddress};
 


### PR DESCRIPTION
## Summary
- Adds a reviewer-friendly Soroban host-call timeline to `escrow/src/external_calls.rs` explaining the transfer + post-balance-check safety pattern.
- Introduces `docs/escrow-host-model.md` with a short execution narrative, contrast with EVM reentrancy framing (contrast-only), and explicit token-behavior assumptions/out-of-scope notes.
- Keeps behavior unchanged; this is a documentation/security-review clarity enhancement for issue #170.

## Implementation Notes
- **Primary files changed**
  - `escrow/src/external_calls.rs`
  - `docs/escrow-host-model.md`
- **Contract/runtime behavior**
  - No logic changes to transfer enforcement; existing strict sender/recipient balance-delta assertions remain the source of safety.
- **Security/reliability notes**
  - Clarifies that Soroban host call boundaries differ from classic EVM reentrancy narratives.
  - Reiterates unsupported token economics (fee-on-transfer, rebasing, hook tokens) as out-of-scope and fail-closed at invariant checks.

## Validation
- `cargo fmt --all -- --check` -> **fail** (pre-existing unrelated formatting diffs in existing test files).
- `cargo test -p liquifact_escrow` -> **fail** (pre-existing unrelated compile/test errors in existing test modules).
- `cargo llvm-cov --features testutils --fail-under-lines 95 --summary-only -p liquifact_escrow` -> **not runnable** due to the same pre-existing test compile failures.
- Merge conflict dry-run against `upstream/main`:
  - `git checkout -b test-merge-dry-run upstream/main`
  - `git merge --no-commit --no-ff docs/escrow-soroban-reentrancy-model`
  - Result: **Automatic merge went well; stopped before committing as requested**
  - Cleanup completed (`git merge --abort`, branch deleted).

## Repro Steps for Maintainer
1. Review `escrow/src/external_calls.rs` top-level docs for the new host-call timeline under “Reviewer timeline (host-call boundary)”.
2. Open `docs/escrow-host-model.md` and verify the transfer sequence diagram + assumptions/out-of-scope section.
3. Confirm no functional contract logic changes were introduced (docs-only scope).

## Risks / Follow-ups
- Existing repository-wide test/format issues are unrelated to this PR and block full quality-gate execution in this branch.
- Follow-up (separate issue/PR): restore baseline green for `liquifact_escrow` tests and formatting so CI coverage gate can run reliably.

Closes #170