### PR TITLE
feat(escrow): add cancel_funding and investor refund path (#242)

### DIFF
--- a/docs/escrow-lifecycle.md
+++ b/docs/escrow-lifecycle.md
@@ -13,6 +13,7 @@ forbidden regressions, and interaction rules between `withdraw` vs `settle` path
 | `1` | `funded` | At least one investor reached or exceeded the funding target |
 | `2` | `settled` | SME has finalized settlement after legal/financial review |
 | `3` | `withdrawn` | SME has withdrawn liquidity (pull model, off-chain settlement) |
+| `4` | `cancelled` | Admin cancelled the escrow before it was funded; investors may reclaim principal via `refund()` |
 
 ---
 
@@ -25,22 +26,23 @@ forbidden regressions, and interaction rules between `withdraw` vs `settle` path
                 │    open      │
                 └──────┬──────┘
                        │
-                       │ fund(amount >= funding_target)
-                       ▼
-                ┌─────────────┐
-                │  funded     │
-                │ status = 1  │
-                └──────┬──────┘
-                       │
-         ┌─────────────┼─────────────┐
-         │             │             │
-         │             │             │
-         ▼             ▼             ▼
-  ┌──────────┐  ┌──────────┐  ┌──────────┐
-  │ settled  │  │ withdrawn│  │  (open)  │  ← more funding if target not met
-  │ status=2 │  │ status=3 │
-  └──────────┘  └──────────┘  └──────────┘
-      (terminal)    (terminal)
+         ┌─────────────┼──────────────────────┐
+         │             │                      │
+         │ fund(amount >= funding_target)      │ cancel_funding() [admin]
+         ▼             │                      ▼
+  ┌─────────────┐      │               ┌─────────────┐
+  │  funded     │      │               │  cancelled  │
+  │ status = 1  │      │               │  status = 4 │
+  └──────┬──────┘      │               └──────┬──────┘
+         │             │                      │
+  ┌──────┼──────┐      │ (more funding        │ refund(investor) [investor]
+  │      │      │      │  if target not met)  │ → returns InvestorContribution
+  ▼      ▼      │      │                      ▼
+┌────┐ ┌────┐   │      │               (principal returned)
+│ 2  │ │ 3  │   └──────┘
+│set │ │wd  │
+└────┘ └────┘
+(terminal)  (terminal)
 ```
 
 ---
@@ -50,6 +52,7 @@ forbidden regressions, and interaction rules between `withdraw` vs `settle` path
 | From | To | Trigger | Auth required |
 |------|----|---------|--------------|
 | `0` (open) | `1` (funded) | `fund()` or `fund_with_commitment()` when `funded_amount >= funding_target` | Investor auth |
+| `0` (open) | `4` (cancelled) | `cancel_funding()` | Admin auth; legal hold must be inactive |
 | `1` (funded) | `2` (settled) | `settle()` | SME auth; legal hold must be inactive; if `maturity > 0`, ledger timestamp must be >= maturity |
 | `1` (funded) | `3` (withdrawn) | `withdraw()` | SME auth; legal hold must be inactive |
 
@@ -63,12 +66,10 @@ forbidden regressions, and interaction rules between `withdraw` vs `settle` path
 | `0` (open) | `2` (settled) | Escrow must be funded first |
 | `0` (open) | `3` (withdrawn) | Escrow must be funded first |
 | `1` (funded) | `0` (open) | Status never regresses |
-| `2` (settled) | `0` (open) | Status never regresses |
-| `2` (settled) | `1` (funded) | Already past this state |
-| `2` (settled) | `3` (withdrawn) | Settle and withdraw are mutually exclusive |
-| `3` (withdrawn) | `0` (open) | Status never regresses |
-| `3` (withdrawn) | `1` (funded) | Already past this state |
-| `3` (withdrawn) | `2` (settled) | Already past this state |
+| `1` (funded) | `4` (cancelled) | `cancel_funding` only allowed in Open state |
+| `2` (settled) | any | Status never regresses from terminal |
+| `3` (withdrawn) | any | Status never regresses from terminal |
+| `4` (cancelled) | any | Status never regresses from terminal |
 
 ---
 
@@ -85,12 +86,41 @@ Once one path is taken, the other is unreachable:
 
 ---
 
+## Investor refund path (status 4 — cancelled)
+
+When an escrow is cancelled before reaching its funding target, investors may recover
+their principal:
+
+1. Admin calls `cancel_funding()` — transitions `status 0 → 4`. Blocked by legal hold.
+2. Each investor calls `refund(investor)` — transfers exactly `DataKey::InvestorContribution`
+   back to the investor via `external_calls::transfer_funding_token_with_balance_checks`.
+3. `InvestorContribution` is zeroed after transfer (checks-effects-interactions pattern).
+4. `DataKey::InvestorRefunded` is set to `true` — `is_investor_refunded()` returns `true`.
+5. A second `refund()` call panics with `"no contribution to refund"` (contribution is 0).
+
+### Invariants
+
+- Total refunded ≤ `funded_amount` (each investor can only reclaim their own contribution).
+- No double-refund: contribution is zeroed before the token transfer.
+- Balance-delta checks enforced by `external_calls` wrapper (SEP-41 conservation).
+- `refund()` is blocked in all states except `4` (cancelled).
+
+### Events emitted
+
+| Event | When |
+|-------|------|
+| `FundingCancelled` | `cancel_funding()` succeeds |
+| `InvestorRefundedEvt` | `refund()` succeeds |
+
+---
+
 ## SME auth vs admin role
 
 | Function | Role |
 |----------|------|
-| `settle()` | SME (off-chain settlement policy, not an EVM `onlyOwner` concept) |
+| `settle()` | SME |
 | `withdraw()` | SME |
+| `cancel_funding()` | Admin only |
 | `set_legal_hold()` | Admin only |
 | `update_maturity()` | Admin only |
 | `transfer_admin()` | Admin only |
@@ -110,6 +140,8 @@ Legal hold blocks all risk-bearing operations regardless of status:
 | `settle()` | Yes |
 | `withdraw()` | Yes |
 | `claim_investor_payout()` | Yes |
+| `cancel_funding()` | Yes |
+| `sweep_terminal_dust()` | Yes |
 
 Once legal hold is cleared, normal state transitions resume.
 
@@ -125,6 +157,21 @@ When `maturity > 0`:
 
 ---
 
+## Terminal states and dust sweep
+
+`sweep_terminal_dust()` is permitted in all three terminal states:
+
+| Status | Terminal | Dust sweep allowed |
+|--------|----------|--------------------|
+| `2` (settled) | Yes | Yes |
+| `3` (withdrawn) | Yes | Yes |
+| `4` (cancelled) | Yes | Yes |
+
+This allows the treasury to recover any rounding residue left after all investors
+have been refunded.
+
+---
+
 ## Security notes
 
 - **Out of scope:** Non-standard token economics (rebasing, fee-on-transfer).
@@ -132,3 +179,5 @@ When `maturity > 0`:
 - **funded_amount** is a non-decreasing i128. Overflow is checked via `checked_add`.
 - **Snapshot immutability:** `FundingCloseSnapshot` is written once at the
   `0 → 1` transition and must remain readable after `settle()` or `withdraw()`.
+- **Refund double-spend prevention:** `InvestorContribution` is zeroed before the
+  token transfer; a second `refund()` call finds contribution `0` and panics.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1485,7 +1485,10 @@ impl LiquifactEscrow {
         let mut escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
-        assert!(escrow.status == 0, "cancel_funding only allowed in Open state");
+        assert!(
+            escrow.status == 0,
+            "cancel_funding only allowed in Open state"
+        );
 
         escrow.status = 4;
         env.storage().instance().set(&DataKey::Escrow, &escrow);
@@ -1515,11 +1518,7 @@ impl LiquifactEscrow {
         assert!(escrow.status == 4, "refund only allowed in Cancelled state");
 
         let contribution_key = DataKey::InvestorContribution(investor.clone());
-        let amount: i128 = env
-            .storage()
-            .instance()
-            .get(&contribution_key)
-            .unwrap_or(0);
+        let amount: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
         assert!(amount > 0, "no contribution to refund");
 
         // Zero out contribution before transfer (checks-effects-interactions).

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -204,6 +204,9 @@ pub enum DataKey {
     AllowlistActive,
     /// Whether a specific address is permitted to fund when [`DataKey::AllowlistActive`] is true.
     InvestorAllowlisted(Address),
+    /// Set to `true` once an investor's principal has been refunded in a cancelled escrow.
+    /// Absent ⇒ `false`. Written once; prevents double-refund.
+    InvestorRefunded(Address),
 }
 
 // --- Data types ---
@@ -227,7 +230,7 @@ pub struct InvoiceEscrow {
     pub funded_amount: i128,
     pub yield_bps: i64,
     pub maturity: u64,
-    /// 0 = open, 1 = funded, 2 = settled, 3 = withdrawn (SME pulled liquidity)
+    /// 0 = open, 1 = funded, 2 = settled, 3 = withdrawn (SME pulled liquidity), 4 = cancelled (admin-gated; investors may refund)
     pub status: u32,
 }
 
@@ -382,6 +385,26 @@ pub struct InvestorPayoutClaimed {
     pub investor: Address,
     #[topic]
     pub invoice_id: Symbol,
+}
+
+#[contractevent]
+pub struct FundingCancelled {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub funded_amount: i128,
+}
+
+#[contractevent]
+pub struct InvestorRefundedEvt {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub investor: Address,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub amount: i128,
 }
 
 #[contractevent]
@@ -690,8 +713,8 @@ impl LiquifactEscrow {
         // env.clone(): env is used again after this call for treasury/token reads and publish.
         let escrow = Self::get_escrow(env.clone());
         assert!(
-            escrow.status == 2 || escrow.status == 3,
-            "dust sweep only in terminal states (settled or withdrawn)"
+            escrow.status == 2 || escrow.status == 3 || escrow.status == 4,
+            "dust sweep only in terminal states (settled, withdrawn, or cancelled)"
         );
 
         let treasury: Address = env
@@ -1443,6 +1466,98 @@ impl LiquifactEscrow {
         .publish(&env);
 
         escrow
+    }
+
+    /// Transition an **open** escrow (status 0) to **cancelled** (status 4).
+    ///
+    /// Only the [`InvoiceEscrow::admin`] may call this. Blocked while a legal hold is active.
+    /// After cancellation, investors may recover their principal via [`LiquifactEscrow::refund`].
+    ///
+    /// # Panics
+    /// - If legal hold is active.
+    /// - If escrow is not in status 0 (open).
+    pub fn cancel_funding(env: Env) -> InvoiceEscrow {
+        assert!(
+            !Self::legal_hold_active(&env),
+            "Legal hold blocks cancel_funding"
+        );
+
+        let mut escrow = Self::get_escrow(env.clone());
+        escrow.admin.require_auth();
+
+        assert!(escrow.status == 0, "cancel_funding only allowed in Open state");
+
+        escrow.status = 4;
+        env.storage().instance().set(&DataKey::Escrow, &escrow);
+
+        FundingCancelled {
+            name: symbol_short!("fund_can"),
+            invoice_id: escrow.invoice_id.clone(),
+            funded_amount: escrow.funded_amount,
+        }
+        .publish(&env);
+
+        escrow
+    }
+
+    /// Return an investor's recorded principal when the escrow is **cancelled** (status 4).
+    ///
+    /// Requires `investor` auth. Zeroes [`DataKey::InvestorContribution`] after transfer so a
+    /// second call is a no-op (contribution is 0 → panics with "no contribution to refund").
+    ///
+    /// # Panics
+    /// - If escrow is not in status 4 (cancelled).
+    /// - If the investor has no recorded contribution (or has already been refunded).
+    pub fn refund(env: Env, investor: Address) {
+        investor.require_auth();
+
+        let escrow = Self::get_escrow(env.clone());
+        assert!(escrow.status == 4, "refund only allowed in Cancelled state");
+
+        let contribution_key = DataKey::InvestorContribution(investor.clone());
+        let amount: i128 = env
+            .storage()
+            .instance()
+            .get(&contribution_key)
+            .unwrap_or(0);
+        assert!(amount > 0, "no contribution to refund");
+
+        // Zero out contribution before transfer (checks-effects-interactions).
+        env.storage().instance().set(&contribution_key, &0i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::InvestorRefunded(investor.clone()), &true);
+
+        let token_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::FundingToken)
+            .expect("funding token must be initialized");
+        let this = env.current_contract_address();
+
+        external_calls::transfer_funding_token_with_balance_checks(
+            &env,
+            &token_addr,
+            &this,
+            &investor,
+            amount,
+        );
+
+        InvestorRefundedEvt {
+            name: symbol_short!("refunded"),
+            investor: investor.clone(),
+            invoice_id: escrow.invoice_id.clone(),
+            amount,
+        }
+        .publish(&env);
+    }
+
+    /// Whether an investor has already received a refund in a cancelled escrow.
+    pub fn is_investor_refunded(env: Env, investor: Address) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::InvestorRefunded(investor))
+            .unwrap_or(false)
     }
 }
 

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -1563,3 +1563,261 @@ fn test_cap_panic_message_quality() {
     let inv2 = Address::generate(&env);
     client.fund(&inv2, &(TARGET / 2));
 }
+
+// ── cancel_funding and refund tests ──────────────────────────────────────────
+
+fn init_with_token<'a>(
+    env: &'a Env,
+    client: &LiquifactEscrowClient<'a>,
+    admin: &Address,
+    sme: &Address,
+) -> (
+    crate::tests::StellarTestToken<'a>,
+    Address, // treasury
+) {
+    let token = install_stellar_asset_token(env);
+    let treasury = Address::generate(env);
+    client.init(
+        admin,
+        &String::from_str(env, "REFUND01"),
+        sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+    (token, treasury)
+}
+
+#[test]
+fn test_cancel_funding_transitions_to_status_4() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    let result = client.cancel_funding();
+    assert_eq!(result.status, 4);
+}
+
+#[test]
+fn test_cancel_funding_requires_admin_auth() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.cancel_funding();
+    assert!(
+        env.auths().iter().any(|(addr, _)| *addr == admin),
+        "admin auth was not recorded for cancel_funding"
+    );
+}
+
+#[test]
+#[should_panic(expected = "cancel_funding only allowed in Open state")]
+fn test_cancel_funding_panics_if_already_funded() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    let investor = Address::generate(&env);
+    client.fund(&investor, &TARGET);
+    client.cancel_funding();
+}
+
+#[test]
+#[should_panic(expected = "cancel_funding only allowed in Open state")]
+fn test_cancel_funding_panics_if_already_cancelled() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.cancel_funding();
+    client.cancel_funding();
+}
+
+#[test]
+#[should_panic(expected = "Legal hold blocks cancel_funding")]
+fn test_cancel_funding_blocked_by_legal_hold() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.set_legal_hold(&true);
+    client.cancel_funding();
+}
+
+#[test]
+fn test_refund_returns_principal_to_investor() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (token, _treasury) = init_with_token(&env, &client, &admin, &sme);
+
+    // Mint tokens into the escrow contract so it can refund
+    let contract_id = client.address.clone();
+    token.stellar.mint(&contract_id, &TARGET);
+
+    client.fund(&investor, &TARGET);
+    // Undo funded status by cancelling — but fund() moved status to 1, so we need open state.
+    // Re-init with partial fund instead.
+    let env2 = Env::default();
+    let (client2, admin2, sme2) = setup(&env2);
+    let investor2 = Address::generate(&env2);
+    let (token2, _) = init_with_token(&env2, &client2, &admin2, &sme2);
+    let contract_id2 = client2.address.clone();
+    token2.stellar.mint(&contract_id2, &(TARGET / 2));
+    client2.fund(&investor2, &(TARGET / 2));
+    client2.cancel_funding();
+
+    let before = token2.token.balance(&investor2);
+    client2.refund(&investor2);
+    let after = token2.token.balance(&investor2);
+    assert_eq!(after - before, TARGET / 2);
+}
+
+#[test]
+fn test_refund_zeroes_contribution() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (token, _) = init_with_token(&env, &client, &admin, &sme);
+    let contract_id = client.address.clone();
+    token.stellar.mint(&contract_id, &(TARGET / 2));
+    client.fund(&investor, &(TARGET / 2));
+    client.cancel_funding();
+    client.refund(&investor);
+    assert_eq!(client.get_contribution(&investor), 0);
+}
+
+#[test]
+fn test_refund_marks_investor_refunded() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (token, _) = init_with_token(&env, &client, &admin, &sme);
+    let contract_id = client.address.clone();
+    token.stellar.mint(&contract_id, &(TARGET / 2));
+    client.fund(&investor, &(TARGET / 2));
+    client.cancel_funding();
+    assert!(!client.is_investor_refunded(&investor));
+    client.refund(&investor);
+    assert!(client.is_investor_refunded(&investor));
+}
+
+#[test]
+#[should_panic(expected = "no contribution to refund")]
+fn test_refund_double_spend_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (token, _) = init_with_token(&env, &client, &admin, &sme);
+    let contract_id = client.address.clone();
+    token.stellar.mint(&contract_id, &(TARGET / 2));
+    client.fund(&investor, &(TARGET / 2));
+    client.cancel_funding();
+    client.refund(&investor);
+    client.refund(&investor); // second call must panic
+}
+
+#[test]
+#[should_panic(expected = "no contribution to refund")]
+fn test_refund_non_investor_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.cancel_funding();
+    let stranger = Address::generate(&env);
+    client.refund(&stranger);
+}
+
+#[test]
+#[should_panic(expected = "refund only allowed in Cancelled state")]
+fn test_refund_panics_in_open_state() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.fund(&investor, &(TARGET / 2));
+    client.refund(&investor);
+}
+
+#[test]
+#[should_panic(expected = "refund only allowed in Cancelled state")]
+fn test_refund_panics_in_funded_state() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.fund(&investor, &TARGET);
+    assert_eq!(client.get_escrow().status, 1);
+    client.refund(&investor);
+}
+
+#[test]
+fn test_refund_requires_investor_auth() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (token, _) = init_with_token(&env, &client, &admin, &sme);
+    let contract_id = client.address.clone();
+    token.stellar.mint(&contract_id, &(TARGET / 2));
+    client.fund(&investor, &(TARGET / 2));
+    client.cancel_funding();
+    client.refund(&investor);
+    assert!(
+        env.auths().iter().any(|(addr, _)| *addr == investor),
+        "investor auth was not recorded for refund"
+    );
+}
+
+#[test]
+fn test_refund_multiple_investors_independent() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+    let (token, _) = init_with_token(&env, &client, &admin, &sme);
+    let contract_id = client.address.clone();
+    let amt_a = TARGET / 3;
+    let amt_b = TARGET / 4;
+    token.stellar.mint(&contract_id, &(amt_a + amt_b));
+    client.fund(&inv_a, &amt_a);
+    client.fund(&inv_b, &amt_b);
+    client.cancel_funding();
+
+    let before_a = token.token.balance(&inv_a);
+    let before_b = token.token.balance(&inv_b);
+    client.refund(&inv_a);
+    client.refund(&inv_b);
+    assert_eq!(token.token.balance(&inv_a) - before_a, amt_a);
+    assert_eq!(token.token.balance(&inv_b) - before_b, amt_b);
+}
+
+#[test]
+fn test_cancel_funding_preserves_funded_amount() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.fund(&investor, &(TARGET / 2));
+    let cancelled = client.cancel_funding();
+    assert_eq!(cancelled.funded_amount, TARGET / 2);
+}
+
+#[test]
+fn test_sweep_terminal_dust_allowed_in_cancelled_state() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (token, treasury) = init_with_token(&env, &client, &admin, &sme);
+    let contract_id = client.address.clone();
+    // Mint slightly more than the investor contributes to leave dust
+    token.stellar.mint(&contract_id, &(TARGET / 2 + 1));
+    client.fund(&investor, &(TARGET / 2));
+    client.cancel_funding();
+    client.refund(&investor);
+    // 1 unit of dust remains in the contract
+    let swept = client.sweep_terminal_dust(&1i128);
+    assert_eq!(swept, 1i128);
+    assert_eq!(token.token.balance(&treasury), 1i128);
+}


### PR DESCRIPTION
## Summary

Closes #242. Adds an admin-gated cancellation transition and a per-investor principal refund path for escrows that fail to reach `funding_target`.

## Changes

### `escrow/src/lib.rs`
- `cancel_funding()` — transitions `status 0 → 4` (cancelled); admin auth; blocked under legal hold; emits `FundingCancelled`
- `refund(investor)` — investor auth; only in status 4; zeroes `InvestorContribution` before transfer (CEI); calls `external_calls::transfer_funding_token_with_balance_checks`; emits `InvestorRefundedEvt`; second call panics (`"no contribution to refund"`)
- `is_investor_refunded(investor)` — getter for `DataKey::InvestorRefunded`
- `DataKey::InvestorRefunded(Address)` — new key; prevents double-refund
- `sweep_terminal_dust` — extended to permit status 4 as a terminal state

### `escrow/src/tests/funding.rs`
15 new tests: status transition, admin auth, double-cancel, legal hold block, principal transfer amount, contribution zeroed, refunded marker, double-spend panic, non-investor panic, wrong-state panics (open, funded), investor auth, multiple independent investors, preserved `funded_amount`, dust sweep in cancelled state.

### `docs/escrow-lifecycle.md`
Updated state table, diagram, valid/forbidden transitions, investor refund path section (invariants, events), and legal hold table.

## Security notes
- **Auth:** `cancel_funding` requires admin; `refund` requires investor
- **Legal hold:** `cancel_funding` is blocked while hold is active
- **Double-spend:** contribution zeroed before token transfer; second call finds 0 and panics
- **Balance-delta:** enforced via `external_calls::transfer_funding_token_with_balance_checks`
- **Overflow:** not applicable (refund amount ≤ recorded contribution ≤ `funded_amount`)

## Test results
```
test result: ok. 264 passed; 0 failed; 17 ignored
```