### PR TITLE
feat(escrow): two-step admin handover with pending acceptance

### DIFF
--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -349,8 +349,9 @@ on-chain entrypoint in the current release.
 
 - Use a multisig wallet or a governed contract as `admin` at all times.
 - Never use a single-signer hot wallet as `admin` in production.
-- `transfer_admin` requires the current admin's authorization — test the
-  rotation on Testnet before executing on Mainnet.
+- Admin rotation is two-step: `propose_admin` requires the current admin's
+  authorization, and `accept_admin` requires the proposed successor's
+  authorization. Test both steps on Testnet before executing on Mainnet.
 
 ### `migrate()` is not a no-op
 

--- a/docs/adr/ADR-002-auth-boundaries.md
+++ b/docs/adr/ADR-002-auth-boundaries.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** 2026-03-28  
-**Refs:** `escrow/src/lib.rs` — `init`, `fund`, `settle`, `withdraw`, `claim_investor_payout`, `sweep_terminal_dust`, `set_legal_hold`, `transfer_admin`
+**Refs:** `escrow/src/lib.rs` — `init`, `fund`, `settle`, `withdraw`, `claim_investor_payout`, `sweep_terminal_dust`, `set_legal_hold`, `propose_admin`, `accept_admin`
 
 ---
 
@@ -20,10 +20,14 @@ Multiple principals interact with the escrow (admin, SME, investors, treasury). 
 | `claim_investor_payout` | `investor` |
 | `sweep_terminal_dust` | `treasury` (immutable after init) |
 | `set_legal_hold`, `clear_legal_hold` | `admin` |
-| `update_funding_target`, `update_maturity`, `transfer_admin`, `migrate` | `admin` |
+| `update_funding_target`, `update_maturity`, `migrate` | `admin` |
+| `propose_admin` | current `admin` |
+| `accept_admin` | pending admin stored in `DataKey::PendingAdmin` |
 | `record_sme_collateral_commitment` | `sme_address` |
 
-`admin` and `treasury` are stored immutably at `init` (except `admin` which rotates via `transfer_admin`). There is no superuser that can act as all roles simultaneously unless the same key is used for multiple roles — which is a deployment concern, not a contract concern.
+`admin` and `treasury` are stored at `init`; `treasury` is immutable, while `admin` rotates only through a two-step handover. The current admin calls `propose_admin(new_admin)`, which stores `DataKey::PendingAdmin` without changing authority. The pending address must then call `accept_admin()`, which requires its own authorization, promotes it into `InvoiceEscrow::admin`, and clears `DataKey::PendingAdmin`. The deprecated `transfer_admin` shim must not be treated as an immediate transfer; it only creates the pending proposal.
+
+There is no superuser that can act as all roles simultaneously unless the same key is used for multiple roles — which is a deployment concern, not a contract concern.
 
 ## Consequences
 
@@ -31,6 +35,8 @@ Multiple principals interact with the escrow (admin, SME, investors, treasury). 
 - A compromised SME key cannot change the admin or sweep dust.
 - Treasury auth on `sweep_terminal_dust` means the admin cannot drain the contract as "dust" unless it is also the treasury.
 - Legal hold can only be set/cleared by admin, so governance controls compliance freezes.
+- Admin authority changes only after both the current admin and successor have authorized. A typo in `new_admin` can be corrected by a new `propose_admin` call and does not lock admin-gated paths.
+- `DataKey::PendingAdmin` is cleared after successful acceptance so stale proposals cannot be reused.
 
 ## Rejected alternatives
 

--- a/docs/adr/ADR-004-legal-hold.md
+++ b/docs/adr/ADR-004-legal-hold.md
@@ -35,4 +35,4 @@ There is no timelock or automatic expiry — clearing always requires an explici
 ## Rejected alternatives
 
 - **Timelock on hold:** adds complexity and a false sense of safety; governance should decide duration.
-- **Separate hold roles (compliance officer vs admin):** out of scope for v1; can be added via `transfer_admin` to a multisig that includes a compliance key.
+- **Separate hold roles (compliance officer vs admin):** out of scope for v1; can be added by rotating admin authority through `propose_admin` and `accept_admin` to a multisig that includes a compliance key.

--- a/docs/audit-handoff-escrow.md
+++ b/docs/audit-handoff-escrow.md
@@ -64,7 +64,7 @@ These map directly to property tests in `escrow/src/test/properties.rs` and `tes
 
 | Role | Stored at | Entrypoints authorized |
 |------|-----------|------------------------|
-| `admin` | `InvoiceEscrow::admin` (rotatable via `transfer_admin`) | `init`, `set_legal_hold`, `clear_legal_hold`, `update_maturity`, `update_funding_target`, `transfer_admin`, `migrate`, `bind_primary_attestation_hash`, `append_attestation_digest` |
+| `admin` | `InvoiceEscrow::admin` (rotatable via `propose_admin` + `accept_admin`) | `init`, `set_legal_hold`, `clear_legal_hold`, `update_maturity`, `update_funding_target`, `propose_admin`, `accept_admin`, `migrate`, `bind_primary_attestation_hash`, `append_attestation_digest` |
 | `sme_address` | `InvoiceEscrow::sme_address` (immutable) | `settle`, `withdraw`, `record_sme_collateral_commitment` |
 | `investor` | per-call argument (verified via `require_auth`) | `fund`, `fund_with_commitment`, `claim_investor_payout` |
 | `treasury` | `DataKey::Treasury` (immutable) | `sweep_terminal_dust` |
@@ -102,7 +102,8 @@ Read-only getters are never blocked. Only `admin` can set or clear the hold. The
 | `set_legal_hold(true)` | `LegalHoldChanged` | `legalhld` | Alert compliance dashboard; suspend investor UI funding flows |
 | `set_legal_hold(false)` / `clear_legal_hold` | `LegalHoldChanged` | `legalhld` | Resume operations; notify relevant parties |
 | `update_maturity` | `MaturityUpdatedEvent` | `maturity` | Update off-chain settlement schedule; re-notify investors if material |
-| `transfer_admin` | `AdminTransferredEvent` | `admin` | Update key registry and access control records |
+| `propose_admin` | `AdminProposedEvent` | `adm_prop` | Notify proposed successor; keep current admin active until acceptance |
+| `accept_admin` | `AdminTransferredEvent` | `admin` | Update key registry and access control records; confirm pending proposal cleared |
 | `update_funding_target` | `FundingTargetUpdated` | `fund_tgt` | Update off-chain target display; re-evaluate investor communications |
 | `record_sme_collateral_commitment` | `CollateralRecordedEvt` | `coll_rec` | Store in compliance/risk system; **do not treat as enforced on-chain lock** |
 | `sweep_terminal_dust` | `TreasuryDustSwept` | `dust_sw` | Reconcile treasury balance; log sweep amount and token address |

--- a/docs/escrow-legal-hold.md
+++ b/docs/escrow-legal-hold.md
@@ -28,7 +28,7 @@ Operations that are **not** gated (read-only or metadata-only):
 - `get_*` accessors
 - `record_sme_collateral_commitment` (metadata record, no token movement)
 - `bind_primary_attestation_hash` / `append_attestation_digest`
-- `update_maturity`, `update_funding_target`, `transfer_admin`, `migrate`
+- `update_maturity`, `update_funding_target`, `propose_admin`, `accept_admin`, `migrate`
 
 ---
 
@@ -73,7 +73,8 @@ as a governed address:
   `set_legal_hold`.
 - **Off-chain playbook** covering: who may initiate a hold, required evidence,
   maximum hold duration, escalation path if the admin key is lost or
-  compromised, and emergency recovery via `transfer_admin` + governance vote.
+  compromised, and emergency recovery via `propose_admin` + `accept_admin`
+  with governance approval.
 
 Without one of the above, a single compromised admin key can freeze all
 investor funds with no on-chain recourse.
@@ -83,7 +84,7 @@ investor funds with no on-chain recourse.
 | Requirement | Rationale |
 |---|---|
 | Governed `admin` at `init` (multisig or DAO contract) | Single EOA admin + hold + key loss = indefinite fund lock |
-| Documented recovery playbook | Operators must know how to execute `transfer_admin` under hold |
+| Documented recovery playbook | Operators must know how to execute `propose_admin` and `accept_admin` under hold |
 | Testnet rotation drill before mainnet | Confirms new admin can `clear_legal_hold` after rotation |
 | Indexer monitoring of `LegalHoldChanged` | Detect holds that exceed policy duration |
 
@@ -106,29 +107,35 @@ lost or destroyed:
 
 **On-chain recovery (only path):**
 
-1. Governance executes [`transfer_admin`](../../escrow/src/lib.rs) using a
+1. Governance executes [`propose_admin`](../../escrow/src/lib.rs) using a
    **still-available** current-admin authorization (e.g. remaining multisig
    signers or DAO vote output). This entrypoint is **not** blocked by the hold.
-2. The **new** admin calls `clear_legal_hold` (or `set_legal_hold(false)`).
-3. Risk-bearing flows resume (`settle`, `withdraw`, etc.).
+2. The proposed successor executes [`accept_admin`](../../escrow/src/lib.rs)
+   with its own authorization. This promotes the successor into
+   `InvoiceEscrow::admin` and clears `DataKey::PendingAdmin`.
+3. The **new** admin calls `clear_legal_hold` (or `set_legal_hold(false)`).
+4. Risk-bearing flows resume (`settle`, `withdraw`, etc.).
 
 **Invariant:** a hold is always clearable by the current admin; recovery
 requires controlling admin authority — not merely controlling the SME or
 treasury roles.
 
 If governance cannot produce a valid current-admin signature for
-`transfer_admin`, funds remain locked until off-chain legal or operational
-recovery restores signing capability. This is why single-signer production
-admins are prohibited.
+`propose_admin`, funds remain locked until off-chain legal or operational
+recovery restores signing capability. If a proposal was created with the wrong
+address, the current admin can overwrite it by calling `propose_admin` again.
+This is why single-signer production admins are prohibited.
 
 ---
 
 ## Admin rotation during a hold
 
-`transfer_admin` is not gated by the hold. This is intentional: if the current
-admin is compromised or unresponsive, governance must be able to rotate the
-admin key even while a hold is active. After rotation the new admin inherits
-the hold state and must explicitly call `clear_legal_hold` to unfreeze.
+`propose_admin` and `accept_admin` are not gated by the hold. This is
+intentional: if the current admin is compromised or unresponsive, governance
+must be able to rotate the admin key even while a hold is active. The handover
+still requires both the current admin and successor to authorize. After
+acceptance the new admin inherits the hold state and must explicitly call
+`clear_legal_hold` to unfreeze.
 
 ---
 
@@ -156,8 +163,8 @@ The matrix in `escrow/src/tests/legal_hold.rs` covers:
 5. Hold defaults to `false` after `init`.
 6. Hold persists across status transitions (no bypass via state change).
 7. Hold can be toggled and re-blocks operations after re-set.
-8. Hold persists after `admin transfer`; new admin must explicitly clear it.
+8. Hold persists after two-step admin handover; new admin must explicitly clear it.
 9. Edge cases: hold check fires before amount / status / auth validation.
-10. Non-gated ops (`update_maturity`, `transfer_admin`, getters) are not blocked.
+10. Non-gated ops (`update_maturity`, `propose_admin`, `accept_admin`, getters) are not blocked.
 11. Claim idempotency survives a hold toggle.
 12. Single hold toggle blocks all gated entrypoints in separate escrows.

--- a/docs/escrow-lifecycle.md
+++ b/docs/escrow-lifecycle.md
@@ -123,7 +123,8 @@ their principal:
 | `cancel_funding()` | Admin only |
 | `set_legal_hold()` | Admin only |
 | `update_maturity()` | Admin only |
-| `transfer_admin()` | Admin only |
+| `propose_admin()` | Admin only |
+| `accept_admin()` | Pending admin only |
 
 The SME role represents the off-chain settlement policy authority. The admin role
 handles on-chain configuration and compliance controls.

--- a/docs/escrow-security-checklist.md
+++ b/docs/escrow-security-checklist.md
@@ -13,7 +13,8 @@ Every state-mutating entrypoint and the identity required to authorize it.
 | Entrypoint | Required signer | Auth call site | Notes |
 |---|---|---|---|
 | `init` | `admin` (caller-supplied) | `admin.require_auth()` | One-time; panics if escrow exists |
-| `transfer_admin` | current `escrow.admin` | `escrow.admin.require_auth()` | `new_admin` must differ; overwrites stored admin |
+| `propose_admin` | current `escrow.admin` | `escrow.admin.require_auth()` | `new_admin` must differ; writes `DataKey::PendingAdmin` only |
+| `accept_admin` | `DataKey::PendingAdmin` | `pending.require_auth()` | Promotes pending address into `escrow.admin`; clears pending key |
 | `update_maturity` | `escrow.admin` | `escrow.admin.require_auth()` | Only in `status == 0` |
 | `update_funding_target` | `escrow.admin` | `escrow.admin.require_auth()` | Only in `status == 0`; `new_target >= funded_amount` |
 | `set_legal_hold` / `clear_legal_hold` | `escrow.admin` | `escrow.admin.require_auth()` | No timelock; no multisig enforced on-chain |
@@ -40,7 +41,7 @@ All `get_*` and `is_*` functions carry no `require_auth`. They expose full escro
 
 ### 2.1 Admin (`InvoiceEscrow::admin`)
 
-- Set at `init`; mutable only via `transfer_admin` (requires current admin signature).
+- Set at `init`; mutable only via `propose_admin` plus `accept_admin` (current admin and successor signatures).
 - Controls: hold activation, allowlist, attestation binding, maturity, funding target, schema migration (future).
 - **Risk**: a single EOA admin can indefinitely freeze funds via `set_legal_hold`. Production deployments **must** use a governed contract or multisig at this address. There is no on-chain escape hatch if the admin key is lost or malicious.
 
@@ -189,10 +190,11 @@ This creates a window where `funded_amount` > actual token balance (unfunded com
 There is no timelock, no council override, and no programmatic expiry. A
 compromised or malicious admin can freeze `settle`, `withdraw`,
 `claim_investor_payout`, and `sweep_terminal_dust` indefinitely. **Recovery:**
-governance executes `transfer_admin` (not blocked by the hold), then the new
-admin calls `clear_legal_hold`. See `docs/escrow-legal-hold.md` and ADR-004.
-Production deployments **must** use a governed admin (multisig or DAO) so a
-single lost key cannot strand funds without a documented rotation playbook.
+governance executes `propose_admin` and the successor executes `accept_admin`
+(both not blocked by the hold), then the new admin calls `clear_legal_hold`.
+See `docs/escrow-legal-hold.md` and ADR-004. Production deployments **must**
+use a governed admin (multisig or DAO) so a single lost key cannot strand funds
+without a documented rotation playbook.
 
 ### 5.4 Storage type mismatch: AllowlistActive vs. InvestorAllowlisted
 
@@ -204,10 +206,11 @@ single lost key cannot strand funds without a documented rotation playbook.
 
 ### 5.6 Admin key loss is unrecoverable without admin authority
 
-There is no guardian, recovery address, or protocol DAO escape hatch beyond
-`transfer_admin`. If **all** current-admin signers are lost while a legal hold
-is active, funds remain blocked until signing capability is restored off-chain.
-If at least one signer remains, rotate via `transfer_admin` then clear the hold.
+There is no guardian, recovery address, or protocol DAO escape hatch beyond the
+two-step admin handover. If **all** current-admin signers are lost while a legal
+hold is active, funds remain blocked until signing capability is restored
+off-chain. If at least one signer remains, rotate via `propose_admin` and
+`accept_admin`, then clear the hold.
 See `docs/escrow-legal-hold.md` § "Failure mode: hold + lost admin key".
 
 ### 5.7 Over-funding is intentional and unbound above the target
@@ -248,7 +251,8 @@ and does not weaken the auth boundary. Refactors must not move step 3 above step
 | Entrypoint | Signer | Pre-auth reads (no writes) | `require_auth` | First mutation |
 |---|---|---|---|---|
 | `init` | `admin` | — | line ~549 (`admin`) | `DataKey::Escrow` set |
-| `transfer_admin` | current `escrow.admin` | `get_escrow` | line ~1427 | `DataKey::Escrow` set |
+| `propose_admin` | current `escrow.admin` | `get_escrow` | line ~1888 | `DataKey::PendingAdmin` set |
+| `accept_admin` | `DataKey::PendingAdmin` | pending read, `get_escrow` after auth | line ~1917 | `DataKey::Escrow` set |
 | `update_maturity` | `escrow.admin` | `get_escrow` | line ~1400 | `DataKey::Escrow` set |
 | `update_funding_target` | `escrow.admin` | `get_escrow` | line ~1007 | `DataKey::Escrow` set |
 | `set_legal_hold` / `clear_legal_hold` | current `escrow.admin` | `get_escrow` | line ~940 | `DataKey::LegalHold` set |
@@ -271,7 +275,7 @@ Line numbers refer to `escrow/src/lib.rs` at schema version 5; re-audit after re
 | Entrypoint | Test location |
 |---|---|
 | `init` | `escrow/src/tests/init.rs` |
-| `transfer_admin`, `fund`, `fund_with_commitment`, `settle`, `withdraw`, `claim_investor_payout`, attestation, allowlist, sweep | `escrow/src/tests/admin.rs` § auth audit |
+| `propose_admin`, `accept_admin`, `fund`, `fund_with_commitment`, `settle`, `withdraw`, `claim_investor_payout`, attestation, allowlist, sweep | `escrow/src/tests/admin.rs` § auth audit |
 | `update_maturity`, `update_funding_target`, collateral | `escrow/src/tests/admin.rs` |
 | `set_legal_hold`, `clear_legal_hold` | `escrow/src/tests/legal_hold.rs` |
 | `bind_primary_attestation_hash`, `append_attestation_digest` | `escrow/src/tests/attestations.rs` |

--- a/docs/escrow-sim-stellar-cli.md
+++ b/docs/escrow-sim-stellar-cli.md
@@ -747,7 +747,7 @@ stellar contract invoke \
   --new_maturity 1767139200
 ```
 
-### `transfer_admin`
+### `propose_admin`
 
 **Auth required:** current `admin`.
 
@@ -758,8 +758,20 @@ stellar contract invoke \
   --id "$CONTRACT_ID" \
   --source admin \
   --network local \
-  -- transfer_admin \
+  -- propose_admin \
   --new_admin "$NEW_ADMIN"
+```
+
+### `accept_admin`
+
+**Auth required:** pending admin from `propose_admin`.
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source new_admin \
+  --network local \
+  -- accept_admin
 ```
 
 ### `sweep_terminal_dust`
@@ -884,7 +896,8 @@ for that address. For the common case where `--source` is the authorizing addres
 | `sweep_terminal_dust` | `treasury` | `treasury` |
 | `set_legal_hold` / `clear_legal_hold` | `admin` | `admin` |
 | `update_maturity` | `admin` | `admin` |
-| `transfer_admin` | `admin` (current) | `admin` |
+| `propose_admin` | `admin` (current) | `admin` |
+| `accept_admin` | pending admin | new admin |
 | `bind_primary_attestation_hash` | `admin` | `admin` |
 | `append_attestation_digest` | `admin` | `admin` |
 | `update_funding_target` | `admin` | `admin` |

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -38,10 +38,11 @@
 //! **Failure mode:** a hold plus loss of the current admin signing key leaves funds blocked
 //! on-chain until governance regains control of admin authority. There is no break-glass bypass.
 //!
-//! **Recovery lever:** [`LiquifactEscrow::transfer_admin`] is **not** gated by the hold.
-//! Governance rotates to a new admin, then the new admin clears the hold. Invariant: a hold
-//! is always clearable by whoever holds `InvoiceEscrow::admin`; recovery requires controlling
-//! that authority. See `docs/escrow-legal-hold.md` and [ADR-004](docs/adr/ADR-004-legal-hold.md).
+//! **Recovery lever:** [`LiquifactEscrow::propose_admin`] and
+//! [`LiquifactEscrow::accept_admin`] are **not** gated by the hold. Governance proposes a new
+//! admin, the proposed address accepts, then the new admin clears the hold. Invariant: a hold is
+//! always clearable by whoever holds `InvoiceEscrow::admin`; recovery requires controlling that
+//! authority. See `docs/escrow-legal-hold.md` and [ADR-004](docs/adr/ADR-004-legal-hold.md).
 //!
 //! ## Authorization guard ordering
 //!
@@ -150,20 +151,18 @@ pub const MAX_DUST_SWEEP_AMOUNT: i128 = 100_000_000;
 pub const MAX_INVOICE_ID_STRING_LEN: u32 = 32;
 
 /// Minimum instance storage TTL extension horizon for time-sensitive escrow entries.
-
 ///
 /// `bump_ttl` extends instance-storage entries to avoid rent/archival edge cases when
 /// maturity/claim locks are far in the future.
 ///
 /// Named as a constant so operators can reason about and audit the threshold.
-pub const INSTANCE_TTL_MIN_EXTENSION_SECS: u64 = 60 * 60; // 1h
+pub const INSTANCE_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 ledger/sec.
 
 /// Minimum persistent storage TTL extension horizon for per-investor allowlist entries.
 ///
 /// When the escrow uses the allowlist gate, investor funding depends on persistent entries.
 /// Extending persistent allowlist TTL reduces the risk of silent allowlist disablement.
-pub const PERSISTENT_TTL_MIN_EXTENSION_SECS: u64 = 60 * 60; // 1h
-
+pub const PERSISTENT_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 ledger/sec.
 
 // --- Storage keys ---
 
@@ -235,6 +234,9 @@ pub enum DataKey {
     /// Optional immutable per-investor cap on total principal credited to a single address.
     /// Absent ⇒ unlimited. Checked against [`DataKey::InvestorContribution`] on every deposit.
     MaxPerInvestorCap,
+    /// Proposed successor admin waiting for [`LiquifactEscrow::accept_admin`].
+    /// Absent ⇒ no pending handover. Cleared after successful acceptance.
+    PendingAdmin,
     /// Count of distinct investor addresses that have a non-zero [`DataKey::InvestorContribution`].
     /// Written as `0` at init; incremented once per new investor in `fund_impl`.
     UniqueFunderCount,
@@ -420,6 +422,16 @@ pub struct AdminTransferredEvent {
     #[topic]
     pub invoice_id: Symbol,
     pub new_admin: Address,
+}
+
+#[contractevent]
+pub struct AdminProposedEvent {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub current_admin: Address,
+    pub pending_admin: Address,
 }
 
 #[contractevent]
@@ -899,9 +911,15 @@ impl LiquifactEscrow {
     /// Optional cap on total principal for a single investor address.
     /// Absent ⇒ unlimited. Enforced on every deposit.
     pub fn get_max_per_investor_cap(env: Env) -> Option<i128> {
-        env.storage()
-            .instance()
-            .get(&DataKey::MaxPerInvestorCap)
+        env.storage().instance().get(&DataKey::MaxPerInvestorCap)
+    }
+
+    /// Proposed successor admin waiting to call [`LiquifactEscrow::accept_admin`].
+    ///
+    /// Returns [`None`] when no handover is pending. This is a read-only helper for governance
+    /// tooling and indexers; it performs no authorization.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::PendingAdmin)
     }
 
     /// Distinct funders counted so far (each address counted once when it first receives principal).
@@ -1118,12 +1136,14 @@ impl LiquifactEscrow {
     /// Set or clear compliance hold. Only the **current** [`InvoiceEscrow::admin`] may call.
     ///
     /// **Clearing:** always requires the current admin's authorization — there is no timelock,
-    /// council override, or break-glass entrypoint. After [`LiquifactEscrow::transfer_admin`],
-    /// only the **new** admin can clear a persisted hold.
+    /// council override, or break-glass entrypoint. After
+    /// [`LiquifactEscrow::propose_admin`] and [`LiquifactEscrow::accept_admin`], only the **new**
+    /// admin can clear a persisted hold.
     ///
     /// **Governance posture:** production `admin` must be a multisig or governed contract so
     /// hold + key loss cannot strand funds without an off-chain recovery vote that executes
-    /// `transfer_admin` then `clear_legal_hold`. See `docs/escrow-legal-hold.md`.
+    /// `propose_admin`, `accept_admin`, then `clear_legal_hold`. See
+    /// `docs/escrow-legal-hold.md`.
     pub fn set_legal_hold(env: Env, active: bool) {
         // env.clone(): env is used again after this call for storage set and publish.
         let escrow = Self::get_escrow(env.clone());
@@ -1195,7 +1215,7 @@ impl LiquifactEscrow {
         let n = investors.len();
         assert!(n > 0, "investors vector must be non-empty");
         assert!(
-            (n as u32) <= MAX_INVESTOR_ALLOWLIST_BATCH,
+            n <= MAX_INVESTOR_ALLOWLIST_BATCH,
             "investors vector length exceeds MAX_INVESTOR_ALLOWLIST_BATCH"
         );
 
@@ -1257,6 +1277,48 @@ impl LiquifactEscrow {
         .publish(&env);
 
         escrow
+    }
+
+    /// Lower the configured distinct-investor cap while the escrow is still open.
+    ///
+    /// This is admin-only and intentionally cannot raise a cap or impose one on an unlimited
+    /// escrow. Existing investors remain able to add principal after the cap is lowered; only new
+    /// investor addresses are blocked once `UniqueFunderCount >= new_cap`.
+    pub fn lower_max_unique_investors(env: Env, new_cap: u32) -> u32 {
+        let escrow = Self::get_escrow(env.clone());
+        escrow.admin.require_auth();
+
+        assert!(escrow.status == 0, "Cap can only be lowered in Open state");
+
+        let old_cap: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxUniqueInvestorsCap)
+            .unwrap_or_else(|| panic!("no investor cap configured"));
+        let unique_count = Self::get_unique_funder_count(env.clone());
+
+        assert!(
+            new_cap < old_cap,
+            "new cap must be strictly lower than current cap"
+        );
+        assert!(
+            new_cap >= unique_count,
+            "new cap cannot be below current unique funder count"
+        );
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxUniqueInvestorsCap, &new_cap);
+
+        MaxUniqueInvestorsCapLowered {
+            name: symbol_short!("inv_cap"),
+            invoice_id: escrow.invoice_id.clone(),
+            old_cap,
+            new_cap,
+        }
+        .publish(&env);
+
+        new_cap
     }
 
     /// Validate the stored schema version and apply a migration if one is implemented.
@@ -1483,9 +1545,6 @@ impl LiquifactEscrow {
             }
         }
 
-        let next_contribution = prev
-            .checked_add(amount)
-            .expect("investor contribution overflow");
         env.storage()
             .instance()
             .set(&contribution_key, &new_contribution);
@@ -1796,55 +1855,35 @@ impl LiquifactEscrow {
         // - docs/escrow-ledger-time.md: all gating uses `Env::ledger().timestamp()` with `>=`.
 
         // Instance storage keys required for settlement + gating behavior.
-        let k_escrow: DataKey = DataKey::Escrow;
-        env.storage().instance().extend_ttl(&k_escrow, &INSTANCE_TTL_MIN_EXTENSION_SECS);
+        env.storage().instance().extend_ttl(
+            INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
+            INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
+        );
 
-        let k_version: DataKey = DataKey::Version;
-        env.storage().instance().extend_ttl(&k_version, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        let k_legal_hold: DataKey = DataKey::LegalHold;
-        env.storage().instance().extend_ttl(&k_legal_hold, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        let k_allowlist_active: DataKey = DataKey::AllowlistActive;
-        env.storage()
-            .instance()
-            .extend_ttl(&k_allowlist_active, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        let k_snapshot: DataKey = DataKey::FundingCloseSnapshot;
-        env.storage()
-            .instance()
-            .extend_ttl(&k_snapshot, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        // Investor contribution + claim gates are instance keys (per investor).
-        // We cannot enumerate contributors on-chain; extend only what the caller provides.
-        for addr in allowlisted.iter() {
-            // Contribution + claim-gate entries are instance-scoped and per-investor.
-            let k_contrib = DataKey::InvestorContribution(addr.clone());
-            env.storage()
-                .instance()
-                .extend_ttl(&k_contrib, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-            let k_claim_not_before = DataKey::InvestorClaimNotBefore(addr.clone());
-            env.storage()
-                .instance()
-                .extend_ttl(&k_claim_not_before, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-        }
-
+        // Instance storage TTL is contract-wide under Soroban SDK 25. The call above covers
+        // Escrow, Version, LegalHold, PendingAdmin, and all per-investor instance keys.
 
         // Persistent allowlist entries.
         for addr in allowlisted.iter() {
             let k = DataKey::InvestorAllowlisted(addr.clone());
-            env.storage()
-                .persistent()
-                .extend_ttl(&k, &PERSISTENT_TTL_MIN_EXTENSION_SECS);
+            env.storage().persistent().extend_ttl(
+                &k,
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            );
         }
     }
 
-    pub fn transfer_admin(env: Env, new_admin: Address) -> InvoiceEscrow {
-        // env.clone(): env is used again after this call for storage set and publish.
-        let mut escrow = Self::get_escrow(env.clone());
-
-
+    /// Propose a successor admin for two-step governance handover.
+    ///
+    /// The current [`InvoiceEscrow::admin`] must authorize this call. The proposed address is stored
+    /// under [`DataKey::PendingAdmin`] and gains no authority until it calls
+    /// [`LiquifactEscrow::accept_admin`] with its own authorization. A later proposal overwrites the
+    /// pending address before acceptance.
+    ///
+    /// Panics when `new_admin` equals the current admin.
+    pub fn propose_admin(env: Env, new_admin: Address) -> Address {
+        let escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
         assert!(
@@ -1852,18 +1891,59 @@ impl LiquifactEscrow {
             "New admin must differ from current admin"
         );
 
-        escrow.admin = new_admin;
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingAdmin, &new_admin);
+
+        AdminProposedEvent {
+            name: symbol_short!("adm_prop"),
+            invoice_id: escrow.invoice_id.clone(),
+            current_admin: escrow.admin,
+            pending_admin: new_admin.clone(),
+        }
+        .publish(&env);
+
+        new_admin
+    }
+
+    /// Accept a pending admin handover.
+    ///
+    /// The address stored in [`DataKey::PendingAdmin`] must authorize this call. On success it is
+    /// promoted into [`InvoiceEscrow::admin`] and the pending key is cleared, so admin authority
+    /// changes only after both the current admin and successor have explicitly authorized.
+    pub fn accept_admin(env: Env) -> InvoiceEscrow {
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .unwrap_or_else(|| panic!("No pending admin"));
+        pending.require_auth();
+
+        let mut escrow = Self::get_escrow(env.clone());
+        escrow.admin = pending.clone();
 
         env.storage().instance().set(&DataKey::Escrow, &escrow);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
 
         AdminTransferredEvent {
             name: symbol_short!("admin"),
             invoice_id: escrow.invoice_id.clone(),
-            new_admin: escrow.admin.clone(),
+            new_admin: pending,
         }
         .publish(&env);
 
         escrow
+    }
+
+    /// Deprecated shim for the former one-step admin transfer API.
+    ///
+    /// This function now only proposes `new_admin` by delegating to
+    /// [`LiquifactEscrow::propose_admin`]. The proposed address must still call
+    /// [`LiquifactEscrow::accept_admin`] before admin authority changes.
+    #[deprecated(note = "use propose_admin followed by accept_admin")]
+    pub fn transfer_admin(env: Env, new_admin: Address) -> InvoiceEscrow {
+        Self::propose_admin(env.clone(), new_admin);
+        Self::get_escrow(env)
     }
 
     /// Transition an **open** escrow (status 0) to **cancelled** (status 4).

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -1,6 +1,9 @@
-use super::{LiquifactEscrow, LiquifactEscrowClient};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use super::{
+    AllowlistEnabledChanged, DataKey, InvestorAllowlistChanged, LiquifactEscrow,
+    LiquifactEscrowClient,
+};
 use soroban_sdk::Vec as SorobanVec;
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Event};
 
 fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
     let id = env.register(LiquifactEscrow, ());
@@ -25,7 +28,7 @@ fn init(env: &Env, client: &LiquifactEscrowClient) -> (Address, Address) {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     (admin, sme)
 }

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -109,7 +109,7 @@ pub fn default_init(client: &LiquifactEscrowClient<'_>, env: &Env, admin: &Addre
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -1,8 +1,8 @@
 use super::*;
-use crate::FundingTargetUpdated;
+use crate::{AdminProposedEvent, FundingTargetUpdated};
 use soroban_sdk::Event;
 
-// Admin/governance operations: target changes, maturity changes, admin transfer,
+// Admin/governance operations: target changes, maturity changes, admin handover,
 // legal hold, migration guards, and collateral metadata.
 
 #[test]
@@ -22,7 +22,7 @@ fn test_update_maturity_success() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let updated = client.update_maturity(&2000u64);
     assert_eq!(updated.maturity, 2000u64);
@@ -48,7 +48,7 @@ fn test_update_maturity_wrong_state() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.update_maturity(&2000u64);
@@ -75,14 +75,14 @@ fn test_update_maturity_unauthorized() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     env.mock_auths(&[]);
     client.update_maturity(&2000u64);
 }
 
 #[test]
-fn test_transfer_admin_updates_admin() {
+fn test_propose_admin_sets_pending_without_changing_admin() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
     let new_admin = Address::generate(&env);
@@ -99,16 +99,72 @@ fn test_transfer_admin_updates_admin() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
-    let updated = client.transfer_admin(&new_admin);
+    let pending = client.propose_admin(&new_admin);
+    assert_eq!(pending, new_admin);
+    assert_eq!(client.get_pending_admin(), Some(new_admin));
+    assert_eq!(client.get_escrow().admin, admin);
+}
+
+#[test]
+fn test_accept_admin_promotes_pending_and_clears_pending() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let new_admin = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TACPT1"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &1000u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    client.propose_admin(&new_admin);
+    let updated = client.accept_admin();
     assert_eq!(updated.admin, new_admin);
     assert_eq!(client.get_escrow().admin, new_admin);
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_transfer_admin_deprecated_shim_only_proposes() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let new_admin = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TSHIM1"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &1000u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let unchanged = client.transfer_admin(&new_admin);
+    assert_eq!(unchanged.admin, admin);
+    assert_eq!(client.get_pending_admin(), Some(new_admin));
 }
 
 #[test]
 #[should_panic(expected = "New admin must differ from current admin")]
-fn test_transfer_admin_same_address_panics() {
+fn test_propose_admin_same_address_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
     client.init(
@@ -124,19 +180,81 @@ fn test_transfer_admin_same_address_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
-    client.transfer_admin(&admin);
+    client.propose_admin(&admin);
 }
 
 #[test]
 #[should_panic(expected = "Escrow not initialized")]
-fn test_transfer_admin_uninitialized_panics() {
+fn test_propose_admin_uninitialized_panics() {
     let env = Env::default();
     env.mock_all_auths();
     let client = deploy(&env);
     let new_admin = Address::generate(&env);
-    client.transfer_admin(&new_admin);
+    client.propose_admin(&new_admin);
+}
+
+#[test]
+#[should_panic(expected = "No pending admin")]
+fn test_accept_admin_without_pending_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.accept_admin();
+}
+
+#[test]
+#[should_panic]
+fn test_accept_admin_requires_pending_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_admin = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.propose_admin(&new_admin);
+    env.mock_auths(&[]);
+    client.accept_admin();
+}
+
+#[test]
+fn test_propose_admin_overwrites_prior_pending() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let first = Address::generate(&env);
+    let second = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    client.propose_admin(&first);
+    client.propose_admin(&second);
+
+    assert_eq!(client.get_pending_admin(), Some(second.clone()));
+    let updated = client.accept_admin();
+    assert_eq!(updated.admin, second);
+}
+
+#[test]
+fn test_propose_admin_emits_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    let new_admin = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    client.propose_admin(&new_admin);
+
+    assert_eq!(
+        env.events().all().events().last().unwrap().clone(),
+        AdminProposedEvent {
+            name: symbol_short!("adm_prop"),
+            invoice_id: client.get_escrow().invoice_id,
+            current_admin: admin,
+            pending_admin: new_admin,
+        }
+        .to_xdr(&env, &contract_id)
+    );
 }
 
 #[test]
@@ -199,7 +317,7 @@ fn test_record_collateral_stored_and_does_not_block_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
     assert_eq!(c.amount, 5000i128);
@@ -229,7 +347,7 @@ fn test_collateral_zero_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
 }
@@ -252,7 +370,7 @@ fn test_collateral_requires_sme_auth() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     env.mock_auths(&[]);
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &100i128);
@@ -276,7 +394,7 @@ fn test_legal_hold_blocks_settle_withdraw_claim_and_fund() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &TARGET);
     client.set_legal_hold(&true);
@@ -327,7 +445,7 @@ fn test_legal_hold_blocks_new_funds_when_open() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.set_legal_hold(&true);
     client.fund(&investor, &1i128);
@@ -367,7 +485,7 @@ fn test_update_funding_target_by_admin_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let updated = client.update_funding_target(&10_000i128);
@@ -398,7 +516,7 @@ fn test_update_funding_target_by_non_admin_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     env.mock_auths(&[]);
@@ -430,7 +548,7 @@ fn test_update_funding_target_fails_when_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128);
     client.update_funding_target(&10_000i128);
@@ -461,7 +579,7 @@ fn test_update_funding_target_below_funded_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &4_000i128);
     client.update_funding_target(&3_000i128);
@@ -491,7 +609,7 @@ fn test_update_funding_target_zero_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.update_funding_target(&0i128);
 }
@@ -527,7 +645,7 @@ fn test_update_funding_target_event_fields() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_funding_target(&9_000i128);
@@ -571,7 +689,7 @@ fn test_update_funding_target_fails_when_settled() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.settle(); // status → 2 (settled)
@@ -605,7 +723,7 @@ fn test_update_funding_target_fails_when_withdrawn() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.withdraw(); // status → 3 (withdrawn)
@@ -639,7 +757,7 @@ fn test_update_funding_target_equal_to_funded_amount_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
 
@@ -675,7 +793,7 @@ fn test_update_funding_target_negative_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.update_funding_target(&-1i128);
 }
@@ -712,7 +830,7 @@ fn test_update_maturity_event_fields() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_maturity(&2000u64);
@@ -756,7 +874,7 @@ fn test_update_maturity_fails_when_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.update_maturity(&2000u64);
@@ -789,7 +907,7 @@ fn test_update_maturity_fails_when_settled() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1
     client.settle(); // status → 2
@@ -823,7 +941,7 @@ fn test_update_maturity_fails_when_withdrawn() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1
     client.withdraw(); // status → 3
@@ -855,7 +973,7 @@ fn test_update_maturity_to_zero_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let updated = client.update_maturity(&0u64);
     assert_eq!(updated.maturity, 0u64);
@@ -889,7 +1007,7 @@ fn test_settle_passes_exactly_at_maturity_ledger_time() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128);
 
@@ -926,7 +1044,7 @@ fn test_settle_fails_one_second_before_maturity() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128);
 
@@ -960,7 +1078,7 @@ fn test_update_maturity_twice_overwrites() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_maturity(&2000u64);
@@ -996,12 +1114,22 @@ fn auth_audit_init_funded(
 
 #[test]
 #[should_panic]
-fn auth_audit_transfer_admin_requires_current_admin() {
+fn auth_audit_propose_admin_requires_current_admin() {
     let env = Env::default();
     let (client, _, _, _, _) = auth_audit_init_funded(&env);
     let new_admin = Address::generate(&env);
     env.mock_auths(&[]);
-    client.transfer_admin(&new_admin);
+    client.propose_admin(&new_admin);
+}
+
+#[test]
+#[should_panic]
+fn auth_audit_accept_admin_requires_pending_admin() {
+    let env = Env::default();
+    let (client, _, _, _, pending_admin) = auth_audit_init_funded(&env);
+    client.propose_admin(&pending_admin);
+    env.mock_auths(&[]);
+    client.accept_admin();
 }
 
 #[test]
@@ -1122,6 +1250,7 @@ fn auth_audit_sweep_terminal_dust_requires_treasury() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{AdminProposedEvent, FundingTargetUpdated};
+use crate::{AdminProposedEvent, EscrowCloseSnapshot, FundingTargetUpdated};
 use soroban_sdk::Event;
 
 // Admin/governance operations: target changes, maturity changes, admin handover,
@@ -297,6 +297,40 @@ fn test_migrate_from_zero_uninitialized_panics() {
     let client = deploy(&env);
     // Uninitialized storage returns version 0; migrate(0) hits the no-path branch.
     client.migrate(&0u32);
+}
+
+#[test]
+fn test_read_model_summary_includes_optional_admin_fields() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let funding_token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TSUM01"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &1000u64,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &Some(100i128),
+        &Some(7u32),
+        &Some(10_000i128),
+    );
+
+    let summary = client.get_escrow_summary();
+
+    assert_eq!(summary.escrow, client.get_escrow());
+    assert_eq!(summary.legal_hold, client.get_legal_hold());
+    assert_eq!(summary.funding_close_snapshot, EscrowCloseSnapshot::None);
+    assert_eq!(summary.unique_funder_count, 0);
+    assert!(!summary.is_allowlist_active);
+    assert_eq!(summary.schema_version, client.get_version());
+    assert_eq!(client.get_max_per_investor_cap(), Some(10_000i128));
 }
 
 #[test]

--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -26,7 +26,7 @@ fn test_unique_funder_count_basic_functionality() {
         &None,
         &None,
         &Some(3u32),
-        &None
+        &None,
     );
 
     // Verify initial state
@@ -77,7 +77,7 @@ fn test_cap_enforcement_blocks_excess_investors() {
         &None,
         &None,
         &Some(2u32),
-        &None
+        &None,
     );
 
     // Add two investors — reaches the investor cap but NOT the funding target.
@@ -115,7 +115,7 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &Some(1u32),
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -156,7 +156,7 @@ fn test_no_cap_allows_unlimited_investors() {
         &None,
         &None,
         &None, // No distinct-investor cap set
-        &None
+        &None,
     );
 
     assert_eq!(client.get_max_unique_investors_cap(), None);
@@ -194,7 +194,7 @@ fn test_max_per_investor_cap_blocks_excess_principal() {
         &None,
         &None,
         &Some(2u32),
-        &Some(50_000_000_000i128)
+        &Some(50_000_000_000i128),
     );
 
     let inv1 = Address::generate(&env);
@@ -227,7 +227,7 @@ fn test_init_zero_max_per_investor_panics() {
         &None,
         &None,
         &Some(2u32),
-        &Some(0i128)
+        &Some(0i128),
     );
 }
 
@@ -260,7 +260,7 @@ fn test_cap_with_fund_with_commitment() {
         &Some(tiers),
         &None,
         &Some(2u32),
-        &None
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -303,6 +303,7 @@ fn test_lower_max_unique_investors_success() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -338,6 +339,7 @@ fn test_lower_cap_blocks_new_investors_at_lowered_limit() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &20_000_000_000i128);
@@ -368,6 +370,7 @@ fn test_lower_cap_existing_investors_may_refund() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -403,6 +406,7 @@ fn test_lower_cap_rejects_raise() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     client.lower_max_unique_investors(&4u32);
@@ -430,6 +434,7 @@ fn test_lower_cap_rejects_below_funder_count() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10_000_000_000i128);
@@ -460,6 +465,7 @@ fn test_lower_cap_rejects_non_open_state() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100_000_000_000i128);
@@ -489,6 +495,7 @@ fn test_lower_cap_rejects_unlimited_escrow() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.lower_max_unique_investors(&10u32);
@@ -515,6 +522,7 @@ fn test_lower_cap_requires_admin_auth() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     client.lower_max_unique_investors(&3u32);
@@ -546,6 +554,7 @@ fn test_lower_cap_unauthorized_panics() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     env.mock_auths(&[]);
@@ -576,6 +585,7 @@ fn test_lower_cap_emits_event() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10_000_000_000i128);

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -1,6 +1,6 @@
 use crate::{
     test::{free_addresses, setup},
-    DataKey, YieldTier, EscrowSummary, EscrowCloseSnapshot,
+    DataKey, EscrowCloseSnapshot, EscrowSummary, YieldTier,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -36,7 +36,7 @@ fn test_migrate_already_current() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.migrate(&5);
@@ -63,7 +63,7 @@ fn test_migrate_no_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     env.as_contract(&client.address, || {
@@ -74,7 +74,7 @@ fn test_migrate_no_path() {
 }
 
 #[test]
-fn test_admin_and_maturity_updates() {
+fn test_admin_handover_and_maturity_updates() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin, sme) = setup(&env);
@@ -93,15 +93,21 @@ fn test_admin_and_maturity_updates() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let updated = client.update_maturity(&200);
     assert_eq!(updated.maturity, 200);
 
     let new_admin = Address::generate(&env);
-    let updated = client.transfer_admin(&new_admin);
+    let pending = client.propose_admin(&new_admin);
+    assert_eq!(pending, new_admin);
+    assert_eq!(client.get_escrow().admin, admin);
+    assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+
+    let updated = client.accept_admin();
     assert_eq!(updated.admin, new_admin);
+    assert_eq!(client.get_pending_admin(), None);
 }
 
 #[test]
@@ -125,7 +131,7 @@ fn test_update_maturity_not_open() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -135,7 +141,7 @@ fn test_update_maturity_not_open() {
 
 #[test]
 #[should_panic(expected = "New admin must differ from current admin")]
-fn test_transfer_admin_same_admin() {
+fn test_propose_admin_same_admin() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin, sme) = setup(&env);
@@ -154,10 +160,10 @@ fn test_transfer_admin_same_admin() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
-    client.transfer_admin(&admin);
+    client.propose_admin(&admin);
 }
 
 #[test]
@@ -686,6 +692,8 @@ fn test_sme_collateral_empty_asset_rejected() {
         &None,
         &None,
         &None,
+
+        &None,
     );
     let empty_asset = soroban_sdk::Symbol::new(&env, "");
     client.record_sme_collateral_commitment(&empty_asset, &5000);
@@ -710,6 +718,8 @@ fn test_sme_collateral_stale_timestamp_rejected() {
         &treasury,
         &None,
         &None,
+        &None,
+
         &None,
     );
 
@@ -740,6 +750,8 @@ fn test_sme_collateral_replacement_preserves_prior_amount() {
         &treasury,
         &None,
         &None,
+        &None,
+
         &None,
     );
 
@@ -1219,6 +1231,8 @@ fn test_get_escrow_summary_happy_path() {
         &None,
         &None,
         &None,
+
+        &None,
     );
 
     let summary = client.get_escrow_summary();
@@ -1263,6 +1277,8 @@ fn test_get_escrow_summary_after_state_changes() {
         &treasury,
         &None,
         &None,
+        &None,
+
         &None,
     );
 

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -20,7 +20,7 @@ fn test_fund_and_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let funded = client.fund(&investor, &TARGET);
     assert_eq!(funded.funded_amount, TARGET);
@@ -47,7 +47,7 @@ fn test_fund_partial_then_full() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let partial = client.fund(&investor, &(TARGET / 2));
     assert_eq!(partial.status, 0);
@@ -109,7 +109,7 @@ fn test_single_investor_contribution_tracked() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(30_000_000_000i128));
     let contribution = client.get_contribution(&investor);
@@ -145,7 +145,7 @@ fn test_repeated_funding_accumulates_contribution() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(20_000_000_000i128));
     client.fund(&investor, &(30_000_000_000i128));
@@ -158,6 +158,7 @@ fn test_funding_amount_accumulation_overflow_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
     let investor = Address::generate(&env);
+    let investor_b = Address::generate(&env);
     client.init(
         &admin,
         &String::from_str(&env, "OVF001"),
@@ -171,11 +172,11 @@ fn test_funding_amount_accumulation_overflow_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &(i128::MAX - 1));
-    client.fund(&investor, &2i128);
+    client.fund(&investor_b, &2i128);
 }
 
 #[test]
@@ -196,7 +197,7 @@ fn test_funding_amount_overflow_does_not_mutate_state() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &(i128::MAX - 1));
@@ -233,6 +234,7 @@ fn test_fund_with_commitment_overflow_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&investor_a, &(i128::MAX - 1));
@@ -255,6 +257,7 @@ fn test_fund_with_commitment_overflow_does_not_mutate_state() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -305,6 +308,7 @@ fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     env.as_contract(&contract_id, || {
@@ -345,6 +349,7 @@ fn test_investor_contribution_overflow_does_not_mutate_state() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -393,7 +398,7 @@ fn test_multiple_investors_tracked_independently() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
@@ -427,7 +432,7 @@ fn test_contributions_sum_equals_funded_amount() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
@@ -456,7 +461,7 @@ fn test_cost_baseline_fund_partial() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(10_000_000_000i128));
 }
@@ -479,7 +484,7 @@ fn test_cost_baseline_fund_full() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &TARGET);
 }
@@ -502,7 +507,7 @@ fn test_cost_baseline_fund_overshoot() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(150_000_000_000i128));
     assert_eq!(client.get_escrow().status, 1);
@@ -526,7 +531,7 @@ fn test_cost_baseline_fund_two_step_completion() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(TARGET / 2));
     client.fund(&investor, &(TARGET / 2));
@@ -555,7 +560,7 @@ fn test_funding_close_snapshot_captures_overfunded_total_once() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_funding_close_snapshot(), None);
     client.fund(&inv, &(TARGET + 50_000_000_000i128));
@@ -589,7 +594,7 @@ fn test_funding_snapshot_immutable_across_second_fund_after_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&a, &(TARGET / 2));
     assert_eq!(client.get_funding_close_snapshot(), None);
@@ -623,7 +628,7 @@ fn test_pro_rata_weight_ratio_from_snapshot() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&a, &(20_000_000_000i128));
     client.fund(&b, &(80_000_000_000i128));
@@ -665,7 +670,7 @@ fn test_tiered_yield_and_follow_on_fund() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &5_000i128, &200u64);
     assert_eq!(client.get_investor_yield_bps(&inv), 900);
@@ -703,7 +708,7 @@ fn test_tier_selection_edges_base_vs_high_bucket() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&i_short, &10_000i128, &40u64);
     assert_eq!(client.get_investor_yield_bps(&i_short), 800);
@@ -739,7 +744,7 @@ fn test_fund_with_commitment_twice_panics() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
@@ -768,7 +773,7 @@ fn test_fund_then_fund_with_commitment_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv, &5_000i128);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
@@ -806,7 +811,7 @@ fn test_tier_selection_ladder() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     let inv_base = Address::generate(&env);
@@ -860,7 +865,7 @@ fn test_fund_with_commitment_zero_lock_behaves_as_fund() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&inv, &5_000i128, &0u64);
@@ -893,7 +898,7 @@ fn test_commitment_claim_time_allows_u64_max_boundary() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&investor, &100i128, &5u64);
@@ -927,7 +932,7 @@ fn test_commitment_claim_time_overflow_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&investor, &100i128, &6u64);
@@ -958,7 +963,7 @@ fn test_commitment_claim_time_overflow_does_not_record_position() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -1002,7 +1007,7 @@ fn test_init_bad_tier_order_panics() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1033,7 +1038,7 @@ fn test_init_tier_yield_below_base_panics() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1060,7 +1065,7 @@ fn test_differential_funding_target_eq_exact_cross() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let escrow = client.fund(&inv, &t);
     assert_eq!(escrow.funded_amount, t);
@@ -1092,7 +1097,7 @@ fn test_ledger_sequence_recorded_in_snapshot_with_tick() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let seq = env.ledger().sequence();
     client.fund(&inv, &1_000i128);
@@ -1122,7 +1127,7 @@ fn test_get_funding_close_snapshot_absent_before_any_funding() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(
         client.get_funding_close_snapshot(),
@@ -1154,7 +1159,7 @@ fn test_get_funding_close_snapshot_present_after_funding_completes() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     // Partial fund — snapshot still absent.
     client.fund(&inv, &(TARGET / 2));
@@ -1197,7 +1202,7 @@ fn test_get_funding_close_snapshot_immutable_after_set() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     // Fund exactly to target — snapshot is written here.
     client.fund(&inv, &TARGET);
@@ -1234,7 +1239,7 @@ fn test_unique_funder_count_initialized_to_zero() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_unique_funder_count(), 0);
 }
@@ -1257,7 +1262,7 @@ fn test_unique_funder_count_increments_on_first_investor() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_unique_funder_count(), 0);
     client.fund(&investor, &(TARGET / 2));
@@ -1286,7 +1291,7 @@ fn test_unique_funder_count_increments_for_distinct_investors() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_unique_funder_count(), 0);
 
@@ -1330,7 +1335,7 @@ fn test_unique_funder_count_with_fund_with_commitment() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -1361,6 +1366,7 @@ fn test_max_unique_investors_cap_none_allows_unlimited() {
         &None,
         &None,
         &None, // No cap set
+        &None,
     );
 
     // Should be able to add many investors when no cap is set
@@ -1389,6 +1395,7 @@ fn test_max_unique_investors_cap_enforced_at_limit() {
         &None,
         &None,
         &Some(3u32), // Cap of 3 investors
+        &None,
     );
 
     assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
@@ -1430,6 +1437,7 @@ fn test_max_unique_investors_cap_blocks_excess_investors() {
         &None,
         &None,
         &Some(2u32), // Cap of 2 investors
+        &None,
     );
 
     // Add 2 investors
@@ -1472,6 +1480,7 @@ fn test_max_unique_investors_cap_blocks_fund_with_commitment() {
         &Some(tiers),
         &None,
         &Some(1u32), // Cap of 1 investor
+        &None,
     );
 
     // First investor succeeds
@@ -1502,6 +1511,7 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &Some(1u32), // Cap of 1 investor
+        &None,
     );
 
     // First fund should succeed
@@ -1536,6 +1546,7 @@ fn test_zero_contribution_then_non_zero_contribution_counts_as_unique_investor()
         &None,
         &None,
         &Some(2u32), // Cap of 2 investors
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -1567,6 +1578,7 @@ fn test_cap_validation_at_init_positive_value_required() {
         &None,
         &None,
         &Some(0u32), // Invalid: zero cap
+        &None,
     );
 }
 
@@ -1588,6 +1600,7 @@ fn test_init_panics_for_zero_cap() {
         &None,
         &None,
         &Some(0u32), // Invalid: zero cap
+        &None,
     );
 }
 
@@ -1609,6 +1622,7 @@ fn test_cap_edge_case_exact_limit_reached() {
         &None,
         &None,
         &Some(5u32), // Cap of 5 investors
+        &None,
     );
 
     // Add exactly 5 investors - should all succeed
@@ -1644,6 +1658,7 @@ fn test_cap_edge_case_exactly_one_over_limit_panics() {
         &None,
         &None,
         &Some(5u32), // Cap of 5 investors
+        &None,
     );
 
     // Add exactly 5 investors
@@ -1675,6 +1690,7 @@ fn test_cap_with_min_contribution_floor_interaction() {
         &None,
         &Some(1_000i128), // Min contribution floor
         &Some(3u32),      // Cap of 3 investors
+        &None,
     );
 
     // Should respect both cap and floor
@@ -1714,6 +1730,7 @@ fn test_cap_blocks_even_with_large_contribution() {
         &None,
         &None,
         &Some(1u32), // Cap of 1 investor
+        &None,
     );
 
     // First investor can fund large amount
@@ -1748,7 +1765,7 @@ fn test_cap_panic_message_quality() {
         &None,
         &None,
         &Some(1u32),
-        &None
+        &None,
     );
 
     // Add first investor
@@ -1783,6 +1800,7 @@ fn init_with_token<'a>(
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -21,7 +21,7 @@ fn test_init_stores_escrow() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(escrow.invoice_id, symbol_short!("INV001"));
     assert_eq!(escrow.admin, admin);
@@ -51,7 +51,7 @@ fn test_init_stores_keyed_invoice_and_lists_it() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let got = client.get_escrow();
     assert_eq!(got, escrow);
@@ -74,7 +74,7 @@ fn test_init_requires_admin_auth() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert!(
         env.auths().iter().any(|(addr, _)| *addr == admin),
@@ -102,7 +102,7 @@ fn test_init_unauthorized_panics() {
             &None,
             &None,
             &None,
-            &None
+            &None,
         );
     }));
     assert!(result.is_err(), "Expected panic without auth");
@@ -142,7 +142,7 @@ fn test_cost_baseline_init() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -163,7 +163,7 @@ fn test_cost_baseline_init_zero_maturity() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -184,7 +184,7 @@ fn test_cost_baseline_init_max_amount() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -210,7 +210,7 @@ fn test_init_invoice_id_empty_string_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -236,7 +236,7 @@ fn test_init_invoice_id_whitespace_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -263,7 +263,7 @@ fn test_init_invoice_id_too_long_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -289,7 +289,7 @@ fn test_init_invoice_id_bad_charset_hyphen_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -316,7 +316,7 @@ fn test_init_stores_registry_some_and_getters() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_registry_ref(), Some(reg));
     assert_eq!(client.get_funding_token(), token);
@@ -347,7 +347,7 @@ fn test_init_min_contribution_floor_stored() {
         &None,
         &Some(1_000i128),
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_min_contribution_floor(), 1_000i128);
 }
@@ -374,7 +374,7 @@ fn test_init_min_contribution_floor_defaults_to_zero() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_min_contribution_floor(), 0i128);
 }
@@ -402,7 +402,7 @@ fn test_init_min_contribution_zero_panics() {
         &None,
         &Some(0i128),
         &None,
-        &None
+        &None,
     );
 }
 
@@ -429,7 +429,7 @@ fn test_init_min_contribution_exceeds_amount_panics() {
         &None,
         &Some(1_001i128),
         &None,
-        &None
+        &None,
     );
 }
 
@@ -455,7 +455,7 @@ fn test_init_min_contribution_equal_to_amount_accepted() {
         &None,
         &Some(5_000i128),
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_min_contribution_floor(), 5_000i128);
 }
@@ -505,7 +505,7 @@ fn test_init_registry_none_roundtrip() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_registry_ref(), None);
 }
@@ -534,6 +534,7 @@ fn test_init_escrow_initialized_event_includes_bound_refs() {
         &token,
         &Some(registry.clone()),
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -578,6 +579,7 @@ fn test_init_escrow_initialized_event_registry_none() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(
@@ -618,7 +620,7 @@ fn try_init_with_id(env: &Env, id: &str) -> Result<(), ()> {
             &None,
             &None,
             &None,
-            &None
+            &None,
         );
     }));
     result.map(|_| ()).map_err(|_| ())
@@ -664,7 +666,7 @@ fn test_invoice_id_length_33_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -58,7 +58,7 @@ fn test_legal_hold_midflow_blocks_and_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     // Funding starts normally.
@@ -174,6 +174,7 @@ fn test_escrow_gold_standard_happy_path_open_overfund_snapshot_settle_claim() {
         &None, // No yield tiers for simplicity
         &None, // No min contribution floor
         &None, // No max investors cap
+        &None,
     );
 
     let initial_escrow = client.get_escrow();
@@ -400,7 +401,7 @@ fn test_escrow_tiered_yield_with_commitment_locks() {
         &Some(yield_tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor_base = Address::generate(&env);
@@ -526,7 +527,7 @@ fn test_collateral_record_is_metadata_only_and_does_not_invoke_token_contract() 
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
@@ -755,7 +756,7 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     // Initial funding succeeds while hold is off.

--- a/escrow/src/tests/legal_hold.rs
+++ b/escrow/src/tests/legal_hold.rs
@@ -7,7 +7,7 @@
 //! Edge-case tests verify:
 //!   - Hold check fires before status validation (fund, settle, withdraw)
 //!   - Idempotent toggling (set true→true, clear false→false)
-//!   - Non-gated operations (`update_maturity`, `transfer_admin`, getters) are NOT blocked
+//!   - Non-gated operations (`update_maturity`, admin handover, getters) are NOT blocked
 //!   - Claim idempotency survives a hold toggle
 //!   - A single hold toggle blocks all gated ops in separate escrows
 //!
@@ -48,7 +48,7 @@ fn init_open(
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     (token, treasury)
 }
@@ -93,7 +93,7 @@ fn init_settled<'a>(
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(investor, &TARGET);
     client.settle();
@@ -394,18 +394,19 @@ fn hold_can_be_toggled_and_re_blocks_operations() {
     assert!(client.is_investor_claimed(&investor));
 }
 
-/// Admin transfer does not grant the new admin a free bypass: the hold persists
+/// Admin handover does not grant the new admin a free bypass: the hold persists
 /// and the new admin must explicitly clear it.
 #[test]
-fn hold_persists_after_admin_transfer() {
+fn hold_persists_after_admin_handover() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
     let investor = Address::generate(&env);
     let new_admin = Address::generate(&env);
     init_funded(&client, &env, &admin, &sme, &investor, "LHX003");
     client.set_legal_hold(&true);
-    client.transfer_admin(&new_admin);
-    // Hold is still active after admin rotation.
+    client.propose_admin(&new_admin);
+    client.accept_admin();
+    // Hold is still active after admin handover.
     assert!(client.get_legal_hold());
     // settle is still blocked.
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -413,7 +414,7 @@ fn hold_persists_after_admin_transfer() {
     }));
     assert!(
         result.is_err(),
-        "settle must remain blocked after admin transfer"
+        "settle must remain blocked after admin handover"
     );
     // New admin clears the hold.
     client.clear_legal_hold();
@@ -509,7 +510,7 @@ fn clear_legal_hold_when_already_false_is_idempotent() {
 
 // ── 13. Non-gated operations are NOT blocked by hold ─────────────────────────
 
-/// `update_maturity`, `transfer_admin`, and getters must all work under hold.
+/// `update_maturity`, admin handover, and getters must all work under hold.
 #[test]
 fn non_risk_operations_not_blocked_by_hold() {
     let env = Env::default();
@@ -529,11 +530,14 @@ fn non_risk_operations_not_blocked_by_hold() {
     let updated = client.update_maturity(&9999u64);
     assert_eq!(updated.maturity, 9999u64);
 
-    // `transfer_admin` must not be blocked.
+    // Two-step admin handover must not be blocked.
     let new_admin = Address::generate(&env);
-    client.transfer_admin(&new_admin);
+    client.propose_admin(&new_admin);
+    assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+    client.accept_admin();
     let escrow = client.get_escrow();
     assert_eq!(escrow.admin, new_admin);
+    assert_eq!(client.get_pending_admin(), None);
 }
 
 // ── 14. Re-entrancy / double-spend: claim idempotent after hold cleared ───────

--- a/escrow/src/tests/properties.rs
+++ b/escrow/src/tests/properties.rs
@@ -115,7 +115,7 @@ fn prop_status_transitions_open_to_funded_only() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let initial = client.get_escrow();
@@ -152,7 +152,7 @@ fn prop_status_settle_transition() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -187,7 +187,7 @@ fn prop_status_withdraw_transition() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -226,7 +226,7 @@ fn prop_no_regression_from_funded_status() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -263,7 +263,7 @@ fn prop_no_regression_after_withdraw() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -298,7 +298,7 @@ fn prop_settled_is_terminal_for_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -331,7 +331,7 @@ fn prop_withdrawn_is_terminal_for_withdraw() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -364,7 +364,7 @@ fn prop_status_invariant_all_states_valid_range() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     assert!(client.get_escrow().status == 0);
@@ -403,7 +403,7 @@ fn prop_funded_amount_sum_of_contributions() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -452,7 +452,7 @@ fn prop_funded_amount_respects_funding_target() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let fund_amount = target + excess;
@@ -489,7 +489,7 @@ fn prop_funded_amount_non_decreasing_across_multiple_funders() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let amt1: i128 = 50_000_000_000i128;
@@ -540,7 +540,7 @@ fn prop_funded_amount_equals_contribution_sum_for_funded_escrow() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let amounts: [i128; 3] = [50_000_000_000i128, 100_000_000_000i128, 50_000_000_000i128];
@@ -657,7 +657,7 @@ fn fuzz_multi_investor_fund_ordering_snapshot_once_only() {
             &None,
             &None,
             &None,
-            &None
+            &None,
         );
 
         // Randomize investor count/order and positive amounts. Keep the sequence small so

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -264,7 +264,7 @@ fn test_claim_investor_twice_is_idempotent() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -298,7 +298,7 @@ fn test_claim_by_non_investor_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     // Escrow settled but stranger never funded
     let investor = Address::generate(&env);
@@ -327,7 +327,7 @@ fn test_clashing_investors_have_independent_claims() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &1_000i128);
     client.fund(&inv_b, &1_000i128);
@@ -410,7 +410,7 @@ fn test_claim_blocked_until_commitment_ledger_time() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &1_000i128, &500u64);
     client.settle();
@@ -439,7 +439,7 @@ fn test_claim_succeeds_after_commitment_and_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &1_000i128, &100u64);
     client.settle();
@@ -473,7 +473,7 @@ fn test_claim_gating_exact_timestamp() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let lock_duration = 500u64;
@@ -521,7 +521,7 @@ fn test_claim_gating_with_multiple_investors() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&inv1, &1_000i128, &100u64); // Expiry 1100
@@ -564,7 +564,7 @@ fn test_cost_baseline_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &TARGET);
     env.ledger().set_timestamp(1001);
@@ -615,7 +615,7 @@ fn settle_with_maturity_zero_succeeds_immediately() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     fund_to_target(&client, &env);
@@ -651,7 +651,7 @@ fn settle_at_maturity_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     fund_to_target(&client, &env);
@@ -784,7 +784,7 @@ fn test_sweep_terminal_dust_after_settle_transfers_to_treasury() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let investor = Address::generate(&env);
     client.fund(&investor, &1_000i128);
@@ -821,7 +821,7 @@ fn test_sweep_terminal_dust_after_withdraw_and_ledger_tick() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let investor = Address::generate(&env);
     client.fund(&investor, &1_000i128);
@@ -856,7 +856,7 @@ fn test_sweep_rejected_when_open() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -883,7 +883,7 @@ fn test_sweep_blocked_under_legal_hold() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -912,7 +912,7 @@ fn test_sweep_rejects_amount_above_dust_cap() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     // status == 1 (funded), not settled — must panic
@@ -940,7 +940,7 @@ fn test_sweep_caps_at_contract_balance() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -966,7 +966,7 @@ fn test_sweep_requires_treasury_auth() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     fund_to_target(&client, &env);
     client.settle();
@@ -1080,7 +1080,7 @@ fn test_is_investor_claimed_false_before_any_claim() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1108,7 +1108,7 @@ fn test_is_investor_claimed_returns_false_for_unfunded_address() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1134,7 +1134,7 @@ fn test_claim_marker_persists_after_claim() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1163,7 +1163,7 @@ fn test_claim_marker_isolated_per_investor() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor_a, &1_000i128);
     client.fund(&investor_b, &1_000i128);
@@ -1195,7 +1195,7 @@ fn test_claim_marker_all_investors_independent() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &1_000i128);
     client.fund(&inv_b, &1_000i128);
@@ -1345,6 +1345,7 @@ fn compute_payout_returns_zero_before_snapshot() {
         &None,
         &None,
         &None,
+        &None,
     );
     // Deposit below target — no snapshot written yet.
     client.fund(&investor, &1i128);
@@ -1376,6 +1377,7 @@ fn compute_payout_single_investor_full_target() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1414,6 +1416,7 @@ fn compute_payout_two_equal_investors() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&inv_a, &1_000i128);
     client.fund(&inv_b, &1_000i128);
@@ -1449,6 +1452,7 @@ fn compute_payout_aggregate_does_not_exceed_settle_pool() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1497,6 +1501,7 @@ fn compute_payout_floor_rounding_unequal_split() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&inv_a, &2i128);
     client.fund(&inv_b, &1i128);
@@ -1532,6 +1537,7 @@ fn compute_payout_zero_yield_equals_principal() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&inv, &5_000i128);
     client.settle();
@@ -1563,6 +1569,7 @@ fn compute_payout_with_over_funding() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1607,6 +1614,7 @@ fn claim_dedupe_single_read_happy_path() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1645,6 +1653,7 @@ fn claim_dedupe_stranger_still_rejected() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1673,6 +1682,7 @@ fn claim_dedupe_hold_still_blocks() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,


### PR DESCRIPTION
## Summary
- Adds `propose_admin` and `accept_admin` for two-step admin handover.
- Stores proposed successor in `DataKey::PendingAdmin` until the successor accepts.
- Keeps `transfer_admin` as a deprecated shim that only creates a pending proposal.
- Clears `PendingAdmin` after successful acceptance.
- Updates ADR/security/operator docs for the new auth boundary.

## Security Notes
- Admin authority changes only after both current admin and proposed admin authorize.
- Self-proposal is rejected.
- Wrong pending admin can be overwritten by a new proposal before acceptance.
- Legal hold does not block handover, but remains active after acceptance.

## Tests
- `cargo fmt --check`
- `cargo check -p liquifact_escrow`
- `cargo clippy -p liquifact_escrow --all-targets -- -D warnings`
- `cargo test`

Result: `332 passed; 0 failed; 14 ignored`


close #246 