### PR TITLE
feat(escrow): update_maturity open-only, ledger time semantics, and MaturityUpdatedEvent (#153)

### DIFF
--- a/docs/escrow-ledger-time.md
+++ b/docs/escrow-ledger-time.md
@@ -1,0 +1,141 @@
+# Escrow Ledger Time Semantics
+
+This document explains how the LiquiFact Escrow contract handles time,
+why it uses ledger timestamps instead of wall-clock time, and how
+integrators and testers should reason about time-dependent operations.
+
+---
+
+## What is Ledger Time?
+
+The Soroban runtime exposes time through `Env::ledger().timestamp()`,
+which returns the **validator-observed Unix timestamp** (seconds since
+epoch) recorded in the ledger header at the time the transaction is
+processed.
+
+This is **not** wall-clock time from your local machine or any external
+oracle. It is the timestamp validators agreed upon when they closed the
+ledger containing your transaction.
+
+---
+
+## Where Ledger Time Is Used in This Contract
+
+### 1. `settle` — Maturity Gate
+
+```rust
+if escrow.maturity > 0 {
+    let now = env.ledger().timestamp();
+    assert!(now >= escrow.maturity, "Escrow has not yet reached maturity");
+}
+```
+
+- The comparison is `>=` (inclusive boundary).
+- When `maturity == 0`, the gate is skipped — no time lock.
+- Maturity is stored as a raw `u64` of seconds.
+
+### 2. `claim_investor_payout` — Commitment Lock
+
+```rust
+let now = env.ledger().timestamp();
+assert!(now >= not_before, "Investor commitment lock not expired (ledger timestamp)");
+```
+
+Same `>=` semantics: the claim is allowed at exactly `not_before`,
+not one second after.
+
+### 3. `record_sme_collateral_commitment` — Timestamp Metadata
+
+The `recorded_at` field is set to `env.ledger().timestamp()` for
+indexing only. It does not gate any operations.
+
+---
+
+## Simulating Time in Tests
+
+Soroban's test environment lets you set the ledger timestamp manually:
+
+```rust
+env.ledger().with_mut(|l| l.timestamp = 5000);
+```
+
+### Example: Testing the Maturity Boundary
+
+```rust
+// Escrow initialized with maturity = 5000
+env.ledger().with_mut(|l| l.timestamp = 4999);
+// settle() panics — one second before maturity
+
+env.ledger().with_mut(|l| l.timestamp = 5000);
+// settle() succeeds — exactly at maturity
+```
+
+---
+
+## Skew Between Test/Simulation and Mainnet
+
+> **Important:** ledger timestamps on testnets and in local simulation
+> may not match mainnet validator observations.
+
+- **Local simulation** sets an arbitrary timestamp with no relation to
+  real time.
+- **Testnet** ledgers close faster than mainnet.
+- **Mainnet** validators agree on timestamps by consensus; actual
+  timestamps may differ slightly from wall-clock time due to network
+  conditions and validator clock skew (~±30s is normal).
+
+### Practical Guidance
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Unit tests | Use `env.ledger().with_mut` to set exact timestamps |
+| Integration tests on testnet | Add a safety buffer of at least 60s to maturity values |
+| Production / mainnet | Treat maturity boundaries as approximate to ±30s of wall clock |
+| Off-chain monitoring | Poll `get_escrow().maturity` and compare to latest ledger timestamp from Horizon |
+
+---
+
+## `update_maturity` — Open State Only
+
+Maturity can only be changed while the escrow is **Open** (status == 0):
+
+| Status | `update_maturity` result |
+|--------|--------------------------|
+| 0 — Open | ✅ Allowed |
+| 1 — Funded | ❌ Panics: "Maturity can only be updated in Open state" |
+| 2 — Settled | ❌ Panics: "Maturity can only be updated in Open state" |
+| 3 — Withdrawn | ❌ Panics: "Maturity can only be updated in Open state" |
+
+This prevents retroactive maturity changes after investors have
+committed funds.
+
+---
+
+## `MaturityUpdatedEvent`
+
+Every successful `update_maturity` emits:
+
+```rust
+pub struct MaturityUpdatedEvent {
+    #[topic] pub name: Symbol,       // symbol_short!("maturity")
+    #[topic] pub invoice_id: Symbol,
+    pub old_maturity: u64,           // previous ledger timestamp
+    pub new_maturity: u64,           // new ledger timestamp
+}
+```
+
+Indexers should listen for this event to track maturity changes
+per invoice without polling contract state on every ledger.
+
+---
+
+## Security Notes
+
+- **No wall-clock oracle:** all time comparisons use
+  `env.ledger().timestamp()` only — no external time source.
+- **No negative time:** `maturity` and `InvestorClaimNotBefore` are
+  `u64` — they cannot be negative.
+- **Overflow guard:** `committed_lock_secs` addition uses
+  `checked_add(...).expect("investor claim time overflow")`.
+- **Token economics:** time-based yield calculations are out of scope.
+  See `escrow/src/external_calls.rs` for token transfer assumptions.

--- a/escrow/src/test/admin.rs
+++ b/escrow/src/test/admin.rs
@@ -659,3 +659,284 @@ fn test_update_funding_target_negative_panics() {
     );
     client.update_funding_target(&-1i128);
 }
+// --- update_maturity: open-only, ledger time semantics, MaturityUpdatedEvent ---
+
+/// `update_maturity` must emit a `MaturityUpdatedEvent` with the correct
+/// topic (`symbol_short!("maturity")`), `invoice_id`, `old_maturity`, and
+/// `new_maturity` fields. Ledger timestamps are validator-observed integers;
+/// the contract stores and compares them as raw `u64` seconds.
+#[test]
+fn test_update_maturity_event_fields() {
+    use soroban_sdk::testutils::Events as _;
+    use crate::MaturityUpdatedEvent;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+    let contract_id = client.address.clone();
+
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MAT001"),
+        &sme,
+        &5_000i128,
+        &800i64,
+        &1000u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+
+    client.update_maturity(&2000u64);
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![MaturityUpdatedEvent {
+            name: symbol_short!("maturity"),
+            invoice_id: client.get_escrow().invoice_id,
+            old_maturity: 1000u64,
+            new_maturity: 2000u64,
+        }
+        .to_xdr(&env, &contract_id)]
+    );
+}
+
+/// `update_maturity` must be rejected when the escrow is in the **funded**
+/// state (status == 1); only Open (0) is permitted.
+#[test]
+#[should_panic(expected = "Maturity can only be updated in Open state")]
+fn test_update_maturity_fails_when_funded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let client = deploy(&env);
+
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MAT002"),
+        &sme,
+        &5_000i128,
+        &800i64,
+        &1000u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &5_000i128); // status → 1 (funded)
+    client.update_maturity(&2000u64);
+}
+
+/// `update_maturity` must be rejected when the escrow is **settled**
+/// (status == 2); only Open (0) is permitted.
+#[test]
+#[should_panic(expected = "Maturity can only be updated in Open state")]
+fn test_update_maturity_fails_when_settled() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let client = deploy(&env);
+
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MAT003"),
+        &sme,
+        &5_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &5_000i128); // status → 1
+    client.settle();                    // status → 2
+    client.update_maturity(&2000u64);
+}
+
+/// `update_maturity` must be rejected when the escrow is **withdrawn**
+/// (status == 3); only Open (0) is permitted.
+#[test]
+#[should_panic(expected = "Maturity can only be updated in Open state")]
+fn test_update_maturity_fails_when_withdrawn() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let client = deploy(&env);
+
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MAT004"),
+        &sme,
+        &5_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &5_000i128); // status → 1
+    client.withdraw();                  // status → 3
+    client.update_maturity(&2000u64);
+}
+
+/// Setting maturity to zero is valid — it means no maturity gate.
+/// The contract must accept zero as new_maturity in Open state.
+#[test]
+fn test_update_maturity_to_zero_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MAT005"),
+        &sme,
+        &5_000i128,
+        &800i64,
+        &1000u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+    let updated = client.update_maturity(&0u64);
+    assert_eq!(updated.maturity, 0u64);
+    assert_eq!(updated.status, 0);
+}
+
+/// Ledger time semantics: `settle` uses `env.ledger().timestamp()`
+/// (validator-observed seconds). Settle must pass exactly at maturity —
+/// confirming the boundary is `now >= maturity` (inclusive).
+#[test]
+fn test_settle_passes_exactly_at_maturity_ledger_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let client = deploy(&env);
+
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MAT006"),
+        &sme,
+        &5_000i128,
+        &800i64,
+        &5000u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &5_000i128);
+
+    // Advance ledger to exactly maturity — must succeed
+    env.ledger().with_mut(|l| l.timestamp = 5000);
+    let settled = client.settle();
+    assert_eq!(settled.status, 2);
+}
+
+/// Ledger time semantics: settle must panic one second before maturity —
+/// confirming the `>=` boundary strictly excludes values below maturity.
+#[test]
+#[should_panic(expected = "Escrow has not yet reached maturity")]
+fn test_settle_fails_one_second_before_maturity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let client = deploy(&env);
+
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MAT007"),
+        &sme,
+        &5_000i128,
+        &800i64,
+        &5000u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &5_000i128);
+
+    // One second before maturity — must reject
+    env.ledger().with_mut(|l| l.timestamp = 4999);
+    client.settle();
+}
+
+/// A second `update_maturity` call in the same Open state must overwrite
+/// the previous value correctly — storage is atomic per call.
+#[test]
+fn test_update_maturity_twice_overwrites() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MAT008"),
+        &sme,
+        &5_000i128,
+        &800i64,
+        &1000u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+
+    client.update_maturity(&2000u64);
+    let updated = client.update_maturity(&3000u64);
+    assert_eq!(updated.maturity, 3000u64);
+    assert_eq!(client.get_escrow().maturity, 3000u64);
+}


### PR DESCRIPTION
## In Summary
Fixes #153

## Changes
- Added tests to `escrow/src/test/admin.rs` covering:
  - `update_maturity` emits correct `MaturityUpdatedEvent` fields
  - `update_maturity` rejected in funded, settled, and withdrawn states
  - `update_maturity` to zero succeeds (no maturity gate)
  - `update_maturity` twice correctly overwrites previous value
  - `settle` passes exactly at maturity ledger timestamp
  - `settle` fails one second before maturity (boundary test)

- Created `docs/escrow-ledger-time.md` covering:
  - What ledger time is vs wall-clock time
  - Where `env.ledger().timestamp()` is used in the contract
  - How to simulate time in tests using `env.ledger().with_mut`
  - Skew between testnet/simulation and mainnet
  - `update_maturity` open-only state table
  - `MaturityUpdatedEvent` fields for indexers
  - Security notes

## Security Notes
- No wall-clock oracle used — all comparisons against `env.ledger().timestamp()`
- Token economics out of scope per `escrow/src/external_calls.rs`
- Maturity boundaries are `>=` inclusive integer second comparisons



## CI Note
The `fmt-build-test` failure is a pre-existing workspace 
configuration issue (multiple Cargo.toml workspace roots) 
that also affects PR #236 by another contributor. 
This is unrelated to the changes in this PR.