### PR TITLE
feat(escrow): allow lowering MaxUniqueInvestorsCap while open + emit bound refs in EscrowInitialized (#255, #251)

### DIFF
--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -43,17 +43,29 @@ Each event has:
 
 ## Events
 
-### 1. `escrow.initialized` — Escrow Created
+### 1. `escrow_ii` — Escrow Created
 
 Emitted by `init()`. Marks the beginning of an invoice escrow lifecycle.
 
 | Field | Value |
 |---|---|
-| `Topic[0]` | `"escrow"` |
-| `Topic[1]` | `"initd"` *(≤ 8 chars — Soroban `symbol_short` limit)* |
-| Payload type | `InvoiceEscrow` |
+| Topic[0] | `"escrow_ii"` (`symbol_short!("escrow_ii")`) |
+| Payload type | `EscrowInitialized` |
 
-#### Payload: `InvoiceEscrow` (intended view)
+#### Payload: `EscrowInitialized`
+
+| Field | Rust type | Description |
+|---|---|---|
+| `escrow` | `InvoiceEscrow` | Full escrow snapshot at init |
+| `funding_token` | `Address` | Bound SEP-41 token; equals `DataKey::FundingToken` |
+| `treasury` | `Address` | Bound treasury; equals `DataKey::Treasury` |
+| `registry` | `Option<Address>` | Optional registry hint; equals `DataKey::RegistryRef` (`None` when unset) |
+
+**Compatibility:** Additive fields on `EscrowInitialized` — old indexers may ignore
+`funding_token`, `treasury`, and `registry`; new indexers can bootstrap bound references
+from this single event without follow-up `get_funding_token` / `get_treasury` polls.
+
+#### Nested `InvoiceEscrow` fields (within `escrow`)
 
 | Field | Rust type | Description |
 |---|---|---|
@@ -82,23 +94,60 @@ storage section for the canonical persisted-layout discussion.
   "funded_amount" : 0,
   "yield_bps"     : 800,
   "maturity"      : 1750000000,
-  "status"        : 0
+  "status"        : 0,
+  "funding_token" : "CTOKEN...",
+  "treasury"      : "GTREAS...",
+  "registry"      : null
 }
 ```
 
 ---
 
-### 2. `escrow.funded` — Investor Contribution Recorded
+### 1a. `inv_cap` — Investor Cap Lowered
 
-Emitted by `fund()` on **every successful call**, regardless of whether the
-target was just met. Use `status == 1` in the payload to detect the moment
+Emitted by `lower_max_unique_investors()` when admin tightens the distinct-investor limit
+while the escrow is **open** (status `0`). Added in Issue #255.
+
+| Field | Value |
+|---|---|
+| Topic[0] | `"inv_cap"` (`symbol_short!("inv_cap")`) |
+| Topic[1] | `invoice_id` (Symbol) |
+| Payload type | `MaxUniqueInvestorsCapLowered` |
+
+#### Payload: `MaxUniqueInvestorsCapLowered`
+
+| Field | Rust type | Description |
+|---|---|---|
+| `name` | `Symbol` | Always `"inv_cap"` |
+| `invoice_id` | `Symbol` | Invoice whose cap was lowered |
+| `old_cap` | `u32` | Previous `MaxUniqueInvestorsCap` value |
+| `new_cap` | `u32` | New (lower) cap value now stored |
+
+#### Example (JSON representation after XDR decode)
+
+```json
+{
+  "event"     : "inv_cap",
+  "invoice_id": "INV1023",
+  "old_cap"   : 10,
+  "new_cap"   : 5
+}
+```
+
+---
+
+### 2. `funded` — Investor Contribution Recorded
+
+Emitted by `fund()` and `fund_with_commitment()` on **every successful call**, regardless of
+whether the target was just met. Use `status == 1` in the payload to detect the moment
 the escrow became fully funded.
 
 | Field | Value |
 |---|---|
-| `Topic[0]` | `"escrow"` |
-| `Topic[1]` | `"funded"` |
-| Payload type | `FundedPayload` |
+| Topic[0] | `"funded"` (`symbol_short!("funded")`) |
+| Topic[1] | `invoice_id` (Symbol) |
+| Topic[2] | `investor` (Address) |
+| Payload type | `EscrowFunded` |
 
 #### Payload: `FundedPayload` (intended view)
 
@@ -133,15 +182,14 @@ is not reflected consistently across the rest of the contract.
 
 ### 3. `escrow.settled` — Invoice Settled by Buyer
 
-Emitted by `settle()` once, when the buyer has paid and the contract marks
-the escrow as settled (status 2). Contains everything needed to compute
-investor payouts without re-reading contract storage.
+Emitted by `settle()` once, when the SME finalizes the escrow after maturity (status → 2).
+Contains everything needed to compute investor payouts without re-reading contract storage.
 
 | Field | Value |
 |---|---|
-| `Topic[0]` | `"escrow"` |
-| `Topic[1]` | `"settled"` |
-| Payload type | `SettledPayload` |
+| Topic[0] | `"escrow_sd"` (`symbol_short!("escrow_sd")`) |
+| Topic[1] | `invoice_id` (Symbol) |
+| Payload type | `EscrowSettled` |
 
 #### Payload: `SettledPayload` (intended view)
 
@@ -189,22 +237,30 @@ the contract file itself.
 
 ## Topic Filter Cheat Sheet
 
-Use these filters with `getEvents` (Stellar RPC) or Mercury subscriptions:
+Use these filters with `getEvents` (Stellar RPC) or Mercury subscriptions.
 
-```json
-{
-  "contractId": "<CONTRACT_ADDRESS>",
-  "topics": [
-    ["AAAADwAAAAZlc2Nyb3c=", "AAAADwAAAAVpbml0ZA=="]
-  ]
-}
-```
+> **Important:** Filter by `Topic[0]` (the event name Symbol) for each event type.
+> The contract does **not** use a shared namespace topic — each event struct has its
+> own `symbol_short!` name as the first topic.
 
-| Event | Topic[0] (base64 XDR) | Topic[1] (base64 XDR) | Human label |
-|---|---|---|---|
-| `initialized` | `AAAADwAAAAZlc2Nyb3c=` | `AAAADwAAAAVpbml0ZA==` | `"escrow"` / `"initd"` |
-| `funded` | `AAAADwAAAAZlc2Nyb3c=` | `AAAADwAAAAZmdW5kZWQ=` | `"escrow"` / `"funded"` |
-| `settled` | `AAAADwAAAAZlc2Nyb3c=` | `AAAADwAAAAdzZXR0bGVk` | `"escrow"` / `"settled"` |
+| Event | Topic[0] symbol | Human label |
+|---|---|---|
+| Escrow created | `escrow_ii` | `EscrowInitialized` |
+| Investor funded | `funded` | `EscrowFunded` |
+| Escrow settled | `escrow_sd` | `EscrowSettled` |
+| SME withdrew | `sme_wd` | `SmeWithdrew` |
+| Investor claimed | `inv_claim` | `InvestorPayoutClaimed` |
+| Dust swept | `dust_sw` | `TreasuryDustSwept` |
+| Legal hold changed | `legalhld` | `LegalHoldChanged` |
+| Funding target updated | `fund_tgt` | `FundingTargetUpdated` |
+| Maturity updated | `maturity` | `MaturityUpdatedEvent` |
+| Admin transferred | `admin` | `AdminTransferredEvent` |
+| Collateral recorded | `coll_rec` | `CollateralRecordedEvt` |
+| Primary attestation bound | `att_bind` | `PrimaryAttestationBound` |
+| Attestation log appended | `att_app` | `AttestationDigestAppended` |
+| Investor cap lowered | `inv_cap` | `MaxUniqueInvestorsCapLowered` |
+| Allowlist enabled/disabled | `al_ena` | `AllowlistEnabledChanged` |
+| Investor allowlist changed | `al_set` | `InvestorAllowlistChanged` |
 
 ---
 
@@ -229,3 +285,6 @@ Use these filters with `getEvents` (Stellar RPC) or Mercury subscriptions:
 | Date | Version | Change |
 |---|---|---|
 | 2026-03-23 | v0.1 | Initial schema — `initialized`, `funded`, `settled` events defined |
+| 2026-05-27 | v0.2 | **Issue #251** — Extended `EscrowInitialized` payload with `funding_token`, `treasury`, `registry` fields (additive; backward-compatible) |
+| 2026-05-27 | v0.2 | **Issue #255** — Added `MaxUniqueInvestorsCapLowered` (`inv_cap`) event for `lower_max_unique_investors` |
+| 2026-05-27 | v0.2 | **Doc fix** — Corrected topic cheat sheet: replaced stale `"escrow"/"initd"` with actual per-event `symbol_short!` names; added complete event catalogue |

--- a/docs/escrow-events.md
+++ b/docs/escrow-events.md
@@ -16,6 +16,43 @@ All events follow the Soroban `contractevent` format. Key fields like `invoice_i
 
 ## 📋 Event Catalog
 
+### `EscrowInitialized`
+Emitted once by `init()`. Carries the escrow snapshot plus immutable bound references so
+indexers can register `funding_token`, `treasury`, and optional `registry` without follow-up reads.
+
+**Topics:**
+1. `escrow_ii` (Symbol)
+
+**Data Payload:**
+- `escrow` (`InvoiceEscrow`)
+- `funding_token` (`Address`) — equals `DataKey::FundingToken`
+- `treasury` (`Address`) — equals `DataKey::Treasury`
+- `registry` (`Option<Address>`) — equals `DataKey::RegistryRef`
+
+**Example (JSON Decoded):**
+```json
+{
+  "topics": ["escrow_ii"],
+  "data": {
+    "escrow": { "invoice_id": "INV_001", "status": 0 },
+    "funding_token": "CTOKEN...",
+    "treasury": "GTREAS...",
+    "registry": "GREG..."
+  }
+}
+```
+
+### `MaxUniqueInvestorsCapLowered`
+Emitted when admin calls `lower_max_unique_investors` while the escrow is open.
+
+**Topics:**
+1. `inv_cap` (Symbol)
+2. `invoice_id` (Symbol)
+
+**Data Payload:**
+- `old_cap` (u32)
+- `new_cap` (u32)
+
 ### `EscrowFunded`
 Emitted when an investor deposits principal.
 

--- a/docs/escrow-indexer.md
+++ b/docs/escrow-indexer.md
@@ -25,7 +25,7 @@ Recommended split:
 
 Contract event names (`symbol_short`) emitted by `escrow/src/lib.rs`:
 
-- `escrow_ii` - escrow initialized
+- `escrow_ii` - escrow initialized (payload includes `escrow`, `funding_token`, `treasury`, `registry`)
 - `funded` - contribution recorded
 - `escrow_sd` - settled
 - `sme_wd` - SME withdraw
@@ -40,6 +40,7 @@ Contract event names (`symbol_short`) emitted by `escrow/src/lib.rs`:
 - `att_app` - attestation append-log updated
 - `al_ena` - allowlist mode enabled/disabled
 - `al_set` - investor allowlist membership set
+- `inv_cap` - max unique investors cap lowered (admin, open state only)
 
 See also: `docs/EVENT_SCHEMA.md`.
 
@@ -77,9 +78,9 @@ Read endpoints and their backing keys (`docs/escrow-read-api.md`):
 
 ### Poll at startup + periodically (config/hints)
 
-- `get_funding_token()` -> `DataKey::FundingToken` (immutable after init)
-- `get_treasury()` -> `DataKey::Treasury` (immutable after init)
-- `get_registry_ref()` -> `DataKey::RegistryRef` (optional hint only)
+- `get_funding_token()` -> `DataKey::FundingToken` (immutable after init; also duplicated on `escrow_ii` for indexers)
+- `get_treasury()` -> `DataKey::Treasury` (immutable after init; also on `escrow_ii`)
+- `get_registry_ref()` -> `DataKey::RegistryRef` (optional hint only; also on `escrow_ii`)
 - `get_min_contribution_floor()` -> `DataKey::MinContributionFloor`
 - `get_max_unique_investors_cap()` -> `DataKey::MaxUniqueInvestorsCap`
 - `get_primary_attestation_hash()` -> `DataKey::PrimaryAttestationHash`

--- a/docs/escrow-investor-caps.md
+++ b/docs/escrow-investor-caps.md
@@ -80,6 +80,17 @@ Returns the configured cap, or `None` if unlimited.
 
 Returns the current count of distinct funders.
 
+#### `lower_max_unique_investors(env: Env, new_cap: u32) -> u32`
+
+Admin-only: reduces the configured cap while the escrow is **open** (status `0`).
+
+- Requires admin authorization.
+- Only permitted when a cap was configured at init.
+- `new_cap` must satisfy `unique_funder_count <= new_cap < old_cap`.
+- Rejects raising the cap or imposing a cap on an unlimited escrow.
+- Emits `MaxUniqueInvestorsCapLowered` (`inv_cap`) for indexers.
+- Returns the stored cap after update (same as `get_max_unique_investors_cap()`).
+
 ### Usage Examples
 
 #### Initialize with Cap
@@ -209,13 +220,14 @@ The cap is checked AFTER allowlist validation:
 - **Cap enforcement:** Strictly enforced with panic on violation
 - **Counter accuracy:** Atomic operations prevent race conditions
 - **Re-funding safety:** Existing investors can always add more principal
+- **Cap tightening:** Admin may lower the cap while open via `lower_max_unique_investors`; cannot raise
 
 ### Out of Scope
 
 - **Sybil resistance:** No mechanism to prevent one person from using multiple addresses
 - **Identity verification:** No KYC/AML integration
-- **Dynamic caps:** Caps cannot be changed after initialization
-- **Cap reduction:** No mechanism to lower caps post-deployment
+- **Cap increases:** Caps cannot be raised after initialization (including unlimited → capped)
+- **Cap lowering below enrolled funders:** Rejected to preserve the retroactive-cap invariant
 
 ### Token Economics Assumptions
 
@@ -294,11 +306,11 @@ Monitor these metrics during live operation:
 
 ### Emergency Procedures
 
-If cap exhaustion becomes an issue:
+If cap exhaustion becomes an issue while the escrow is still **open**:
 
-1. **No on-chain solution:** Caps cannot be increased post-deployment
-2. **New escrow deployment:** Required for different cap settings
-3. **Off-chain coordination:** Direct investors to new escrow instances
+1. **Lower the cap:** Admin may call `lower_max_unique_investors` to tighten the limit (cannot raise).
+2. **New escrow deployment:** Required for a higher cap or to change unlimited → capped.
+3. **Off-chain coordination:** Direct investors to new escrow instances when needed.
 
 ## Best Practices
 
@@ -338,4 +350,4 @@ When deploying capped escrows:
 
 The MaxUniqueInvestorsCap and UniqueFunderCount functionality provides a robust, Sybil-limited mechanism for controlling investor participation in LiquiFact escrows. While it doesn't prevent Sybil attacks, it offers operational control and compliance benefits with clear semantics and comprehensive edge case handling.
 
-The implementation prioritizes safety and predictability, with strict enforcement and clear error messages. Organizations should carefully consider their cap requirements during deployment, as caps cannot be modified after initialization.
+The implementation prioritizes safety and predictability, with strict enforcement and clear error messages. Organizations should carefully consider their cap requirements during deployment; caps can be **lowered** while open but never raised.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -806,10 +806,7 @@ impl LiquifactEscrow {
         let escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
-        assert!(
-            escrow.status == 0,
-            "Cap can only be lowered in Open state"
-        );
+        assert!(escrow.status == 0, "Cap can only be lowered in Open state");
 
         let old_cap = env
             .storage()
@@ -827,7 +824,10 @@ impl LiquifactEscrow {
             new_cap > 0,
             "max_unique_investors must be positive when configured"
         );
-        assert!(new_cap < old_cap, "new cap must be strictly lower than current cap");
+        assert!(
+            new_cap < old_cap,
+            "new cap must be strictly lower than current cap"
+        );
         assert!(
             cur_count <= new_cap,
             "new cap cannot be below current unique funder count"

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -282,6 +282,22 @@ pub struct EscrowInitialized {
     #[topic]
     pub name: Symbol,
     pub escrow: InvoiceEscrow,
+    /// Bound funding token; equals [`DataKey::FundingToken`].
+    pub funding_token: Address,
+    /// Bound treasury; equals [`DataKey::Treasury`].
+    pub treasury: Address,
+    /// Optional registry hint; equals [`DataKey::RegistryRef`] (`None` when unset).
+    pub registry: Option<Address>,
+}
+
+#[contractevent]
+pub struct MaxUniqueInvestorsCapLowered {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub old_cap: u32,
+    pub new_cap: u32,
 }
 
 #[contractevent]
@@ -624,9 +640,11 @@ impl LiquifactEscrow {
 
         EscrowInitialized {
             name: symbol_short!("escrow_ii"),
-            // Read the stored value so we do not clone an in-memory escrow snapshot.
-            // env.clone(): env is used again after this call for .publish(&env).
+            // Read stored values so event fields match persisted keys (indexer single-event bootstrap).
             escrow: Self::get_escrow(env.clone()),
+            funding_token: Self::get_funding_token(env.clone()),
+            treasury: Self::get_treasury(env.clone()),
+            registry: Self::get_registry_ref(env.clone()),
         }
         .publish(&env);
 
@@ -762,10 +780,72 @@ impl LiquifactEscrow {
     }
 
     /// Optional cap on **distinct** investor addresses (`prev == 0` at fund time); [`None`] if unlimited.
+    ///
+    /// Reflects the current stored cap, including any admin reduction via
+    /// [`LiquifactEscrow::lower_max_unique_investors`].
     pub fn get_max_unique_investors_cap(env: Env) -> Option<u32> {
         env.storage()
             .instance()
             .get(&DataKey::MaxUniqueInvestorsCap)
+    }
+
+    /// Admin-only: reduce the distinct-investor cap while the escrow is **open** (status `0`).
+    ///
+    /// # Rules
+    /// - Requires [`InvoiceEscrow::admin`] authorization.
+    /// - Only permitted when a cap exists ([`DataKey::MaxUniqueInvestorsCap`]).
+    /// - `new_cap` must satisfy `unique_funder_count <= new_cap < old_cap` (strict decrease).
+    /// - Raising the cap or imposing a cap on an unlimited escrow is rejected.
+    ///
+    /// Existing funders remain honored; new addresses are blocked once
+    /// `unique_funder_count >= new_cap`.
+    ///
+    /// # Returns
+    /// The stored cap after update (same as [`LiquifactEscrow::get_max_unique_investors_cap`]).
+    pub fn lower_max_unique_investors(env: Env, new_cap: u32) -> u32 {
+        let escrow = Self::get_escrow(env.clone());
+        escrow.admin.require_auth();
+
+        assert!(
+            escrow.status == 0,
+            "Cap can only be lowered in Open state"
+        );
+
+        let old_cap = env
+            .storage()
+            .instance()
+            .get::<DataKey, u32>(&DataKey::MaxUniqueInvestorsCap)
+            .unwrap_or_else(|| panic!("no investor cap configured"));
+
+        let cur_count = env
+            .storage()
+            .instance()
+            .get(&DataKey::UniqueFunderCount)
+            .unwrap_or(0);
+
+        assert!(
+            new_cap > 0,
+            "max_unique_investors must be positive when configured"
+        );
+        assert!(new_cap < old_cap, "new cap must be strictly lower than current cap");
+        assert!(
+            cur_count <= new_cap,
+            "new cap cannot be below current unique funder count"
+        );
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxUniqueInvestorsCap, &new_cap);
+
+        MaxUniqueInvestorsCapLowered {
+            name: symbol_short!("inv_cap"),
+            invoice_id: escrow.invoice_id.clone(),
+            old_cap,
+            new_cap,
+        }
+        .publish(&env);
+
+        new_cap
     }
 
     /// Distinct funders counted so far (each address counted once when it first receives principal).

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -9,8 +9,8 @@
 #[allow(unused_imports)]
 use super::{
     DataKey, EscrowInitialized, FundingTargetUpdated, LegalHoldChanged, LiquifactEscrow,
-    LiquifactEscrowClient, MaxUniqueInvestorsCapLowered, YieldTier,
-    MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, SCHEMA_VERSION,
+    LiquifactEscrowClient, MaxUniqueInvestorsCapLowered, YieldTier, MAX_ATTESTATION_APPEND_ENTRIES,
+    MAX_DUST_SWEEP_AMOUNT, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -8,8 +8,9 @@
 )]
 #[allow(unused_imports)]
 use super::{
-    DataKey, FundingTargetUpdated, LegalHoldChanged, LiquifactEscrow, LiquifactEscrowClient,
-    YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, SCHEMA_VERSION,
+    DataKey, EscrowInitialized, FundingTargetUpdated, LegalHoldChanged, LiquifactEscrow,
+    LiquifactEscrowClient, MaxUniqueInvestorsCapLowered, YieldTier,
+    MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,

--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -53,7 +53,6 @@ fn test_unique_funder_count_basic_functionality() {
 }
 
 #[test]
-#[ignore]
 #[should_panic(expected = "unique investor cap reached")]
 fn test_cap_enforcement_blocks_excess_investors() {
     let env = Env::default();
@@ -62,12 +61,13 @@ fn test_cap_enforcement_blocks_excess_investors() {
     let admin = Address::generate(&env);
     let sme = Address::generate(&env);
 
-    // Initialize escrow with cap of 2 investors
+    // Use a target (200B) larger than inv1+inv2 (50B+50B=100B) so the escrow
+    // remains open (status=0) when the third investor hits the cap gate.
     client.init(
         &admin,
         &String::from_str(&env, "CAP_TEST2"),
         &sme,
-        &100_000_000_000i128,
+        &200_000_000_000i128,
         &800i64,
         &0u64,
         &Address::generate(&env),
@@ -78,20 +78,20 @@ fn test_cap_enforcement_blocks_excess_investors() {
         &Some(2u32),
     );
 
-    // Add two investors (reaches cap)
+    // Add two investors — reaches the investor cap but NOT the funding target.
     let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     client.fund(&inv1, &50_000_000_000i128);
     client.fund(&inv2, &50_000_000_000i128);
     assert_eq!(client.get_unique_funder_count(), 2);
+    assert_eq!(client.get_escrow().status, 0); // still open
 
-    // Try to add third investor - should panic
+    // Third investor hits the cap — must panic "unique investor cap reached".
     let inv3 = Address::generate(&env);
     client.fund(&inv3, &1_000_000_000i128);
 }
 
 #[test]
-#[ignore]
 fn test_re_funding_same_address_doesnt_count_against_cap() {
     let env = Env::default();
     env.mock_all_auths();
@@ -214,4 +214,317 @@ fn test_cap_with_fund_with_commitment() {
     assert_eq!(client.get_investor_yield_bps(&inv2), 800);
 
     assert_eq!(client.get_escrow().status, 1); // Funded
+}
+
+// --- lower_max_unique_investors (#255) ---
+
+#[test]
+fn test_lower_max_unique_investors_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "CAP_LOWER"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(5u32),
+    );
+
+    let inv1 = Address::generate(&env);
+    let inv2 = Address::generate(&env);
+    client.fund(&inv1, &20_000_000_000i128);
+    client.fund(&inv2, &20_000_000_000i128);
+    assert_eq!(client.get_unique_funder_count(), 2);
+
+    let new_cap = client.lower_max_unique_investors(&2u32);
+    assert_eq!(new_cap, 2);
+    assert_eq!(client.get_max_unique_investors_cap(), Some(2));
+}
+
+#[test]
+#[should_panic(expected = "unique investor cap reached")]
+fn test_lower_cap_blocks_new_investors_at_lowered_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "CAP_LOWER2"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(3u32),
+    );
+
+    client.fund(&Address::generate(&env), &20_000_000_000i128);
+    client.fund(&Address::generate(&env), &20_000_000_000i128);
+    client.lower_max_unique_investors(&2u32);
+
+    client.fund(&Address::generate(&env), &1_000_000_000i128);
+}
+
+#[test]
+fn test_lower_cap_existing_investors_may_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "CAP_LOWER3"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(3u32),
+    );
+
+    let inv1 = Address::generate(&env);
+    let inv2 = Address::generate(&env);
+    client.fund(&inv1, &30_000_000_000i128);
+    client.fund(&inv2, &30_000_000_000i128);
+    client.lower_max_unique_investors(&2u32);
+
+    client.fund(&inv1, &20_000_000_000i128);
+    client.fund(&inv2, &20_000_000_000i128);
+    assert_eq!(client.get_unique_funder_count(), 2);
+}
+
+#[test]
+#[should_panic(expected = "new cap must be strictly lower than current cap")]
+fn test_lower_cap_rejects_raise() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "CAP_LOWER4"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(3u32),
+    );
+
+    client.lower_max_unique_investors(&4u32);
+}
+
+#[test]
+#[should_panic(expected = "new cap cannot be below current unique funder count")]
+fn test_lower_cap_rejects_below_funder_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "CAP_LOWER5"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(5u32),
+    );
+
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+    client.lower_max_unique_investors(&2u32);
+}
+
+#[test]
+#[should_panic(expected = "Cap can only be lowered in Open state")]
+fn test_lower_cap_rejects_non_open_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "CAP_LOWER6"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(3u32),
+    );
+
+    client.fund(&Address::generate(&env), &100_000_000_000i128);
+    assert_eq!(client.get_escrow().status, 1);
+    client.lower_max_unique_investors(&2u32);
+}
+
+#[test]
+#[should_panic(expected = "no investor cap configured")]
+fn test_lower_cap_rejects_unlimited_escrow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "CAP_LOWER7"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &None,
+    );
+
+    client.lower_max_unique_investors(&10u32);
+}
+
+#[test]
+fn test_lower_cap_requires_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "CAP_LOWER8"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(5u32),
+    );
+
+    client.lower_max_unique_investors(&3u32);
+    assert!(
+        env.auths().iter().any(|(addr, _)| *addr == admin),
+        "admin auth was not recorded for lower_max_unique_investors"
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_lower_cap_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "CAP_LOWER9"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(5u32),
+    );
+
+    env.mock_auths(&[]);
+    client.lower_max_unique_investors(&3u32);
+}
+
+#[test]
+fn test_lower_cap_emits_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+    let contract_id = client.address.clone();
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "CAP_EVT"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(5u32),
+    );
+
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+    client.lower_max_unique_investors(&3u32);
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![MaxUniqueInvestorsCapLowered {
+            name: symbol_short!("inv_cap"),
+            invoice_id: client.get_escrow().invoice_id,
+            old_cap: 5,
+            new_cap: 3,
+        }
+        .to_xdr(&env, &contract_id)]
+    );
 }

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -492,6 +492,89 @@ fn test_init_registry_none_roundtrip() {
     assert_eq!(client.get_registry_ref(), None);
 }
 
+#[test]
+fn test_init_escrow_initialized_event_includes_bound_refs() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let contract_id = client.address.clone();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let registry = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INIT_EVT"),
+        &sme,
+        &5_000i128,
+        &100i64,
+        &0u64,
+        &token,
+        &Some(registry.clone()),
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![EscrowInitialized {
+            name: symbol_short!("escrow_ii"),
+            escrow: client.get_escrow(),
+            funding_token: token,
+            treasury,
+            registry: Some(registry),
+        }
+        .to_xdr(&env, &contract_id)]
+    );
+}
+
+#[test]
+fn test_init_escrow_initialized_event_registry_none() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let contract_id = client.address.clone();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INIT_EVT2"),
+        &sme,
+        &5_000i128,
+        &100i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![EscrowInitialized {
+            name: symbol_short!("escrow_ii"),
+            escrow: client.get_escrow(),
+            funding_token: token,
+            treasury,
+            registry: None,
+        }
+        .to_xdr(&env, &contract_id)]
+    );
+}
+
 // ---------------------------------------------------------------------------
 // invoice_id boundary and charset fuzz/parameterized tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #251 
Closes #255  


### #255 — `lower_max_unique_investors`

Adds an admin-gated entrypoint to tighten `MaxUniqueInvestorsCap` while the escrow is still open.

**Rules:**
- `admin.require_auth()` — no other role may call this
- `status == 0` only
- `unique_funder_count <= new_cap < old_cap` — strict decrease; never retroactive
- Unlimited escrows rejected; cap cannot be raised

**Event:** `MaxUniqueInvestorsCapLowered` (`inv_cap`) — emits `old_cap`, `new_cap`, `invoice_id`

**Tests:** 12 cases in `escrow/src/tests/cap_validation.rs` covering auth, state gate, raise rejection, below-funder-count rejection, existing-investor re-fund, new-investor block, unlimited escrow, and event payload. Also fixed and un-ignored two previously broken tests.

**Docs:** `docs/escrow-investor-caps.md` updated with full API and security guidance.


### #251 — `EscrowInitialized` with bound references

Extends `EscrowInitialized` with three additive fields so indexers can bootstrap from a single event without follow-up RPC reads.

```rust
pub funding_token: Address,       // equals DataKey::FundingToken
pub treasury: Address,            // equals DataKey::Treasury
pub registry: Option<Address>,    // equals DataKey::RegistryRef; None when unset
```

Values are read from storage after the write — not from in-memory copies — guaranteeing event fields match persisted keys.

**Tests:** 2 cases in `escrow/src/tests/init.rs` asserting exact XDR payload for `Some(registry)` and `None`.

**Docs:** `docs/escrow-events.md` and `docs/EVENT_SCHEMA.md` updated. Also fixed stale topic symbols in the EVENT_SCHEMA cheat sheet (`"escrow"/"initd"` → actual `symbol_short!` names for all 16 events).


### Compatibility

Both changes are additive — no `SCHEMA_VERSION` bump required.