### PR TITLE
refactor(escrow): dedupe claim contribution read (#256) and add compute_investor_payout view (#245)

### DIFF
--- a/docs/escrow-pro-rata.md
+++ b/docs/escrow-pro-rata.md
@@ -52,3 +52,30 @@ function calculatePayout(contribution, totalPrincipal, settleAmount) {
   return (c * sa) / tp; 
 }
 ```
+
+## 🔗 On-Chain View: `compute_investor_payout`
+
+The contract exposes an authoritative on-chain implementation of the formula above:
+
+```
+LiquifactEscrow::compute_investor_payout(investor: Address) → i128
+```
+
+This view derives `effective_yield_bps` from `DataKey::InvestorEffectiveYield` (tiered ladder
+selection from `fund_with_commitment`) and falls back to `InvoiceEscrow::yield_bps` for investors
+who used plain `fund`. Off-chain tools **must** call this view rather than re-implementing the
+formula to guarantee identical rounding.
+
+### On-chain integer safety
+
+- All intermediate multiplications use `i128::checked_mul`.
+- All divisions use `i128::checked_div`.
+- The function panics with `"compute_investor_payout: arithmetic overflow"` on overflow rather than
+  silently returning a wrong value.
+- `total_principal` is always positive when a `FundingCloseSnapshot` exists; the function
+  guards against the `≤ 0` edge case and returns `0` early.
+
+### Reference
+
+See `docs/escrow-read-api.md` → `compute_investor_payout` for the full parameter, return-value,
+and authorization documentation.

--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -163,3 +163,48 @@ Returns the single-set 32-byte attestation digest, or `None` when unbound.
 
 Returns the append-only audit chain of digests. Returns an empty `Vec` when no entries exist.
 Bounded by `MAX_ATTESTATION_APPEND_ENTRIES`.
+
+---
+
+## `compute_investor_payout(investor: Address) → i128`
+
+**Storage keys read:** `DataKey::InvestorContribution(investor)`, `DataKey::FundingCloseSnapshot`,
+`DataKey::InvestorEffectiveYield(investor)`, `DataKey::Escrow` (yield fallback)
+
+On-chain read-only pro-rata gross payout view. Implements the authoritative formula from
+`docs/escrow-pro-rata.md` using **floor (truncating) integer division** so that off-chain
+tooling and on-chain logic always agree on rounding.
+
+### Formula
+
+```
+coupon       = total_principal × effective_yield_bps / 10_000  (floor)
+settle_pool  = total_principal + coupon
+gross_payout = contribution × settle_pool / total_principal     (floor)
+```
+
+The `effective_yield_bps` is the investor-specific tier yield locked in at their first deposit
+(`DataKey::InvestorEffectiveYield`), falling back to `InvoiceEscrow::yield_bps` when absent.
+
+### Return values
+
+| Condition | Return |
+|-----------|--------|
+| `FundingCloseSnapshot` absent (escrow not yet funded) | `0` |
+| `InvestorContribution` absent or zero | `0` |
+| Normal case | Floor-rounded gross payout in token base units |
+
+### Invariant
+
+The sum of `compute_investor_payout` over all investors is ≤ `total_principal + coupon`.
+Any rounding residual (dust) is recoverable via `sweep_terminal_dust`.
+
+### Authorization
+
+None — pure read; no auth required. Safe to call at any escrow status.
+
+### Overflow safety
+
+All multiplications use `i128::checked_mul`; divisions use `i128::checked_div`.
+Panics with `"compute_investor_payout: arithmetic overflow"` rather than silently
+returning a wrong value.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1341,6 +1341,23 @@ impl LiquifactEscrow {
     }
 
     /// Investor records a payout claim after settlement. Idempotent marker per investor.
+    ///
+    /// # Idempotency
+    ///
+    /// A second call for the same investor is a silent no-op: the `InvestorClaimed` marker is
+    /// written **before** `InvestorPayoutClaimed` is emitted, so re-entrant or replayed calls
+    /// return early without re-emitting the event.
+    ///
+    /// # Guard ordering (ADR-002)
+    ///
+    /// 1. Legal-hold gate (read-only).
+    /// 2. `investor.require_auth()`.
+    /// 3. Single contribution fetch — eliminates the previous duplicate `get_contribution` call;
+    ///    the value is reused for the participation guard.
+    /// 4. Settled-status gate (escrow read).
+    /// 5. `not_before` ledger-time gate (see `docs/escrow-ledger-time.md`).
+    /// 6. Idempotent early-return on `InvestorClaimed`.
+    /// 7. Storage write + event emit.
     pub fn claim_investor_payout(env: Env, investor: Address) {
         assert!(
             !Self::legal_hold_active(&env),
@@ -1349,7 +1366,8 @@ impl LiquifactEscrow {
 
         investor.require_auth();
 
-        // Ensure the caller is actually an investor with a recorded contribution.
+        // Single fetch: consolidates the previous two reads of InvestorContribution.
+        // Retains the participation guard without a redundant second storage access.
         let contribution: i128 = env
             .storage()
             .instance()
@@ -1375,15 +1393,13 @@ impl LiquifactEscrow {
             "Investor commitment lock not expired (ledger timestamp)"
         );
 
-        // Investor must have participated (non-zero contribution) to claim.
-        let contribution: i128 = Self::get_contribution(env.clone(), investor.clone());
-        assert!(contribution > 0, "Investor did not participate");
-
+        // Idempotent early-return: a second claim is a no-op (no re-emit).
         let key = DataKey::InvestorClaimed(investor.clone());
         if env.storage().instance().get(&key).unwrap_or(false) {
             return;
         }
 
+        // Mark before emit — prevents re-emission on any re-entrant path.
         env.storage().instance().set(&key, &true);
 
         InvestorPayoutClaimed {
@@ -1392,6 +1408,94 @@ impl LiquifactEscrow {
             invoice_id: escrow.invoice_id.clone(),
         }
         .publish(&env);
+    }
+
+    /// On-chain read-only pro-rata gross payout for `investor`.
+    ///
+    /// Derives the **gross payout** (principal share plus `InvestorEffectiveYield`-adjusted
+    /// coupon) from [`FundingCloseSnapshot`], providing an authoritative on-chain implementation
+    /// of the math specified in `docs/escrow-pro-rata.md`. Off-chain tooling should call this
+    /// view rather than re-implementing the formula to guarantee identical rounding.
+    ///
+    /// # Formula (floor / truncating integer division)
+    ///
+    /// ```text
+    /// coupon       = total_principal × effective_yield_bps / 10_000  (floor)
+    /// settle_pool  = total_principal + coupon
+    /// gross_payout = contribution × settle_pool / total_principal     (floor)
+    /// ```
+    ///
+    /// # Returns
+    ///
+    /// - `0` when [`DataKey::FundingCloseSnapshot`] does not exist (escrow not yet funded).
+    /// - `0` when `investor` has no contribution (`DataKey::InvestorContribution` absent or zero).
+    /// - Computed floor payout otherwise.
+    ///
+    /// # Invariant
+    ///
+    /// The sum of `compute_investor_payout` over all investors is ≤ `total_principal + coupon`;
+    /// any rounding residual is swept by [`LiquifactEscrow::sweep_terminal_dust`].
+    ///
+    /// # Overflow safety
+    ///
+    /// All multiplications use [`i128::checked_mul`] and divisions use [`i128::checked_div`].
+    /// Panics with `"compute_investor_payout: arithmetic overflow"` rather than silently
+    /// producing a wrong value.
+    ///
+    /// # Authorization
+    ///
+    /// None — pure read; no auth required.
+    pub fn compute_investor_payout(env: Env, investor: Address) -> i128 {
+        // Contribution fetch: returns 0 for non-participants without panicking.
+        let contribution: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::InvestorContribution(investor.clone()))
+            .unwrap_or(0);
+        if contribution == 0 {
+            return 0;
+        }
+
+        // Snapshot must exist (written when escrow first reaches status == 1).
+        let Some(snap) = env
+            .storage()
+            .instance()
+            .get::<DataKey, FundingCloseSnapshot>(&DataKey::FundingCloseSnapshot)
+        else {
+            return 0;
+        };
+
+        let total_principal = snap.total_principal;
+        if total_principal <= 0 {
+            return 0;
+        }
+
+        // Resolve effective yield: investor-specific tier (set at first deposit) or escrow base.
+        // env.clone(): env is used again after this call for InvestorEffectiveYield read.
+        let escrow = Self::get_escrow(env.clone());
+        let effective_yield_bps: i64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::InvestorEffectiveYield(investor.clone()))
+            .unwrap_or(escrow.yield_bps);
+
+        // coupon = total_principal × effective_yield_bps / 10_000  (floor)
+        let coupon = total_principal
+            .checked_mul(effective_yield_bps as i128)
+            .expect("compute_investor_payout: arithmetic overflow")
+            .checked_div(10_000)
+            .expect("compute_investor_payout: arithmetic overflow");
+
+        let settle_pool = total_principal
+            .checked_add(coupon)
+            .expect("compute_investor_payout: arithmetic overflow");
+
+        // gross_payout = contribution × settle_pool / total_principal  (floor)
+        contribution
+            .checked_mul(settle_pool)
+            .expect("compute_investor_payout: arithmetic overflow")
+            .checked_div(total_principal)
+            .expect("compute_investor_payout: arithmetic overflow")
     }
 
     pub fn update_maturity(env: Env, new_maturity: u64) -> InvoiceEscrow {

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -1277,3 +1277,387 @@ fn no_state_mutation_possible_after_withdraw() {
         assert!(r.is_err(), "fund after withdraw must panic");
     }
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// compute_investor_payout — issue #245
+//
+// Verifies the on-chain pro-rata view against the formula in docs/escrow-pro-rata.md:
+//   coupon       = total_principal × effective_yield_bps / 10_000  (floor)
+//   settle_pool  = total_principal + coupon
+//   gross_payout = contribution × settle_pool / total_principal     (floor)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Returns 0 for an address that never contributed.
+#[test]
+fn compute_payout_returns_zero_for_non_investor() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let stranger = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    fund_to_target(&client, &env);
+    client.settle();
+
+    assert_eq!(client.compute_investor_payout(&stranger), 0);
+}
+
+/// Returns 0 before the snapshot exists (escrow still open, target not yet reached).
+#[test]
+fn compute_payout_returns_zero_before_snapshot() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "CP_PRE"),
+        &sme,
+        &10_000i128,
+        &500i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    // Deposit below target — no snapshot written yet.
+    client.fund(&investor, &1i128);
+    assert_eq!(client.compute_investor_payout(&investor), 0);
+}
+
+/// Single investor funding the full target.
+///
+/// Formula (yield = 5 %):
+///   coupon       = 10_000 × 500 / 10_000 = 500
+///   settle_pool  = 10_000 + 500 = 10_500
+///   gross_payout = 10_000 × 10_500 / 10_000 = 10_500
+#[test]
+fn compute_payout_single_investor_full_target() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "CP001"),
+        &sme,
+        &10_000i128,
+        &500i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &10_000i128);
+    client.settle();
+
+    assert_eq!(client.compute_investor_payout(&investor), 10_500i128);
+}
+
+/// Two equal investors — each receives half the settle pool.
+///
+/// Formula (yield = 10 %):
+///   coupon = 2_000 × 1_000 / 10_000 = 200  →  settle_pool = 2_200
+///   payout each = 1_000 × 2_200 / 2_000 = 1_100
+#[test]
+fn compute_payout_two_equal_investors() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "CP002"),
+        &sme,
+        &2_000i128,
+        &1_000i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&inv_a, &1_000i128);
+    client.fund(&inv_b, &1_000i128);
+    client.settle();
+
+    assert_eq!(client.compute_investor_payout(&inv_a), 1_100i128);
+    assert_eq!(client.compute_investor_payout(&inv_b), 1_100i128);
+}
+
+/// Aggregate invariant: sum of all payouts ≤ settle_pool (floor rounding, 3 investors).
+///
+/// Extreme case: 100 % yield — maximises rounding stress.
+///   total_principal = 3, coupon = 3  →  settle_pool = 6
+///   each investor (1 unit): 1 × 6 / 3 = 2  →  sum = 6 ≤ 6 ✓
+#[test]
+fn compute_payout_aggregate_does_not_exceed_settle_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+    let inv_c = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "CP003"),
+        &sme,
+        &3i128,
+        &10_000i64, // 100 % yield
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&inv_a, &1i128);
+    client.fund(&inv_b, &1i128);
+    client.fund(&inv_c, &1i128);
+    client.settle();
+
+    let pa = client.compute_investor_payout(&inv_a);
+    let pb = client.compute_investor_payout(&inv_b);
+    let pc = client.compute_investor_payout(&inv_c);
+    let sum = pa + pb + pc;
+
+    assert_eq!(pa, 2i128, "inv_a payout");
+    assert_eq!(pb, 2i128, "inv_b payout");
+    assert_eq!(pc, 2i128, "inv_c payout");
+    assert!(sum <= 6i128, "aggregate {sum} exceeded settle_pool 6");
+}
+
+/// Floor rounding: unequal 2:1 split with zero yield.
+///
+///   total_principal = 3, yield = 0  →  settle_pool = 3
+///   inv_a (2): 2 × 3 / 3 = 2
+///   inv_b (1): 1 × 3 / 3 = 1
+#[test]
+fn compute_payout_floor_rounding_unequal_split() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "CP004"),
+        &sme,
+        &3i128,
+        &0i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&inv_a, &2i128);
+    client.fund(&inv_b, &1i128);
+    client.settle();
+
+    assert_eq!(client.compute_investor_payout(&inv_a), 2i128);
+    assert_eq!(client.compute_investor_payout(&inv_b), 1i128);
+    assert!(
+        client.compute_investor_payout(&inv_a) + client.compute_investor_payout(&inv_b) <= 3i128
+    );
+}
+
+/// Zero yield: payout equals principal contribution exactly.
+#[test]
+fn compute_payout_zero_yield_equals_principal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "CP006"),
+        &sme,
+        &5_000i128,
+        &0i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&inv, &5_000i128);
+    client.settle();
+
+    assert_eq!(client.compute_investor_payout(&inv), 5_000i128);
+}
+
+/// Over-funded escrow: total_principal > funding_target; pro-rata still correct.
+///
+///   funding_target = 1_000, total_principal = 1_500, yield = 0
+///   each investor (750 units): 750 × 1_500 / 1_500 = 750
+#[test]
+fn compute_payout_with_over_funding() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "CP007"),
+        &sme,
+        &1_000i128,
+        &0i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&inv_a, &750i128);
+    client.fund(&inv_b, &750i128); // pushes total to 1_500 > target
+    client.settle();
+
+    assert_eq!(client.compute_investor_payout(&inv_a), 750i128);
+    assert_eq!(client.compute_investor_payout(&inv_b), 750i128);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// claim_investor_payout dedupe regression — issue #256
+//
+// Verifies the single-fetch refactor works correctly end-to-end and that the
+// removed redundant "Investor did not participate" assertion does not leave a
+// gap in the participation guard.
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Claim executes cleanly with the consolidated single-read path (happy path).
+/// A second call must be a silent no-op — idempotent, no re-emit.
+#[test]
+fn claim_dedupe_single_read_happy_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "DED001"),
+        &sme,
+        &1_000i128,
+        &200i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &1_000i128);
+    client.settle();
+
+    // First claim — must succeed.
+    client.claim_investor_payout(&investor);
+    assert!(client.is_investor_claimed(&investor));
+
+    // Second claim — must be idempotent (no panic, no re-emit).
+    client.claim_investor_payout(&investor);
+    assert!(client.is_investor_claimed(&investor));
+}
+
+/// Claim correctly rejects a stranger with the deduplicated read path.
+#[test]
+#[should_panic(expected = "Address has no contribution to claim")]
+fn claim_dedupe_stranger_still_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "DED002"),
+        &sme,
+        &1_000i128,
+        &200i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &1_000i128);
+    client.settle();
+
+    client.claim_investor_payout(&stranger); // must panic: no contribution
+}
+
+/// Legal hold still blocks the claim after the dedupe refactor.
+#[test]
+#[should_panic]
+fn claim_dedupe_hold_still_blocks() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "DED003"),
+        &sme,
+        &1_000i128,
+        &200i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &1_000i128);
+    client.settle();
+    client.set_legal_hold(&true);
+
+    client.claim_investor_payout(&investor); // must panic: hold active
+}


### PR DESCRIPTION
Closes #256 
Closes #245 

### **Description**
This PR addresses two critical enhancements for the LiquiFact escrow contract:

1. **Deduplicate Contribution Reads in Payout Claims (#256)**:
   * Consolidates two separate reads of `DataKey::InvestorContribution` in `claim_investor_payout` into a single fetch.
   * Removes the redundant second `get_contribution` assertion (`assert!(contribution > 0, "Investor did not participate")`) while retaining the necessary security gates.
   * Updates state before emitting the `InvestorPayoutClaimed` event to align with Soroban best practices.

2. **On-Chain Pro-Rata Payout View (#245)**:
   * Implements `compute_investor_payout(investor: Address) -> i128` as a read-only view.
   * Provides authoritative pro-rata calculation using the formula:
     $$\text{coupon} = \frac{\text{total\_principal} \times \text{effective\_yield\_bps}}{10,000} \text{ (floor)}$$
     $$\text{gross\_payout} = \frac{\text{contribution} \times (\text{total\_principal} + \text{coupon})}{\text{total\_principal}} \text{ (floor)}$$
   * Leverages checked `i128` arithmetic (`checked_mul`, `checked_div`, `checked_add`) to prevent overflow.
   * Falls back gracefully to `yield_bps` if no investor-specific tier yield is recorded, and returns `0` if the close snapshot or contribution is missing.