### PR TITLE
test(escrow): complete allowlist gating matrix and checked contribution overflow coverage

### DIFF
--- a/docs/escrow-data-model.md
+++ b/docs/escrow-data-model.md
@@ -10,9 +10,13 @@ For the policy that governs schema evolution see [ADR-007](adr/ADR-007-storage-k
 
 ## Storage backend
 
-All keys use `env.storage().instance()`. Instance storage is scoped to a single contract address
-and is loaded in full on every host-function invocation. There is no persistent or temporary storage
-in this contract.
+Most keys use `env.storage().instance()`. Instance storage is scoped to a single contract address
+and is loaded in full on every host-function invocation.
+
+The contract also uses `env.storage().persistent()` for allowlist membership entries
+(`DataKey::InvestorAllowlisted(Address)`), which are per-address and naturally modeled as
+independent persistent keys (see Stellar/Soroban storage guidance on instance vs persistent
+storage).
 
 Consequence: the total serialised size of all instance entries must stay within Soroban's
 contract-data entry limit. The investor-contribution map is the main growth vector; it is bounded
@@ -66,6 +70,18 @@ These variants carry an `Address` discriminator so each investor gets an indepen
 
 All four per-address keys are written together on an investor's first `fund` or
 `fund_with_commitment` call. Subsequent `fund` calls update only `InvestorContribution`.
+
+### Per-address keys in persistent storage (allowlist)
+
+These entries live in **persistent** storage (not instance storage).
+
+| Variant | Rust type stored | Set by | Default when absent |
+|---------|------------------|--------|---------------------|
+| `InvestorAllowlisted(Address)` | `bool` | `set_investor_allowlisted` | `false` |
+
+When `AllowlistActive` is enabled (instance storage flag), `fund_impl` gates `fund` and
+`fund_with_commitment` by asserting `InvestorAllowlisted(investor) == true`. Only the admin may
+mutate allowlist membership.
 
 ---
 

--- a/docs/escrow-numeric-model.md
+++ b/docs/escrow-numeric-model.md
@@ -8,6 +8,7 @@ This contract uses Soroban host values and Rust integer types directly. It does 
 - State-changing entrypoints that accept funding-like amounts require strictly positive values before storage updates.
 - Token amounts must be passed in the token's smallest unit. The escrow contract does not read token decimals to rescale user-facing amounts.
 - `funded_amount` is accumulated with `checked_add`. If `funded_amount + amount` exceeds `i128::MAX`, the contract panics with `funded_amount overflow` and the Soroban invocation aborts.
+- Per-investor `InvestorContribution(Address)` is accumulated with `checked_add`. If `prev_contribution + amount` exceeds `i128::MAX`, the contract panics with `investor contribution overflow` and the Soroban invocation aborts.
 - The contract does not saturate, clamp, or intentionally wrap funding totals.
 
 ## Commitment locks: `u64`

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1242,9 +1242,12 @@ impl LiquifactEscrow {
             }
         }
 
+        let next_contribution = prev
+            .checked_add(amount)
+            .expect("investor contribution overflow");
         env.storage()
             .instance()
-            .set(&contribution_key, &(prev + amount));
+            .set(&contribution_key, &next_contribution);
 
         if prev == 0 {
             // Use the hoisted cur_funder_count; no second storage read needed.

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -67,7 +67,10 @@ fn test_enable_and_disable_allowlist() {
     let enabled_events = env.events().all();
     env.as_contract(&contract_id, || {
         assert!(
-            env.storage().instance().get::<DataKey, bool>(&DataKey::AllowlistActive) == Some(true)
+            env.storage()
+                .instance()
+                .get::<DataKey, bool>(&DataKey::AllowlistActive)
+                == Some(true)
         );
     });
 
@@ -75,7 +78,10 @@ fn test_enable_and_disable_allowlist() {
     let disabled_events = env.events().all();
     env.as_contract(&contract_id, || {
         assert!(
-            env.storage().instance().get::<DataKey, bool>(&DataKey::AllowlistActive) == Some(false)
+            env.storage()
+                .instance()
+                .get::<DataKey, bool>(&DataKey::AllowlistActive)
+                == Some(false)
         );
     });
 
@@ -397,7 +403,9 @@ fn test_allowlist_membership_is_persistent_storage() {
             "expected allowlist membership to be stored in persistent storage"
         );
         assert!(
-            !env.storage().instance().has(&DataKey::InvestorAllowlisted(investor)),
+            !env.storage()
+                .instance()
+                .has(&DataKey::InvestorAllowlisted(investor)),
             "allowlist membership must not be stored in instance storage"
         );
     });
@@ -464,7 +472,8 @@ fn test_toggle_investor_off_after_commitment_blocks_follow_on_fund() {
 }
 
 #[test]
-fn test_fund_and_fund_with_commitment_allowed_when_allowlist_disabled_and_investor_explicitly_blocked() {
+fn test_fund_and_fund_with_commitment_allowed_when_allowlist_disabled_and_investor_explicitly_blocked(
+) {
     let env = Env::default();
     env.mock_all_auths();
     let client = deploy(&env);
@@ -515,7 +524,8 @@ fn test_enable_allowlist_mid_funding_blocks_unallowlisted_investor_from_further_
 }
 
 #[test]
-fn test_enable_allowlist_after_commitment_mid_funding_blocks_unallowlisted_investor_from_further_increases() {
+fn test_enable_allowlist_after_commitment_mid_funding_blocks_unallowlisted_investor_from_further_increases(
+) {
     let env = Env::default();
     env.mock_all_auths();
     let client = deploy(&env);

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -1,5 +1,6 @@
-use super::{LiquifactEscrow, LiquifactEscrowClient};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use super::{DataKey, LiquifactEscrow, LiquifactEscrowClient};
+use crate::{AllowlistEnabledChanged, InvestorAllowlistChanged};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Event};
 
 fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
     let id = env.register(LiquifactEscrow, ());
@@ -53,16 +54,49 @@ fn test_is_allowlisted_false_by_default() {
 
 #[test]
 fn test_enable_and_disable_allowlist() {
+    use soroban_sdk::testutils::Events as _;
+
     let env = Env::default();
     env.mock_all_auths();
     let client = deploy(&env);
     init(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
 
     client.set_allowlist_active(&true);
-    assert!(client.is_allowlist_active());
+    let enabled_events = env.events().all();
+    env.as_contract(&contract_id, || {
+        assert!(
+            env.storage().instance().get::<DataKey, bool>(&DataKey::AllowlistActive) == Some(true)
+        );
+    });
 
     client.set_allowlist_active(&false);
-    assert!(!client.is_allowlist_active());
+    let disabled_events = env.events().all();
+    env.as_contract(&contract_id, || {
+        assert!(
+            env.storage().instance().get::<DataKey, bool>(&DataKey::AllowlistActive) == Some(false)
+        );
+    });
+
+    assert_eq!(
+        enabled_events,
+        std::vec![AllowlistEnabledChanged {
+            name: symbol_short!("al_ena"),
+            invoice_id: invoice_id.clone(),
+            active: 1,
+        }
+        .to_xdr(&env, &contract_id)]
+    );
+    assert_eq!(
+        disabled_events,
+        std::vec![AllowlistEnabledChanged {
+            name: symbol_short!("al_ena"),
+            invoice_id,
+            active: 0,
+        }
+        .to_xdr(&env, &contract_id)]
+    );
 }
 
 #[test]
@@ -92,17 +126,58 @@ fn test_disable_allowlist_requires_admin_auth() {
 
 #[test]
 fn test_add_and_remove_from_allowlist() {
+    use soroban_sdk::testutils::Events as _;
+
     let env = Env::default();
     env.mock_all_auths();
     let client = deploy(&env);
     init(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
     let investor = Address::generate(&env);
 
     client.set_investor_allowlisted(&investor, &true);
-    assert!(client.is_investor_allowlisted(&investor));
+    let added_events = env.events().all();
+    env.as_contract(&contract_id, || {
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(investor.clone()))
+                == Some(true)
+        );
+    });
 
     client.set_investor_allowlisted(&investor, &false);
-    assert!(!client.is_investor_allowlisted(&investor));
+    let removed_events = env.events().all();
+    env.as_contract(&contract_id, || {
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(investor.clone()))
+                == Some(false)
+        );
+    });
+
+    assert_eq!(
+        added_events,
+        std::vec![InvestorAllowlistChanged {
+            name: symbol_short!("al_set"),
+            invoice_id: invoice_id.clone(),
+            investor: investor.clone(),
+            allowed: 1,
+        }
+        .to_xdr(&env, &contract_id)]
+    );
+    assert_eq!(
+        removed_events,
+        std::vec![InvestorAllowlistChanged {
+            name: symbol_short!("al_set"),
+            invoice_id,
+            investor: investor.clone(),
+            allowed: 0,
+        }
+        .to_xdr(&env, &contract_id)]
+    );
 }
 
 #[test]
@@ -153,6 +228,18 @@ fn test_fund_allowed_when_allowlist_disabled() {
     let investor = Address::generate(&env);
     // Allowlist off — anyone can fund.
     let escrow = client.fund(&investor, &5_000i128);
+    assert_eq!(escrow.funded_amount, 5_000i128);
+}
+
+#[test]
+fn test_fund_with_commitment_allowed_when_allowlist_disabled() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let investor = Address::generate(&env);
+    // Allowlist off — anyone can fund with commitment.
+    let escrow = client.fund_with_commitment(&investor, &5_000i128, &0u64);
     assert_eq!(escrow.funded_amount, 5_000i128);
 }
 
@@ -288,4 +375,170 @@ fn test_multiple_investors_independent_allowlist_entries() {
         client.fund(&c, &1_000i128);
     }));
     assert!(blocked.is_err());
+}
+
+#[test]
+fn test_allowlist_membership_is_persistent_storage() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let investor = Address::generate(&env);
+    client.set_investor_allowlisted(&investor, &true);
+
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        // Membership entries are intentionally stored in persistent storage.
+        assert!(
+            env.storage()
+                .persistent()
+                .has(&DataKey::InvestorAllowlisted(investor.clone())),
+            "expected allowlist membership to be stored in persistent storage"
+        );
+        assert!(
+            !env.storage().instance().has(&DataKey::InvestorAllowlisted(investor)),
+            "allowlist membership must not be stored in instance storage"
+        );
+    });
+}
+
+#[test]
+fn test_toggle_investor_off_mid_funding_blocks_further_increases() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let investor = Address::generate(&env);
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+
+    // First deposit succeeds.
+    client.fund(&investor, &2_000i128);
+    let before = client.get_escrow().funded_amount;
+    assert_eq!(before, 2_000i128);
+
+    // Toggle address off and prove it can never increase funded_amount.
+    client.set_investor_allowlisted(&investor, &false);
+    let blocked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund(&investor, &1_000i128);
+    }));
+    assert!(blocked.is_err());
+
+    let after = client.get_escrow().funded_amount;
+    assert_eq!(
+        after, before,
+        "blocked investor must not be able to increase funded_amount"
+    );
+}
+
+#[test]
+fn test_toggle_investor_off_after_commitment_blocks_follow_on_fund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let investor = Address::generate(&env);
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+
+    // First deposit is tier/commitment path.
+    client.fund_with_commitment(&investor, &2_000i128, &0u64);
+    let before = client.get_escrow().funded_amount;
+    assert_eq!(before, 2_000i128);
+
+    // Remove membership: subsequent principal must be blocked (follow-on uses fund()).
+    client.set_investor_allowlisted(&investor, &false);
+    let blocked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund(&investor, &1_000i128);
+    }));
+    assert!(blocked.is_err());
+
+    let after = client.get_escrow().funded_amount;
+    assert_eq!(
+        after, before,
+        "blocked investor must not be able to increase funded_amount"
+    );
+}
+
+#[test]
+fn test_fund_and_fund_with_commitment_allowed_when_allowlist_disabled_and_investor_explicitly_blocked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let investor_a = Address::generate(&env);
+    let investor_b = Address::generate(&env);
+
+    // Explicitly set allowed = false.
+    client.set_investor_allowlisted(&investor_a, &false);
+    client.set_investor_allowlisted(&investor_b, &false);
+
+    // Gating is inactive, so both calls must succeed despite explicit false value.
+    let escrow = client.fund(&investor_a, &3_000i128);
+    assert_eq!(escrow.funded_amount, 3_000i128);
+
+    let escrow = client.fund_with_commitment(&investor_b, &4_000i128, &0u64);
+    assert_eq!(escrow.funded_amount, 7_000i128);
+}
+
+#[test]
+fn test_enable_allowlist_mid_funding_blocks_unallowlisted_investor_from_further_increases() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let investor = Address::generate(&env);
+
+    // Initial deposit under disabled allowlist.
+    client.fund(&investor, &2_000i128);
+    let before = client.get_escrow().funded_amount;
+    assert_eq!(before, 2_000i128);
+
+    // Toggle allowlist on mid-funding. Investor is NOT allowlisted.
+    client.set_allowlist_active(&true);
+
+    let blocked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund(&investor, &1_000i128);
+    }));
+    assert!(blocked.is_err());
+
+    let after = client.get_escrow().funded_amount;
+    assert_eq!(
+        after, before,
+        "unallowlisted investor must not be able to increase funded_amount after allowlist is enabled"
+    );
+}
+
+#[test]
+fn test_enable_allowlist_after_commitment_mid_funding_blocks_unallowlisted_investor_from_further_increases() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let investor = Address::generate(&env);
+
+    // Initial commitment deposit under disabled allowlist.
+    client.fund_with_commitment(&investor, &2_000i128, &0u64);
+    let before = client.get_escrow().funded_amount;
+    assert_eq!(before, 2_000i128);
+
+    // Toggle allowlist on mid-funding. Investor is NOT allowlisted.
+    client.set_allowlist_active(&true);
+
+    let blocked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund(&investor, &1_000i128);
+    }));
+    assert!(blocked.is_err());
+
+    let after = client.get_escrow().funded_amount;
+    assert_eq!(
+        after, before,
+        "unallowlisted investor must not be able to increase funded_amount after allowlist is enabled"
+    );
 }

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -208,6 +208,164 @@ fn test_funding_amount_overflow_does_not_mutate_state() {
 }
 
 #[test]
+#[should_panic(expected = "funded_amount overflow")]
+fn test_fund_with_commitment_overflow_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor_a = Address::generate(&env);
+    let investor_b = Address::generate(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "OVF001b"),
+        &sme,
+        &i128::MAX,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &None,
+    );
+
+    client.fund(&investor_a, &(i128::MAX - 1));
+    client.fund_with_commitment(&investor_b, &2i128, &0u64);
+}
+
+#[test]
+fn test_fund_with_commitment_overflow_does_not_mutate_state() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor_a = Address::generate(&env);
+    let investor_b = Address::generate(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "OVF002b"),
+        &sme,
+        &i128::MAX,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &None,
+    );
+
+    client.fund(&investor_a, &(i128::MAX - 1));
+    let before = client.get_escrow();
+
+    let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund_with_commitment(&investor_b, &2i128, &0u64);
+    }));
+    assert!(overflowed.is_err());
+
+    let after = client.get_escrow();
+    assert_eq!(after.funded_amount, before.funded_amount);
+    assert_eq!(after.status, 0);
+    assert_eq!(client.get_contribution(&investor_b), 0);
+}
+
+#[test]
+#[should_panic(expected = "investor contribution overflow")]
+fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
+    // This test intentionally constructs an inconsistent storage snapshot to ensure
+    // the per-investor accounting never wraps even under corrupted / unexpected state.
+    //
+    // Rationale: `funded_amount` overflow is already guarded by checked_add. This test
+    // separately proves the per-investor `InvestorContribution` update uses checked_add.
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let contract_id = client.address.clone();
+
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "OVF003"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+
+    env.as_contract(&contract_id, || {
+        // Force the contribution near i128::MAX while keeping funded_amount small.
+        // `fund` must still trap on contribution overflow even if funded_amount would not.
+        env.storage()
+            .instance()
+            .set(&DataKey::InvestorContribution(investor.clone()), &(i128::MAX - 1));
+        let mut escrow = LiquifactEscrow::get_escrow(env.clone());
+        escrow.funded_amount = 0;
+        escrow.status = 0;
+        env.storage().instance().set(&DataKey::Escrow, &escrow);
+    });
+
+    client.fund(&investor, &2i128);
+}
+
+#[test]
+fn test_investor_contribution_overflow_does_not_mutate_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let contract_id = client.address.clone();
+
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "OVF004"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+    );
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::InvestorContribution(investor.clone()), &(i128::MAX - 1));
+        let mut escrow = LiquifactEscrow::get_escrow(env.clone());
+        escrow.funded_amount = 0;
+        escrow.status = 0;
+        env.storage().instance().set(&DataKey::Escrow, &escrow);
+    });
+
+    let before_escrow = client.get_escrow();
+    let before_contribution = client.get_contribution(&investor);
+
+    let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund(&investor, &2i128);
+    }));
+    assert!(overflowed.is_err());
+
+    assert_eq!(client.get_escrow(), before_escrow);
+    assert_eq!(client.get_contribution(&investor), before_contribution);
+}
+
+#[test]
 fn test_multiple_investors_tracked_independently() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -304,9 +304,10 @@ fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
     env.as_contract(&contract_id, || {
         // Force the contribution near i128::MAX while keeping funded_amount small.
         // `fund` must still trap on contribution overflow even if funded_amount would not.
-        env.storage()
-            .instance()
-            .set(&DataKey::InvestorContribution(investor.clone()), &(i128::MAX - 1));
+        env.storage().instance().set(
+            &DataKey::InvestorContribution(investor.clone()),
+            &(i128::MAX - 1),
+        );
         let mut escrow = LiquifactEscrow::get_escrow(env.clone());
         escrow.funded_amount = 0;
         escrow.status = 0;
@@ -344,9 +345,10 @@ fn test_investor_contribution_overflow_does_not_mutate_state() {
     );
 
     env.as_contract(&contract_id, || {
-        env.storage()
-            .instance()
-            .set(&DataKey::InvestorContribution(investor.clone()), &(i128::MAX - 1));
+        env.storage().instance().set(
+            &DataKey::InvestorContribution(investor.clone()),
+            &(i128::MAX - 1),
+        );
         let mut escrow = LiquifactEscrow::get_escrow(env.clone());
         escrow.funded_amount = 0;
         escrow.status = 0;


### PR DESCRIPTION
Closes #259 
Closes #263 

### Description
This PR implements complete test coverage and numeric safety checks for issues #263 and #259 in the LiquiFact escrow contract codebase.

#### Key Changes

##### Issue #263: Allowlist Gating Matrix
- **Matrix Gating Tests**: Expanded `test_allowlist_tests.rs` to cover all combinations of allowlist status and transitions:
  - Allowed/blocked investors under both disabled and enabled allowlist states for both `fund` and `fund_with_commitment`.
  - Mid-funding allowlist status change (enabling allowlist after initial funding blocks non-allowlisted investors from further deposits).
  - Mid-funding investor status change (revoking an investor's allowlist entry blocks them from further contribution increases).
- **Persistent Storage Invariant**: Verified that allowlist entries are correctly persisted inside persistent contract storage and not instance storage.
- **Admin Authentication**: Verified admin-auth requirements on all allowlist mutating actions.
- **Event Logging**: Checked that the events `AllowlistEnabledChanged` and `InvestorAllowlistChanged` are correctly published with correct parameters.

##### Issue #259: Numeric Overflow Guard
- **Checked Arithmetic**: Converted investor-specific contribution accumulation from `prev + amount` to `.checked_add(amount)` to match aggregate `funded_amount` safety.
- **Aggregate and Contribution Overflow Coverage**: Added `test_fund_with_commitment_overflow_panics` and `test_fund_with_commitment_overflow_does_not_mutate_state` to ensure overflow panics deterministically and rolls back state completely without partial storage writes.