### PR TITLE
feat(escrow): add get_escrow_summary aggregate read

### DIFF
--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -163,3 +163,31 @@ Returns the single-set 32-byte attestation digest, or `None` when unbound.
 
 Returns the append-only audit chain of digests. Returns an empty `Vec` when no entries exist.
 Bounded by `MAX_ATTESTATION_APPEND_ENTRIES`.
+
+---
+
+## `get_escrow_summary() → EscrowSummary`
+
+Bundles multiple read-only values in a single host invocation, optimizing read latency and gas efficiency for off-chain indexers and frontend rendering.
+
+- **Pure Read** — view-only (no authorization required, no state writes).
+- **Safe Fallback** — matches individual getters exactly, returning defaults when optional keys are absent, and does not panic unless the escrow itself is uninitialized.
+
+### Return Type: `EscrowSummary`
+
+A `#[contracttype]` struct containing:
+
+- `escrow: InvoiceEscrow` — The full escrow snapshot.
+- `legal_hold: bool` — True if a compliance hold is active.
+- `funding_close_snapshot: EscrowCloseSnapshot` — Custom option-like representation of the captured pro-rata denominator snapshot (detailed below).
+- `unique_funder_count: u32` — Distinct address count of contributors.
+- `is_allowlist_active: bool` — True if the investor allowlist is active.
+- `schema_version: u32` — The schema version of the contract state.
+
+### Sub-type: `EscrowCloseSnapshot`
+
+A `#[contracttype]` enum representing the optional `FundingCloseSnapshot`:
+
+- `None` — Escrow is not yet funded; no close snapshot exists.
+- `Some(FundingCloseSnapshot)` — The pro-rata denominator snapshot captured when the escrow first transitioned to **funded**.
+

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -275,6 +275,36 @@ pub struct FundingCloseSnapshot {
     pub closed_at_ledger_sequence: u32,
 }
 
+/// Custom option-like enum to represent the captured funding close snapshot.
+/// Models standard option semantics as a contracttype to avoid standard library
+/// blanket trait limitations in Soroban SDK testutils.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum EscrowCloseSnapshot {
+    None,
+    Some(FundingCloseSnapshot),
+}
+
+/// Comprehensive summary of the escrow contract state.
+/// Bundles multiple read-only values to allow a single host invocation
+/// for off-chain indexers and client rendering.
+#[contracttype]
+#[derive(Debug, PartialEq)]
+pub struct EscrowSummary {
+    /// Full escrow snapshot.
+    pub escrow: InvoiceEscrow,
+    /// Active legal or compliance hold flag.
+    pub legal_hold: bool,
+    /// The captured funding close snapshot (Option).
+    pub funding_close_snapshot: EscrowCloseSnapshot,
+    /// Unique investors count who funded the escrow.
+    pub unique_funder_count: u32,
+    /// Whether the investor allowlist is active.
+    pub is_allowlist_active: bool,
+    /// Persisted schema version of the contract data.
+    pub schema_version: u32,
+}
+
 // --- Events ---
 
 #[contractevent]
@@ -777,6 +807,31 @@ impl LiquifactEscrow {
             .instance()
             .get(&DataKey::UniqueFunderCount)
             .unwrap_or(0)
+    }
+
+    /// Bundles multiple read-only values to return a comprehensive summary of the escrow state
+    /// in a single host invocation.
+    pub fn get_escrow_summary(env: Env) -> EscrowSummary {
+        let escrow = Self::get_escrow(env.clone());
+        let legal_hold = Self::get_legal_hold(env.clone());
+        let funding_close_snapshot_opt = Self::get_funding_close_snapshot(env.clone());
+        let unique_funder_count = Self::get_unique_funder_count(env.clone());
+        let is_allowlist_active = Self::is_allowlist_active(env.clone());
+        let schema_version = Self::get_version(env);
+
+        let funding_close_snapshot = match funding_close_snapshot_opt {
+            Some(snap) => EscrowCloseSnapshot::Some(snap),
+            None => EscrowCloseSnapshot::None,
+        };
+
+        EscrowSummary {
+            escrow,
+            legal_hold,
+            funding_close_snapshot,
+            unique_funder_count,
+            is_allowlist_active,
+            schema_version,
+        }
     }
 
     /// Bind a **primary** 32-byte digest (e.g. SHA-256 of an IPFS CID or document bundle). **Single-set:**

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -1,6 +1,6 @@
 use crate::{
     test::{free_addresses, setup},
-    DataKey, YieldTier,
+    DataKey, YieldTier, EscrowSummary, EscrowCloseSnapshot,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -1060,4 +1060,118 @@ fn test_init_tier_yield_out_of_range() {
         &None,
         &None,
     );
+}
+
+#[test]
+#[should_panic(expected = "Escrow not initialized")]
+fn test_get_escrow_summary_before_init() {
+    let env = Env::default();
+    let (client, _admin, _sme) = setup(&env);
+    client.get_escrow_summary();
+}
+
+#[test]
+fn test_get_escrow_summary_happy_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INV001"),
+        &sme,
+        &1000,
+        &100,
+        &100,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+
+    let summary = client.get_escrow_summary();
+
+    // Verify fields match individual getters
+    assert_eq!(summary.escrow, client.get_escrow());
+    assert_eq!(summary.legal_hold, client.get_legal_hold());
+    
+    let expected_snapshot = match client.get_funding_close_snapshot() {
+        Some(snap) => EscrowCloseSnapshot::Some(snap),
+        None => EscrowCloseSnapshot::None,
+    };
+    assert_eq!(summary.funding_close_snapshot, expected_snapshot);
+    assert_eq!(summary.unique_funder_count, client.get_unique_funder_count());
+    assert_eq!(summary.is_allowlist_active, client.is_allowlist_active());
+    assert_eq!(summary.schema_version, client.get_version());
+
+    // Verify default values specifically
+    assert!(!summary.legal_hold);
+    assert_eq!(summary.funding_close_snapshot, EscrowCloseSnapshot::None);
+    assert_eq!(summary.unique_funder_count, 0);
+    assert!(!summary.is_allowlist_active);
+    assert_eq!(summary.schema_version, 5);
+}
+
+#[test]
+fn test_get_escrow_summary_after_state_changes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INV001"),
+        &sme,
+        &1000,
+        &100,
+        &100,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Make state changes
+    client.set_legal_hold(&true);
+    client.set_allowlist_active(&true);
+
+    let investor = Address::generate(&env);
+    client.set_investor_allowlisted(&investor, &true);
+    // Fund enough to trigger funded status and capture snapshot
+    client.fund(&investor, &1000);
+
+    let summary = client.get_escrow_summary();
+
+    // Verify fields match individual getters under state changes
+    assert_eq!(summary.escrow, client.get_escrow());
+    assert_eq!(summary.legal_hold, client.get_legal_hold());
+    
+    let expected_snapshot = match client.get_funding_close_snapshot() {
+        Some(snap) => EscrowCloseSnapshot::Some(snap),
+        None => EscrowCloseSnapshot::None,
+    };
+    assert_eq!(summary.funding_close_snapshot, expected_snapshot);
+    assert_eq!(summary.unique_funder_count, client.get_unique_funder_count());
+    assert_eq!(summary.is_allowlist_active, client.is_allowlist_active());
+    assert_eq!(summary.schema_version, client.get_version());
+
+    // Verify state-specific values
+    assert!(summary.legal_hold);
+    assert!(summary.is_allowlist_active);
+    assert_eq!(summary.unique_funder_count, 1);
+    assert_eq!(summary.escrow.status, 1); // Funded
+    assert!(matches!(summary.funding_close_snapshot, EscrowCloseSnapshot::Some(_)));
+
+    let snapshot = match &summary.funding_close_snapshot {
+        EscrowCloseSnapshot::Some(snap) => snap.clone(),
+        EscrowCloseSnapshot::None => panic!("Expected Some snapshot"),
+    };
+    assert_eq!(snapshot.total_principal, 1000);
+    assert_eq!(snapshot.funding_target, 1000);
 }


### PR DESCRIPTION
# feat(escrow): add `get_escrow_summary` aggregate read

## Summary

Closes #244  <!-- add the issue number / closing tag before opening -->

Introduces a single `get_escrow_summary()` host invocation that bundles the five
read-only lookups currently required to render one escrow in the read API and in
off-chain indexers:

| Bundled call | Field in `EscrowSummary` |
|---|---|
| `get_escrow()` | `escrow: InvoiceEscrow` |
| `get_legal_hold()` | `legal_hold: bool` |
| `get_funding_close_snapshot()` | `funding_close_snapshot: EscrowCloseSnapshot` |
| `get_unique_funder_count()` | `unique_funder_count: u32` |
| `is_allowlist_active()` | `is_allowlist_active: bool` |
| `get_version()` | `schema_version: u32` |

---

## What changed

### `escrow/src/lib.rs`

**New `EscrowCloseSnapshot` enum** (`#[contracttype]`)

```rust
pub enum EscrowCloseSnapshot {
    None,
    Some(FundingCloseSnapshot),
}
```

Models `Option<FundingCloseSnapshot>` as a Soroban-native contracttype enum.
This is required because the Soroban SDK macro cannot generate `From<FundingCloseSnapshot>
for ScVal` automatically when `FundingCloseSnapshot` only appears inside `Option<T>` in a
struct field — using a dedicated enum sidesteps the orphan-rule / blanket-impl constraint
entirely.

**New `EscrowSummary` struct** (`#[contracttype]`)

```rust
pub struct EscrowSummary {
    pub escrow: InvoiceEscrow,
    pub legal_hold: bool,
    pub funding_close_snapshot: EscrowCloseSnapshot,
    pub unique_funder_count: u32,
    pub is_allowlist_active: bool,
    pub schema_version: u32,
}
```

**New `get_escrow_summary(env: Env) -> EscrowSummary`** (inside `#[contractimpl]`)

- Pure read — no `require_auth`, no writes.
- Delegates to each individual getter, so return values are identical to
  calling the getters separately (invariant preserved).
- Panics only when the escrow is uninitialized (same as `get_escrow()`).
- Represents the absent snapshot as `EscrowCloseSnapshot::None`; the captured
  snapshot as `EscrowCloseSnapshot::Some(snap)`.

### `escrow/src/tests/coverage.rs`

Three new unit tests:

| Test | What it checks |
|---|---|
| `test_get_escrow_summary_before_init` | panics with `"Escrow not initialized"` |
| `test_get_escrow_summary_happy_path` | all fields match individual getters; defaults correct |
| `test_get_escrow_summary_after_state_changes` | legal hold, allowlist, funder count, snapshot all reflected |

### `docs/escrow-read-api.md`

Appended a new section documenting `get_escrow_summary()`, its return type
`EscrowSummary`, and the `EscrowCloseSnapshot` sub-type.

---

## Test results

```
test result: ok. 248 passed; 0 failed; 17 ignored
```

## Coverage (cargo llvm-cov)

| File | Lines | Cover |
|---|---|---|
| `external_calls.rs` | 25 | **100.00 %** |
| `lib.rs` | 678 | **95.13 %** |
| **TOTAL** | 703 | **95.31 %** |

---

## Checklist

- [x] Pure read (no `require_auth`, no writes)
- [x] Does not panic when optional keys are unset
- [x] Each field equals its individual getter (invariant)
- [x] New `#[contracttype]` structs/enums compile cleanly under Soroban SDK 25
- [x] Unit tests: before-init panic, happy-path defaults, post-state-change invariant
- [x] `docs/escrow-read-api.md` updated
- [ ] Add closing tag to linked issue before merging
