### PR TITLE
feat(escrow): introduce typed contracterror codes

### DIFF
--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -1,83 +1,117 @@
-# Liquifact Escrow Error Messages
+# Liquifact Escrow Typed Error Codes
 
-This document catalogs the panic messages emitted by the Liquifact Escrow contract. These messages are intended for developers and SDK authors to help diagnose transaction failures.
+LiquiFact escrow emits typed Soroban contract errors through `EscrowError`. Clients should branch
+on the numeric `ContractError(code)` value, not on panic strings or diagnostic text.
 
-> [!IMPORTANT]
-> In Soroban, contract panics abort the entire transaction. The string messages provided in `assert!` and `panic!` calls are visible in transaction simulation and diagnostic events.
+## Stability Policy
 
-## 📋 Message Catalog
+Error codes are append-only. Once a code is assigned, it must not be renamed for a different
+meaning, reused, or renumbered. New failures must receive new codes after the existing range.
 
-### Initialization (`init`)
-| Message | Rationale |
-|---------|-----------|
-| `Amount must be positive` | The base invoice amount must be > 0. |
-| `yield_bps must be between 0 and 10_000` | Yield must be in the range 0% - 100%. |
-| `Escrow already initialized` | `init` was called on a contract instance that already has state. |
-| `min_contribution must be positive when configured` | If a floor is set, it must be > 0. |
-| `min_contribution cannot exceed initial invoice amount` | The floor cannot be higher than the target. |
-| `max_unique_investors must be positive when configured` | If an investor cap is set, it must be > 0. |
-| `invoice_id length must be 1..=32` | The invoice string identifier is too long or empty. |
-| `invoice_id must be [A-Za-z0-9_] only` | The identifier contains invalid characters for a Soroban Symbol. |
+Legacy panic messages are listed only to help integrators migrate old simulations and logs.
 
-### Funding (`fund` / `fund_with_commitment`)
-| Message | Rationale |
-|---------|-----------|
-| `Funding amount must be positive` | Investors cannot deposit 0 or negative amounts. |
-| `funding amount below min_contribution floor` | The deposit does not meet the minimum required amount. |
-| `Legal hold blocks new funding while active` | The admin has frozen the escrow for compliance reasons. |
-| `Escrow not open for funding` | The escrow is already funded, settled, or withdrawn. |
-| `Investor not on allowlist` | The allowlist is active and the caller is not permitted to fund. |
-| `unique investor cap reached` | The maximum number of distinct investor addresses has been reached. |
-| `Additional principal after a tiered first deposit must use fund()` | Once a tier is selected via commitment, subsequent deposits must use the simple `fund` method. |
+## Canonical Code Table
 
-### Settlement & Withdrawal
-| Message | Rationale |
-|---------|-----------|
-| `Legal hold blocks settlement finalization` | Settlement cannot proceed during a compliance hold. |
-| `Escrow must be funded before settlement` | Cannot settle an invoice that hasn't met its funding target. |
-| `Escrow has not yet reached maturity` | The ledger timestamp is earlier than the configured `maturity`. |
-| `Legal hold blocks SME withdrawal` | SME cannot pull funds during a compliance hold. |
-| `Escrow must be funded before withdrawal` | SME can only withdraw funds after the status is `Funded`. |
+| Code | Variant | Legacy failure |
+| ---: | --- | --- |
+| 1 | `AmountMustBePositive` | `Amount must be positive` |
+| 2 | `YieldBpsOutOfRange` | `yield_bps must be between 0 and 10_000` |
+| 3 | `EscrowAlreadyInitialized` | `Escrow already initialized` |
+| 4 | `InvoiceIdInvalidLength` | `invoice_id length must be 1..=MAX_INVOICE_ID_STRING_LEN` |
+| 5 | `InvoiceIdInvalidCharset` | `invoice_id must be [A-Za-z0-9_] only` |
+| 6 | `MinContributionNotPositive` | `min_contribution must be positive when configured` |
+| 7 | `MinContributionExceedsAmount` | `min_contribution cannot exceed initial invoice amount / target hint` |
+| 8 | `MaxUniqueInvestorsNotPositive` | `max_unique_investors must be positive when configured` |
+| 9 | `MaxPerInvestorNotPositive` | `max_per_investor must be positive when configured` |
+| 10 | `TierYieldOutOfRange` | `tier yield_bps must be 0..=10_000` |
+| 11 | `TierYieldBelowBase` | `tier yield_bps must be >= base yield_bps` |
+| 12 | `TierLockNotIncreasing` | `tiers must have strictly increasing min_lock_secs` |
+| 13 | `TierYieldNotNonDecreasing` | `tiers must have non-decreasing yield_bps` |
+| 20 | `EscrowNotInitialized` | `Escrow not initialized` |
+| 21 | `FundingTokenNotSet` | `Funding token not set` |
+| 22 | `TreasuryNotSet` | `Treasury not set` |
+| 30 | `LegalHoldBlocksTreasuryDustSweep` | `Legal hold blocks treasury dust sweep` |
+| 31 | `SweepAmountNotPositive` | `sweep amount must be positive` |
+| 32 | `SweepAmountExceedsMax` | `sweep amount exceeds MAX_DUST_SWEEP_AMOUNT` |
+| 33 | `DustSweepNotTerminal` | `dust sweep only in terminal states` |
+| 34 | `NoFundingTokenBalanceToSweep` | `no funding token balance to sweep` |
+| 35 | `EffectiveSweepAmountZero` | `effective sweep amount is zero` |
+| 36 | `TransferAmountNotPositive` | `transfer amount must be positive` |
+| 37 | `InsufficientTokenBalanceBeforeTransfer` | `insufficient token balance before transfer` |
+| 38 | `SenderBalanceUnderflow` | `balance underflow on sender` |
+| 39 | `RecipientBalanceUnderflow` | `balance underflow on recipient` |
+| 40 | `SenderBalanceDeltaMismatch` | `sender balance delta must equal transfer amount` |
+| 41 | `RecipientBalanceDeltaMismatch` | `recipient balance delta must equal transfer amount` |
+| 50 | `PrimaryAttestationAlreadyBound` | `primary attestation already bound` |
+| 51 | `AttestationAppendLogCapacityReached` | `attestation append log capacity reached` |
+| 60 | `CollateralAmountNotPositive` | `Collateral amount must be positive` |
+| 61 | `CollateralAssetEmpty` | `Collateral asset symbol must not be empty` |
+| 62 | `CollateralTimestampBackwards` | `Collateral commitment timestamp must not go backward` |
+| 70 | `InvestorBatchEmpty` | `investors vector must be non-empty` |
+| 71 | `InvestorBatchTooLarge` | `investors vector length exceeds MAX_INVESTOR_ALLOWLIST_BATCH` |
+| 72 | `TargetNotPositive` | `Target must be strictly positive` |
+| 73 | `TargetUpdateNotOpen` | `Target can only be updated in Open state` |
+| 74 | `TargetBelowFundedAmount` | `Target cannot be less than already funded amount` |
+| 75 | `CapLowerNotOpen` | `Cap can only be lowered in Open state` |
+| 76 | `NoInvestorCapConfigured` | `no investor cap configured` |
+| 77 | `NewCapNotLower` | `new cap must be strictly lower than current cap` |
+| 78 | `NewCapBelowCurrentFunderCount` | `new cap cannot be below current unique funder count` |
+| 79 | `MaturityUpdateNotOpen` | `Maturity can only be updated in Open state` |
+| 80 | `NewAdminSameAsCurrent` | `New admin must differ from current admin` |
+| 90 | `MigrationVersionMismatch` | `from_version does not match stored version` |
+| 91 | `AlreadyCurrentSchemaVersion` | `Already at current schema version` |
+| 92 | `NoMigrationPath` | `No migration path from version 0 - extend migrate or redeploy` |
+| 100 | `FundingAmountNotPositive` | `Funding amount must be positive` |
+| 101 | `FundingBelowMinContribution` | `funding amount below min_contribution floor` |
+| 102 | `LegalHoldBlocksFunding` | `Legal hold blocks new funding while active` |
+| 103 | `EscrowNotOpenForFunding` | `Escrow not open for funding` |
+| 104 | `InvestorNotAllowlisted` | `Investor not on allowlist` |
+| 105 | `InvestorContributionOverflow` | `investor contribution overflow` |
+| 106 | `InvestorContributionExceedsCap` | `investor contribution exceeds max_per_investor cap` |
+| 107 | `UniqueInvestorCapReached` | `unique investor cap reached` |
+| 108 | `TieredSecondDeposit` | `Additional principal after a tiered first deposit must use fund()` |
+| 109 | `InvestorClaimTimeOverflow` | `investor claim time overflow` |
+| 110 | `FundedAmountOverflow` | `funded_amount overflow` |
+| 120 | `LegalHoldBlocksSettlement` | `Legal hold blocks settlement finalization` |
+| 121 | `SettlementNotFunded` | `Escrow must be funded before settlement` |
+| 122 | `MaturityNotReached` | `Escrow has not yet reached maturity` |
+| 123 | `LegalHoldBlocksWithdrawal` | `Legal hold blocks SME withdrawal` |
+| 124 | `WithdrawalNotFunded` | `Escrow must be funded before withdrawal` |
+| 125 | `LegalHoldBlocksInvestorClaims` | `Legal hold blocks investor claims` |
+| 126 | `NoContributionToClaim` | `Address has no contribution to claim` |
+| 127 | `InvestorClaimNotSettled` | `Escrow must be settled before investor claim` |
+| 128 | `InvestorCommitmentLockNotExpired` | `Investor commitment lock not expired` |
+| 129 | `ComputePayoutArithmeticOverflow` | `compute_investor_payout: arithmetic overflow` |
+| 140 | `LegalHoldBlocksCancelFunding` | `Legal hold blocks cancel_funding` |
+| 141 | `CancelFundingNotOpen` | `cancel_funding only allowed in Open state` |
+| 142 | `RefundNotCancelled` | `refund only allowed in Cancelled state` |
+| 143 | `NoContributionToRefund` | `no contribution to refund` |
 
-### Payout Claims (`claim_investor_payout`)
-| Message | Rationale |
-|---------|-----------|
-| `Legal hold blocks investor claims` | Payouts are frozen during a compliance hold. |
-| `Address has no contribution to claim` | The caller never participated in this escrow. |
-| `Escrow must be settled before investor claim` | Payouts only happen after the `Settled` state is reached. |
-| `Investor commitment lock not expired` | The investor's specific lock period (from tiered yield) has not elapsed. |
+## Client Guidance
 
-### Administrative & Compliance
-| Message | Rationale |
-|---------|-----------|
-| `Target must be strictly positive` | Funding target update must be > 0. |
-| `Target can only be updated in Open state` | Cannot change the target once funding has completed. |
-| `Target cannot be less than already funded amount` | Cannot lower the target below what has already been committed. |
-| `primary attestation already bound` | The primary audit hash is immutable once set. |
-| `attestation append log capacity reached` | The append-only log has reached its limit (32 entries). |
-| `New admin must differ from current admin` | Transferring admin to the same address is rejected. |
+In tests and SDK simulations, `try_*` clients surface typed traps as contract errors. For example,
+`FundingAmountNotPositive` is observable as `ContractError(100)` / `Error(Contract, #100)`.
 
-### Token & External Calls
-| Message | Rationale |
-|---------|-----------|
-| `insufficient token balance before transfer` | The contract does not have enough tokens to perform the transfer. |
-| `sender balance delta must equal transfer amount` | Detected a fee-on-transfer or non-compliant token. |
-| `recipient balance delta must equal transfer amount` | Detected a malicious or non-compliant token. |
+Recommended SDK mappings:
 
----
+| Codes | Suggested client category |
+| --- | --- |
+| 1-13 | Invalid initialization or pricing configuration |
+| 20-22 | Missing initialized escrow metadata |
+| 30-41 | Dust sweep or token integration failure |
+| 50-62 | Attestation or collateral metadata failure |
+| 70-80 | Administrative validation failure |
+| 90-92 | Migration failure |
+| 100-110 | Funding failure |
+| 120-129 | Settlement, withdrawal, or investor payout failure |
+| 140-143 | Cancellation or refund failure |
 
-## 🛠️ Guidance for SDK Authors
+## Security Notes
 
-### Error Mapping
-SDKs should catch these strings from the `diagnostic_events` or the `error` field of the transaction simulation. It is recommended to map common failures to user-friendly enums:
-
-- `Legal hold active` -> `Error::ComplianceHold`
-- `Escrow not open` -> `Error::InvalidState`
-- `amount below floor` -> `Error::InsufficientAmount`
-
-### Stability Policy
-Panic messages marked with a 📋 in this catalog are considered part of the **Integration Contract**. While logic may evolve, these strings will remain stable within the same major schema version to avoid breaking off-chain error handlers.
-
-### Recovery Suggestions
-- **Legal Hold**: Direct the user to contact the platform admin or check the `LegalHoldChanged` event history.
-- **Maturity**: Verify the `maturity` field from `get_escrow` against the current ledger time before submitting a `settle` transaction.
+- Auth boundaries from ADR-002 remain unchanged. Typed errors do not replace `require_auth`.
+- Overflow-sensitive paths use checked arithmetic and map each overflow to a stable code.
+- Dust sweep and refund transfers keep balance-delta checks at the external token boundary.
+- Refund uses checks-effects-interactions by zeroing contribution before transfer to prevent
+  double-spend. Investor payout remains idempotent after the claim marker is written.
+- Storage TTL behavior is unchanged by the error migration; `bump_ttl` still extends contract
+  instance storage and persistent allowlist entries.

--- a/escrow/src/external_calls.rs
+++ b/escrow/src/external_calls.rs
@@ -66,6 +66,7 @@
 //! Security takeaway: this is not relying on "non-reentrancy" as a magic property. It enforces
 //! post-call accounting invariants at the external-call boundary where token behavior is observed.
 
+use crate::{ensure, fail, EscrowError};
 use soroban_sdk::{token::TokenClient, Address, Env, MuxedAddress};
 
 /// Transfer `amount` of `token_addr` from `from` (typically this escrow contract) to `treasury`,
@@ -91,20 +92,17 @@ use soroban_sdk::{token::TokenClient, Address, Env, MuxedAddress};
 /// * `treasury` - Address receiving the tokens
 /// * `amount` - Amount to transfer (must be positive)
 ///
-/// # Panics
+/// # Errors
 ///
-/// - If `amount` is not positive
-/// - If sender has insufficient balance before transfer
-/// - If sender balance delta does not equal `amount` (fee-on-transfer detection)
-/// - If recipient balance delta does not equal `amount` (malicious token detection)
-/// - If balance underflow occurs during delta calculation
+/// Emits typed [`EscrowError`] codes if `amount` is not positive, sender balance is insufficient,
+/// balance deltas do not equal `amount`, or balance delta calculation underflows.
 ///
 /// # Security Considerations
 ///
 /// This function assumes the token contract follows standard SEP-41 semantics without
 /// fee-on-transfer, rebasing, or hook behaviors. Non-compliant tokens will cause this
-/// function to panic, serving as a safety boundary. Such tokens should be excluded through
-/// governance allowlists and integration review processes.
+/// function to fail with a typed error, serving as a safety boundary. Such tokens should be
+/// excluded through governance allowlists and integration review processes.
 pub fn transfer_funding_token_with_balance_checks(
     env: &Env,
     token_addr: &Address,
@@ -112,13 +110,14 @@ pub fn transfer_funding_token_with_balance_checks(
     treasury: &Address,
     amount: i128,
 ) {
-    assert!(amount > 0, "transfer amount must be positive");
+    ensure(env, amount > 0, EscrowError::TransferAmountNotPositive);
     let token = TokenClient::new(env, token_addr);
     let from_before = token.balance(from);
     let treasury_before = token.balance(treasury);
-    assert!(
+    ensure(
+        env,
         from_before >= amount,
-        "insufficient token balance before transfer"
+        EscrowError::InsufficientTokenBalanceBeforeTransfer,
     );
 
     token.transfer(from, MuxedAddress::from(treasury.clone()), &amount);
@@ -128,17 +127,19 @@ pub fn transfer_funding_token_with_balance_checks(
 
     let spent = from_before
         .checked_sub(from_after)
-        .expect("balance underflow on sender");
+        .unwrap_or_else(|| fail(env, EscrowError::SenderBalanceUnderflow));
     let received = treasury_after
         .checked_sub(treasury_before)
-        .expect("balance underflow on recipient");
+        .unwrap_or_else(|| fail(env, EscrowError::RecipientBalanceUnderflow));
 
-    assert_eq!(
-        spent, amount,
-        "sender balance delta must equal transfer amount (check fee-on-transfer / malicious token)"
+    ensure(
+        env,
+        spent == amount,
+        EscrowError::SenderBalanceDeltaMismatch,
     );
-    assert_eq!(
-        received, amount,
-        "recipient balance delta must equal transfer amount (check fee-on-transfer / malicious token)"
+    ensure(
+        env,
+        received == amount,
+        EscrowError::RecipientBalanceDeltaMismatch,
     );
 }

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -13,9 +13,10 @@
 //! The constant [`SCHEMA_VERSION`] is written to [`DataKey::Version`] by [`LiquifactEscrow::init`]
 //! and is the canonical source of truth for upgrade decisions. **Current value: 5.**
 //!
-//! [`LiquifactEscrow::migrate`] **panics in all current execution paths** — no silent migration
-//! work is promised or performed. Operators must extend `migrate` before calling it, or redeploy
-//! when stored struct layout changes. See `docs/OPERATOR_RUNBOOK.md` for the full decision tree.
+//! [`LiquifactEscrow::migrate`] **fails with typed errors in all current execution paths** — no
+//! silent migration work is promised or performed. Operators must extend `migrate` before calling
+//! it, or redeploy when stored struct layout changes. See `docs/OPERATOR_RUNBOOK.md` for the full
+//! decision tree.
 //!
 //! ## SME collateral commitment metadata
 //!
@@ -75,11 +76,11 @@
 //!
 //! [`LiquifactEscrow::sweep_terminal_dust`] moves at most [`MAX_DUST_SWEEP_AMOUNT`] units of the
 //! bound funding token from this contract to the immutable **treasury** address, only when the
-//! escrow has reached a **terminal** [`InvoiceEscrow::status`] (settled or withdrawn). It cannot run
-//! during a legal hold. Transfers go through [`crate::external_calls`] so **pre/post token balances**
-//! must match the requested amount (standard SEP-41 behavior); fee-on-transfer or malicious tokens
-//! are **explicitly out of scope** and will cause safe-failure panics at the balance-check boundary.
-//! This is meant for rounding residue / stray transfers, not for settling live liabilities —
+//! escrow has reached a **terminal** [`InvoiceEscrow::status`] (settled, withdrawn, or cancelled).
+//! It cannot run during a legal hold. Transfers go through [`crate::external_calls`] so **pre/post
+//! token balances** must match the requested amount (standard SEP-41 behavior); fee-on-transfer or
+//! malicious tokens are **explicitly out of scope** and fail with typed errors at the balance-check
+//! boundary. This is meant for rounding residue / stray transfers, not for settling live liabilities —
 //! integrations that custody principal on-chain must keep token balances reconciled with
 //! `funded_amount` so treasury sweeps cannot pull user funds.
 //!
@@ -113,8 +114,8 @@ extern crate std;
 
 use core::{clone::Clone, default::Default};
 use soroban_sdk::{
-    contract, contractevent, contractimpl, contracttype, symbol_short, token::TokenClient, Address,
-    BytesN, Env, String, Symbol, Vec,
+    contract, contracterror, contractevent, contractimpl, contracttype, panic_with_error,
+    symbol_short, token::TokenClient, Address, BytesN, Env, String, Symbol, Vec,
 };
 
 pub mod external_calls;
@@ -150,20 +151,121 @@ pub const MAX_DUST_SWEEP_AMOUNT: i128 = 100_000_000;
 pub const MAX_INVOICE_ID_STRING_LEN: u32 = 32;
 
 /// Minimum instance storage TTL extension horizon for time-sensitive escrow entries.
-
 ///
 /// `bump_ttl` extends instance-storage entries to avoid rent/archival edge cases when
 /// maturity/claim locks are far in the future.
 ///
 /// Named as a constant so operators can reason about and audit the threshold.
-pub const INSTANCE_TTL_MIN_EXTENSION_SECS: u64 = 60 * 60; // 1h
+pub const INSTANCE_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 ledger/sec.
 
 /// Minimum persistent storage TTL extension horizon for per-investor allowlist entries.
 ///
 /// When the escrow uses the allowlist gate, investor funding depends on persistent entries.
 /// Extending persistent allowlist TTL reduces the risk of silent allowlist disablement.
-pub const PERSISTENT_TTL_MIN_EXTENSION_SECS: u64 = 60 * 60; // 1h
+pub const PERSISTENT_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 ledger/sec.
 
+/// Stable typed errors emitted by LiquiFact escrow entrypoints.
+///
+/// Codes are append-only: never reuse or renumber a variant. Client SDKs should branch on the
+/// numeric code rather than legacy panic strings. See `docs/escrow-error-messages.md`.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum EscrowError {
+    AmountMustBePositive = 1,
+    YieldBpsOutOfRange = 2,
+    EscrowAlreadyInitialized = 3,
+    InvoiceIdInvalidLength = 4,
+    InvoiceIdInvalidCharset = 5,
+    MinContributionNotPositive = 6,
+    MinContributionExceedsAmount = 7,
+    MaxUniqueInvestorsNotPositive = 8,
+    MaxPerInvestorNotPositive = 9,
+    TierYieldOutOfRange = 10,
+    TierYieldBelowBase = 11,
+    TierLockNotIncreasing = 12,
+    TierYieldNotNonDecreasing = 13,
+
+    EscrowNotInitialized = 20,
+    FundingTokenNotSet = 21,
+    TreasuryNotSet = 22,
+
+    LegalHoldBlocksTreasuryDustSweep = 30,
+    SweepAmountNotPositive = 31,
+    SweepAmountExceedsMax = 32,
+    DustSweepNotTerminal = 33,
+    NoFundingTokenBalanceToSweep = 34,
+    EffectiveSweepAmountZero = 35,
+    TransferAmountNotPositive = 36,
+    InsufficientTokenBalanceBeforeTransfer = 37,
+    SenderBalanceUnderflow = 38,
+    RecipientBalanceUnderflow = 39,
+    SenderBalanceDeltaMismatch = 40,
+    RecipientBalanceDeltaMismatch = 41,
+
+    PrimaryAttestationAlreadyBound = 50,
+    AttestationAppendLogCapacityReached = 51,
+
+    CollateralAmountNotPositive = 60,
+    CollateralAssetEmpty = 61,
+    CollateralTimestampBackwards = 62,
+
+    InvestorBatchEmpty = 70,
+    InvestorBatchTooLarge = 71,
+    TargetNotPositive = 72,
+    TargetUpdateNotOpen = 73,
+    TargetBelowFundedAmount = 74,
+    CapLowerNotOpen = 75,
+    NoInvestorCapConfigured = 76,
+    NewCapNotLower = 77,
+    NewCapBelowCurrentFunderCount = 78,
+    MaturityUpdateNotOpen = 79,
+    NewAdminSameAsCurrent = 80,
+
+    MigrationVersionMismatch = 90,
+    AlreadyCurrentSchemaVersion = 91,
+    NoMigrationPath = 92,
+
+    FundingAmountNotPositive = 100,
+    FundingBelowMinContribution = 101,
+    LegalHoldBlocksFunding = 102,
+    EscrowNotOpenForFunding = 103,
+    InvestorNotAllowlisted = 104,
+    InvestorContributionOverflow = 105,
+    InvestorContributionExceedsCap = 106,
+    UniqueInvestorCapReached = 107,
+    TieredSecondDeposit = 108,
+    InvestorClaimTimeOverflow = 109,
+    FundedAmountOverflow = 110,
+
+    LegalHoldBlocksSettlement = 120,
+    SettlementNotFunded = 121,
+    MaturityNotReached = 122,
+    LegalHoldBlocksWithdrawal = 123,
+    WithdrawalNotFunded = 124,
+    LegalHoldBlocksInvestorClaims = 125,
+    NoContributionToClaim = 126,
+    InvestorClaimNotSettled = 127,
+    InvestorCommitmentLockNotExpired = 128,
+    ComputePayoutArithmeticOverflow = 129,
+
+    LegalHoldBlocksCancelFunding = 140,
+    CancelFundingNotOpen = 141,
+    RefundNotCancelled = 142,
+    NoContributionToRefund = 143,
+}
+
+#[inline(always)]
+pub(crate) fn fail(env: &Env, error: EscrowError) -> ! {
+    panic_with_error!(env, error)
+}
+
+#[inline(always)]
+pub(crate) fn ensure(env: &Env, condition: bool, error: EscrowError) {
+    if !condition {
+        fail(env, error);
+    }
+}
 
 // --- Storage keys ---
 
@@ -202,7 +304,7 @@ pub enum DataKey {
     /// Absent when no commitment has been recorded. Replaceable by the SME.
     SmeCollateralPledge,
     /// Set to `true` when an investor has exercised a claim after settlement.
-    /// Absent ⇒ `false`. Written once; a second claim panics.
+    /// Absent ⇒ `false`. Written once; a second claim returns without re-emitting.
     InvestorClaimed(Address),
     /// SEP-41 funding asset for this invoice instance; set once in [`LiquifactEscrow::init`].
     /// Immutable after init.
@@ -549,9 +651,10 @@ pub struct LiquifactEscrow;
 
 fn validate_invoice_id_string(env: &Env, invoice_id: &String) -> Symbol {
     let len = invoice_id.len();
-    assert!(
+    ensure(
+        env,
         (1..=MAX_INVOICE_ID_STRING_LEN).contains(&len),
-        "invoice_id length must be 1..=MAX_INVOICE_ID_STRING_LEN"
+        EscrowError::InvoiceIdInvalidLength,
     );
     let len_u = len as usize;
     let mut buf = [0u8; 32];
@@ -559,12 +662,10 @@ fn validate_invoice_id_string(env: &Env, invoice_id: &String) -> Symbol {
     for &b in &buf[..len_u] {
         let ok =
             b.is_ascii_uppercase() || b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_';
-        assert!(
-            ok,
-            "invoice_id must be [A-Za-z0-9_] only (Soroban Symbol charset subset)"
-        );
+        ensure(env, ok, EscrowError::InvoiceIdInvalidCharset);
     }
-    let s = core::str::from_utf8(&buf[..len_u]).expect("invoice_id ascii");
+    let s = core::str::from_utf8(&buf[..len_u])
+        .unwrap_or_else(|_| fail(env, EscrowError::InvoiceIdInvalidCharset));
     Symbol::new(env, s)
 }
 
@@ -577,7 +678,7 @@ impl LiquifactEscrow {
             .unwrap_or(false)
     }
 
-    fn validate_yield_tiers_table(tiers: &Option<Vec<YieldTier>>, base_yield: i64) {
+    fn validate_yield_tiers_table(env: &Env, tiers: &Option<Vec<YieldTier>>, base_yield: i64) {
         let Some(tiers) = tiers else {
             return;
         };
@@ -587,23 +688,27 @@ impl LiquifactEscrow {
         let n = tiers.len();
         for i in 0..n {
             let t = tiers.get(i).unwrap();
-            assert!(
+            ensure(
+                env,
                 (0..=10_000).contains(&t.yield_bps),
-                "tier yield_bps must be 0..=10_000"
+                EscrowError::TierYieldOutOfRange,
             );
-            assert!(
+            ensure(
+                env,
                 t.yield_bps >= base_yield,
-                "tier yield_bps must be >= base yield_bps"
+                EscrowError::TierYieldBelowBase,
             );
             if i > 0 {
                 let p = tiers.get(i - 1).unwrap();
-                assert!(
+                ensure(
+                    env,
                     t.min_lock_secs > p.min_lock_secs,
-                    "tiers must have strictly increasing min_lock_secs"
+                    EscrowError::TierLockNotIncreasing,
                 );
-                assert!(
+                ensure(
+                    env,
                     t.yield_bps >= p.yield_bps,
-                    "tiers must have non-decreasing yield_bps"
+                    EscrowError::TierYieldNotNonDecreasing,
                 );
             }
         }
@@ -643,9 +748,9 @@ impl LiquifactEscrow {
     /// `invoice_id` must satisfy [`MAX_INVOICE_ID_STRING_LEN`] and charset rules (see
     /// [`validate_invoice_id_string`]).
     ///
-    /// # Panics
-    /// If `amount` or implied target is not positive, `yield_bps > 10_000`, invoice id invalid,
-    /// or escrow exists.
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes for invalid amounts, yield bounds, invoice id validation,
+    /// duplicate initialization, malformed optional caps, and invalid tier configuration.
     pub fn init(
         env: Env,
         admin: Address,
@@ -664,17 +769,19 @@ impl LiquifactEscrow {
     ) -> InvoiceEscrow {
         admin.require_auth();
 
-        assert!(amount > 0, "Amount must be positive");
-        assert!(
+        ensure(&env, amount > 0, EscrowError::AmountMustBePositive);
+        ensure(
+            &env,
             (0..=10_000).contains(&yield_bps),
-            "yield_bps must be between 0 and 10_000"
+            EscrowError::YieldBpsOutOfRange,
         );
-        assert!(
+        ensure(
+            &env,
             !env.storage().instance().has(&DataKey::Escrow),
-            "Escrow already initialized"
+            EscrowError::EscrowAlreadyInitialized,
         );
 
-        Self::validate_yield_tiers_table(&yield_tiers, yield_bps);
+        Self::validate_yield_tiers_table(&env, &yield_tiers, yield_bps);
 
         let invoice_sym = validate_invoice_id_string(&env, &invoice_id);
 
@@ -711,13 +818,11 @@ impl LiquifactEscrow {
 
         let floor = min_contribution.unwrap_or(0);
         if min_contribution.is_some() {
-            assert!(
-                floor > 0,
-                "min_contribution must be positive when configured"
-            );
-            assert!(
+            ensure(&env, floor > 0, EscrowError::MinContributionNotPositive);
+            ensure(
+                &env,
                 floor <= amount,
-                "min_contribution cannot exceed initial invoice amount / target hint"
+                EscrowError::MinContributionExceedsAmount,
             );
         }
         env.storage()
@@ -729,17 +834,14 @@ impl LiquifactEscrow {
             .set(&DataKey::UniqueFunderCount, &0u32);
 
         if let Some(cap) = max_per_investor {
-            assert!(cap > 0, "max_per_investor must be positive when configured");
+            ensure(&env, cap > 0, EscrowError::MaxPerInvestorNotPositive);
             env.storage()
                 .instance()
                 .set(&DataKey::MaxPerInvestorCap, &cap);
         }
 
         if let Some(cap) = max_unique_investors {
-            assert!(
-                cap > 0,
-                "max_unique_investors must be positive when configured"
-            );
+            ensure(&env, cap > 0, EscrowError::MaxUniqueInvestorsNotPositive);
             env.storage()
                 .instance()
                 .set(&DataKey::MaxUniqueInvestorsCap, &cap);
@@ -760,23 +862,25 @@ impl LiquifactEscrow {
 
     /// Returns the SEP-41 funding token bound at [`LiquifactEscrow::init`] ([`DataKey::FundingToken`]).
     ///
-    /// **Immutable:** set once at init; cannot change after deploy. Panics if called before init.
+    /// **Immutable:** set once at init; cannot change after deploy. Emits
+    /// [`EscrowError::FundingTokenNotSet`] if called before init.
     pub fn get_funding_token(env: Env) -> Address {
         env.storage()
             .instance()
             .get(&DataKey::FundingToken)
-            .unwrap_or_else(|| panic!("Funding token not set"))
+            .unwrap_or_else(|| fail(&env, EscrowError::FundingTokenNotSet))
     }
 
     /// Returns the protocol treasury address bound at [`LiquifactEscrow::init`] ([`DataKey::Treasury`]).
     ///
     /// **Immutable:** set once at init; cannot change after deploy. The treasury is the only
-    /// recipient of [`LiquifactEscrow::sweep_terminal_dust`]. Panics if called before init.
+    /// recipient of [`LiquifactEscrow::sweep_terminal_dust`]. Emits
+    /// [`EscrowError::TreasuryNotSet`] if called before init.
     pub fn get_treasury(env: Env) -> Address {
         env.storage()
             .instance()
             .get(&DataKey::Treasury)
-            .unwrap_or_else(|| panic!("Treasury not set"))
+            .unwrap_or_else(|| fail(&env, EscrowError::TreasuryNotSet))
     }
 
     /// Returns the optional off-chain registry hint stored at [`DataKey::RegistryRef`], or [`None`]
@@ -793,51 +897,59 @@ impl LiquifactEscrow {
     /// from this contract to [`DataKey::Treasury`].
     ///
     /// # Terminal state requirement
-    /// Only permitted when [`InvoiceEscrow::status`] is **2 (settled)** or **3 (withdrawn)**.
-    /// Open (0) or funded (1) states reject the call so live principal cannot be swept as dust.
+    /// Only permitted when [`InvoiceEscrow::status`] is **2 (settled)**, **3 (withdrawn)**, or
+    /// **4 (cancelled)**. Open (0) or funded (1) states reject the call so live principal cannot
+    /// be swept as dust.
     ///
     /// # Authorization
     /// The configured **treasury** account must authorize this call; the admin cannot sweep unless
     /// it is also the treasury.
     ///
     /// Blocked while [`DataKey::LegalHold`] is active.
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes for legal hold, invalid sweep amount, non-terminal state,
+    /// missing initialized addresses, empty balances, and token transfer invariant failures.
     pub fn sweep_terminal_dust(env: Env, amount: i128) -> i128 {
-        assert!(
+        ensure(
+            &env,
             !Self::legal_hold_active(&env),
-            "Legal hold blocks treasury dust sweep"
+            EscrowError::LegalHoldBlocksTreasuryDustSweep,
         );
-        assert!(amount > 0, "sweep amount must be positive");
-        assert!(
+        ensure(&env, amount > 0, EscrowError::SweepAmountNotPositive);
+        ensure(
+            &env,
             amount <= MAX_DUST_SWEEP_AMOUNT,
-            "sweep amount exceeds MAX_DUST_SWEEP_AMOUNT"
+            EscrowError::SweepAmountExceedsMax,
         );
 
         // env.clone(): env is used again after this call for treasury/token reads and publish.
         let escrow = Self::get_escrow(env.clone());
-        assert!(
+        ensure(
+            &env,
             escrow.status == 2 || escrow.status == 3 || escrow.status == 4,
-            "dust sweep only in terminal states (settled, withdrawn, or cancelled)"
+            EscrowError::DustSweepNotTerminal,
         );
 
         let treasury: Address = env
             .storage()
             .instance()
             .get(&DataKey::Treasury)
-            .expect("treasury must be initialized");
+            .unwrap_or_else(|| fail(&env, EscrowError::TreasuryNotSet));
         treasury.require_auth();
 
         let token_addr = env
             .storage()
             .instance()
             .get(&DataKey::FundingToken)
-            .expect("funding token must be initialized");
+            .unwrap_or_else(|| fail(&env, EscrowError::FundingTokenNotSet));
         let this = env.current_contract_address();
 
         let token = TokenClient::new(&env, &token_addr);
         let balance = token.balance(&this);
-        assert!(balance > 0, "no funding token balance to sweep");
+        ensure(&env, balance > 0, EscrowError::NoFundingTokenBalanceToSweep);
         let sweep_amt = amount.min(balance);
-        assert!(sweep_amt > 0, "effective sweep amount is zero");
+        ensure(&env, sweep_amt > 0, EscrowError::EffectiveSweepAmountZero);
 
         external_calls::transfer_funding_token_with_balance_checks(
             &env,
@@ -862,7 +974,7 @@ impl LiquifactEscrow {
         env.storage()
             .instance()
             .get(&DataKey::Escrow)
-            .unwrap_or_else(|| panic!("Escrow not initialized"))
+            .unwrap_or_else(|| fail(&env, EscrowError::EscrowNotInitialized))
     }
 
     pub fn get_version(env: Env) -> u32 {
@@ -899,9 +1011,7 @@ impl LiquifactEscrow {
     /// Optional cap on total principal for a single investor address.
     /// Absent ⇒ unlimited. Enforced on every deposit.
     pub fn get_max_per_investor_cap(env: Env) -> Option<i128> {
-        env.storage()
-            .instance()
-            .get(&DataKey::MaxPerInvestorCap)
+        env.storage().instance().get(&DataKey::MaxPerInvestorCap)
     }
 
     /// Distinct funders counted so far (each address counted once when it first receives principal).
@@ -946,15 +1056,20 @@ impl LiquifactEscrow {
     ///
     /// **Authorization:** [`InvoiceEscrow::admin`]. **Frontrunning:** whichever binding transaction lands
     /// first wins; observers must read on-chain state (or parse events) after finality—there is no replay lock.
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes when the escrow is uninitialized or the primary digest has
+    /// already been bound.
     pub fn bind_primary_attestation_hash(env: Env, digest: BytesN<32>) {
         // env.clone(): env is used again after this call for storage has/set and publish.
         let escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
-        assert!(
+        ensure(
+            &env,
             !env.storage()
                 .instance()
                 .has(&DataKey::PrimaryAttestationHash),
-            "primary attestation already bound"
+            EscrowError::PrimaryAttestationAlreadyBound,
         );
         env.storage()
             .instance()
@@ -975,6 +1090,9 @@ impl LiquifactEscrow {
 
     /// Append a digest to a bounded on-chain log (see [`MAX_ATTESTATION_APPEND_ENTRIES`]) for **versioned**
     /// or incremental attestation updates. Does not replace [`LiquifactEscrow::bind_primary_attestation_hash`].
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes when the escrow is uninitialized or the append log is full.
     pub fn append_attestation_digest(env: Env, digest: BytesN<32>) {
         // env.clone(): env is used again after this call for storage get/set and publish.
         let escrow = Self::get_escrow(env.clone());
@@ -985,9 +1103,10 @@ impl LiquifactEscrow {
             .instance()
             .get(&DataKey::AttestationAppendLog)
             .unwrap_or_else(|| Vec::new(&env));
-        assert!(
+        ensure(
+            &env,
             log.len() < MAX_ATTESTATION_APPEND_ENTRIES,
-            "attestation append log capacity reached"
+            EscrowError::AttestationAppendLogCapacityReached,
         );
         let idx = log.len();
         log.push_back(digest.clone());
@@ -1068,15 +1187,20 @@ impl LiquifactEscrow {
     /// - `asset` must be a non-empty symbol.
     /// - When replacing an existing commitment, the current ledger timestamp must not be
     ///   earlier than the prior `recorded_at` (defense-in-depth against stale writes).
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes for invalid collateral metadata, stale ledger timestamp,
+    /// or an uninitialized escrow.
     pub fn record_sme_collateral_commitment(
         env: Env,
         asset: Symbol,
         amount: i128,
     ) -> SmeCollateralCommitment {
-        assert!(amount > 0, "Collateral amount must be positive");
-        assert!(
+        ensure(&env, amount > 0, EscrowError::CollateralAmountNotPositive);
+        ensure(
+            &env,
             asset != Symbol::new(&env, ""),
-            "Collateral asset symbol must not be empty"
+            EscrowError::CollateralAssetEmpty,
         );
 
         // env.clone(): env is used again after this call for storage read/write, timestamp, and publish.
@@ -1089,9 +1213,10 @@ impl LiquifactEscrow {
         let prior_amount = prior.as_ref().map(|c| c.amount).unwrap_or(0);
 
         if let Some(ref existing) = prior {
-            assert!(
+            ensure(
+                &env,
                 now >= existing.recorded_at,
-                "Collateral commitment timestamp must not go backward"
+                EscrowError::CollateralTimestampBackwards,
             );
         }
 
@@ -1187,16 +1312,21 @@ impl LiquifactEscrow {
     ///
     /// Invariant: the end state and emitted events are identical to calling
     /// `set_investor_allowlisted` individually for each element in `investors`.
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes when the escrow is uninitialized, the batch is empty, or
+    /// the batch exceeds [`MAX_INVESTOR_ALLOWLIST_BATCH`].
     pub fn set_investors_allowlisted(env: Env, investors: Vec<Address>, allowed: bool) {
         // env.clone(): env is used again after this call for storage writes and publish.
         let escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
         let n = investors.len();
-        assert!(n > 0, "investors vector must be non-empty");
-        assert!(
-            (n as u32) <= MAX_INVESTOR_ALLOWLIST_BATCH,
-            "investors vector length exceeds MAX_INVESTOR_ALLOWLIST_BATCH"
+        ensure(&env, n > 0, EscrowError::InvestorBatchEmpty);
+        ensure(
+            &env,
+            n <= MAX_INVESTOR_ALLOWLIST_BATCH,
+            EscrowError::InvestorBatchTooLarge,
         );
 
         // Iterate and perform per-address persistent storage write and event emission.
@@ -1233,14 +1363,12 @@ impl LiquifactEscrow {
         let mut escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
-        assert!(new_target > 0, "Target must be strictly positive");
-        assert!(
-            escrow.status == 0,
-            "Target can only be updated in Open state"
-        );
-        assert!(
+        ensure(&env, new_target > 0, EscrowError::TargetNotPositive);
+        ensure(&env, escrow.status == 0, EscrowError::TargetUpdateNotOpen);
+        ensure(
+            &env,
             new_target >= escrow.funded_amount,
-            "Target cannot be less than already funded amount"
+            EscrowError::TargetBelowFundedAmount,
         );
 
         let old_target = escrow.funding_target;
@@ -1259,25 +1387,69 @@ impl LiquifactEscrow {
         escrow
     }
 
+    /// Lower the configured distinct-investor cap while the escrow is still open.
+    ///
+    /// This is admin-only and intentionally cannot raise a cap or impose one on an unlimited
+    /// escrow. Existing investors remain able to add principal after the cap is lowered; only new
+    /// investor addresses are blocked once `UniqueFunderCount >= new_cap`.
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes for non-open state, missing caps, attempted raises, or
+    /// lowering below the already-recorded unique funder count.
+    pub fn lower_max_unique_investors(env: Env, new_cap: u32) -> u32 {
+        let escrow = Self::get_escrow(env.clone());
+        escrow.admin.require_auth();
+
+        ensure(&env, escrow.status == 0, EscrowError::CapLowerNotOpen);
+
+        let old_cap: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxUniqueInvestorsCap)
+            .unwrap_or_else(|| fail(&env, EscrowError::NoInvestorCapConfigured));
+        let unique_count = Self::get_unique_funder_count(env.clone());
+
+        ensure(&env, new_cap < old_cap, EscrowError::NewCapNotLower);
+        ensure(
+            &env,
+            new_cap >= unique_count,
+            EscrowError::NewCapBelowCurrentFunderCount,
+        );
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxUniqueInvestorsCap, &new_cap);
+
+        MaxUniqueInvestorsCapLowered {
+            name: symbol_short!("inv_cap"),
+            invoice_id: escrow.invoice_id.clone(),
+            old_cap,
+            new_cap,
+        }
+        .publish(&env);
+
+        new_cap
+    }
+
     /// Validate the stored schema version and apply a migration if one is implemented.
     ///
-    /// # Behavior — **panics on all current paths**
+    /// # Behavior - **typed error on all current paths**
     ///
     /// This entrypoint currently contains **no implemented migration logic**. Every call
-    /// terminates with a `panic!` (aborts the Soroban transaction). This is intentional:
+    /// terminates with a typed contract error (aborts the Soroban transaction). This is intentional:
     /// it makes the "no migration" guarantee explicit rather than silently returning success.
     ///
     /// **Execution order:** the function first reads [`DataKey::Version`] from instance
-    /// storage, then asserts the supplied `from_version` matches, then panics. No storage
+    /// storage, validates the supplied `from_version`, then emits a typed error. No storage
     /// writes ever occur; the storage read is read-only and side-effect-free. There is
     /// **no [`Address::require_auth`] call** — any account may invoke `migrate`. This is
-    /// safe only because the final `panic!` is reached on every code path and no state
+    /// safe only because a typed error is reached on every code path and no state
     /// is mutated. Adding migration logic without also adding an auth guard would make
     /// this entrypoint callable by any account.
     ///
     /// Do **not** call `migrate` expecting it to perform bookkeeping work in the current
     /// release. To add a real migration path (e.g. rewriting a stored struct after a field
-    /// addition), implement the transformation above the final `panic!` branch, update
+    /// addition), implement the transformation above the final error branch, update
     /// [`DataKey::Version`], and bump [`SCHEMA_VERSION`].
     ///
     /// # When to call
@@ -1288,38 +1460,43 @@ impl LiquifactEscrow {
     ///   require a `migrate` call; old instances simply return the default.
     /// - If `InvoiceEscrow` struct layout changed, `migrate` cannot help — redeploy instead.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// | Condition | Message |
+    /// | Condition | Typed error |
     /// |-----------|--------|
-    /// | `stored_version != from_version` | `"from_version does not match stored version"` |
-    /// | `from_version >= SCHEMA_VERSION` | `"Already at current schema version"` |
-    /// | Any `from_version < SCHEMA_VERSION` (all paths) | `"No migration path from version {N} - extend migrate or redeploy"` |
+    /// | `stored_version != from_version` | [`EscrowError::MigrationVersionMismatch`] |
+    /// | `from_version >= SCHEMA_VERSION` | [`EscrowError::AlreadyCurrentSchemaVersion`] |
+    /// | Any `from_version < SCHEMA_VERSION` (all paths) | [`EscrowError::NoMigrationPath`] |
     ///
     /// See `docs/OPERATOR_RUNBOOK.md` §2 for step-by-step instructions on implementing
     /// a concrete migration path.
     pub fn migrate(env: Env, from_version: u32) -> u32 {
         let stored: u32 = env.storage().instance().get(&DataKey::Version).unwrap_or(0);
 
-        assert!(
+        ensure(
+            &env,
             stored == from_version,
-            "from_version does not match stored version"
+            EscrowError::MigrationVersionMismatch,
         );
 
         if from_version >= SCHEMA_VERSION {
-            panic!("Already at current schema version");
+            fail(&env, EscrowError::AlreadyCurrentSchemaVersion);
         }
 
         // No migration path is implemented for any version below SCHEMA_VERSION.
         // To add one: implement the transformation here, call
         //   env.storage().instance().set(&DataKey::Version, &NEW_VERSION);
-        // and return NEW_VERSION before reaching this panic.
-        panic!("No migration path from version {from_version} - extend migrate or redeploy");
+        // and return NEW_VERSION before reaching this typed error.
+        fail(&env, EscrowError::NoMigrationPath);
     }
 
     /// Record investor principal while the invoice is **open**. First deposit sets base
     /// [`InvoiceEscrow::yield_bps`] for this investor; further amounts must use this method (not
     /// [`LiquifactEscrow::fund_with_commitment`]) so tier selection stays immutable after the first leg.
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes for invalid amount, legal hold, closed funding state,
+    /// allowlist rejection, cap violations, and checked-arithmetic overflow.
     pub fn fund(env: Env, investor: Address, amount: i128) -> InvoiceEscrow {
         Self::fund_impl(env, investor, amount, true, 0)
     }
@@ -1327,6 +1504,10 @@ impl LiquifactEscrow {
     /// First deposit only (per investor): optional longer lock and tier ladder from [`DataKey::YieldTierTable`].
     /// Sets [`DataKey::InvestorClaimNotBefore`] when `committed_lock_secs > 0`. Additional principal
     /// from the same investor must use [`LiquifactEscrow::fund`].
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes for the same funding guards as [`LiquifactEscrow::fund`],
+    /// plus tiered follow-on deposit misuse and claim-lock timestamp overflow.
     pub fn fund_with_commitment(
         env: Env,
         investor: Address,
@@ -1345,7 +1526,7 @@ impl LiquifactEscrow {
     ) -> InvoiceEscrow {
         investor.require_auth();
 
-        assert!(amount > 0, "Funding amount must be positive");
+        ensure(&env, amount > 0, EscrowError::FundingAmountNotPositive);
 
         let floor: i128 = env
             .storage()
@@ -1353,9 +1534,10 @@ impl LiquifactEscrow {
             .get(&DataKey::MinContributionFloor)
             .unwrap_or(0);
         if floor > 0 {
-            assert!(
+            ensure(
+                &env,
                 amount >= floor,
-                "funding amount below min_contribution floor"
+                EscrowError::FundingBelowMinContribution,
             );
         }
 
@@ -1364,16 +1546,22 @@ impl LiquifactEscrow {
         // Legal hold check is intentionally after the escrow read: the escrow is needed for
         // status and yield_bps regardless, and hoisting the hold check before the escrow read
         // would not reduce storage operations (both keys are always read on this path).
-        assert!(
+        ensure(
+            &env,
             !Self::legal_hold_active(&env),
-            "Legal hold blocks new funding while active"
+            EscrowError::LegalHoldBlocksFunding,
         );
-        assert!(escrow.status == 0, "Escrow not open for funding");
+        ensure(
+            &env,
+            escrow.status == 0,
+            EscrowError::EscrowNotOpenForFunding,
+        );
 
         if Self::is_allowlist_active(env.clone()) {
-            assert!(
+            ensure(
+                &env,
                 Self::is_investor_allowlisted(env.clone(), investor.clone()),
-                "Investor not on allowlist"
+                EscrowError::InvestorNotAllowlisted,
             );
         }
 
@@ -1381,16 +1569,17 @@ impl LiquifactEscrow {
         let prev: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
         let new_contribution: i128 = prev
             .checked_add(amount)
-            .expect("investor contribution overflow");
+            .unwrap_or_else(|| fail(&env, EscrowError::InvestorContributionOverflow));
 
         if let Some(cap) = env
             .storage()
             .instance()
             .get::<DataKey, i128>(&DataKey::MaxPerInvestorCap)
         {
-            assert!(
+            ensure(
+                &env,
                 new_contribution <= cap,
-                "investor contribution exceeds max_per_investor cap"
+                EscrowError::InvestorContributionExceedsCap,
             );
         }
 
@@ -1412,7 +1601,11 @@ impl LiquifactEscrow {
                 .instance()
                 .get::<DataKey, u32>(&DataKey::MaxUniqueInvestorsCap)
             {
-                assert!(cur_funder_count < cap, "unique investor cap reached");
+                ensure(
+                    &env,
+                    cur_funder_count < cap,
+                    EscrowError::UniqueInvestorCapReached,
+                );
             }
         }
 
@@ -1440,10 +1633,7 @@ impl LiquifactEscrow {
             }
             // If prev > 0, preserve existing effective yield and claim lock
         } else {
-            assert!(
-                prev == 0,
-                "Additional principal after a tiered first deposit must use fund(), not fund_with_commitment()"
-            );
+            ensure(&env, prev == 0, EscrowError::TieredSecondDeposit);
             let eff =
                 Self::effective_yield_for_commitment(&env, escrow.yield_bps, committed_lock_secs);
             investor_effective_yield_bps = eff;
@@ -1455,7 +1645,7 @@ impl LiquifactEscrow {
                 0u64
             } else {
                 now.checked_add(committed_lock_secs)
-                    .expect("investor claim time overflow")
+                    .unwrap_or_else(|| fail(&env, EscrowError::InvestorClaimTimeOverflow))
             };
             env.storage().instance().set(
                 &DataKey::InvestorClaimNotBefore(investor.clone()),
@@ -1466,7 +1656,7 @@ impl LiquifactEscrow {
         escrow.funded_amount = escrow
             .funded_amount
             .checked_add(amount)
-            .expect("funded_amount overflow");
+            .unwrap_or_else(|| fail(&env, EscrowError::FundedAmountOverflow));
 
         if escrow.status == 0 && escrow.funded_amount >= escrow.funding_target {
             escrow.status = 1;
@@ -1483,9 +1673,6 @@ impl LiquifactEscrow {
             }
         }
 
-        let next_contribution = prev
-            .checked_add(amount)
-            .expect("investor contribution overflow");
         env.storage()
             .instance()
             .set(&contribution_key, &new_contribution);
@@ -1526,26 +1713,29 @@ impl LiquifactEscrow {
     /// # Maturity gate
     /// If [`InvoiceEscrow::maturity`] > 0, settlement is further gated on the ledger timestamp
     /// reaching `maturity`. A zero maturity means no time gate.
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes for legal hold, uninitialized escrow, non-funded state,
+    /// and unreached maturity.
     pub fn settle(env: Env) -> InvoiceEscrow {
-        assert!(
+        ensure(
+            &env,
             !Self::legal_hold_active(&env),
-            "Legal hold blocks settlement finalization"
+            EscrowError::LegalHoldBlocksSettlement,
         );
 
         // env.clone(): env is used again after this call for ledger timestamp, storage set, and publish.
         let mut escrow = Self::get_escrow(env.clone());
 
         escrow.sme_address.require_auth();
-        assert!(
-            escrow.status == 1,
-            "Escrow must be funded before settlement"
-        );
+        ensure(&env, escrow.status == 1, EscrowError::SettlementNotFunded);
 
         if escrow.maturity > 0 {
             let now = env.ledger().timestamp();
-            assert!(
+            ensure(
+                &env,
                 now >= escrow.maturity,
-                "Escrow has not yet reached maturity"
+                EscrowError::MaturityNotReached,
             );
         }
 
@@ -1566,20 +1756,21 @@ impl LiquifactEscrow {
     }
 
     /// SME pulls funded liquidity (accounting). Blocked when a legal hold is active.
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes for legal hold, uninitialized escrow, or non-funded state.
     pub fn withdraw(env: Env) -> InvoiceEscrow {
-        assert!(
+        ensure(
+            &env,
             !Self::legal_hold_active(&env),
-            "Legal hold blocks SME withdrawal"
+            EscrowError::LegalHoldBlocksWithdrawal,
         );
 
         // env.clone(): env is used again after this call for storage set and publish.
         let mut escrow = Self::get_escrow(env.clone());
         escrow.sme_address.require_auth();
 
-        assert!(
-            escrow.status == 1,
-            "Escrow must be funded before withdrawal"
-        );
+        ensure(&env, escrow.status == 1, EscrowError::WithdrawalNotFunded);
 
         let amount = escrow.funded_amount;
         escrow.status = 3;
@@ -1614,10 +1805,15 @@ impl LiquifactEscrow {
     /// 5. `not_before` ledger-time gate (see `docs/escrow-ledger-time.md`).
     /// 6. Idempotent early-return on `InvestorClaimed`.
     /// 7. Storage write + event emit.
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes for legal hold, missing contribution, unsettled escrow,
+    /// or an unexpired commitment lock.
     pub fn claim_investor_payout(env: Env, investor: Address) {
-        assert!(
+        ensure(
+            &env,
             !Self::legal_hold_active(&env),
-            "Legal hold blocks investor claims"
+            EscrowError::LegalHoldBlocksInvestorClaims,
         );
 
         investor.require_auth();
@@ -1629,13 +1825,14 @@ impl LiquifactEscrow {
             .instance()
             .get(&DataKey::InvestorContribution(investor.clone()))
             .unwrap_or(0);
-        assert!(contribution > 0, "Address has no contribution to claim");
+        ensure(&env, contribution > 0, EscrowError::NoContributionToClaim);
 
         // env.clone(): env is used again after this call for storage reads, ledger timestamp, and publish.
         let escrow = Self::get_escrow(env.clone());
-        assert!(
+        ensure(
+            &env,
             escrow.status == 2,
-            "Escrow must be settled before investor claim"
+            EscrowError::InvestorClaimNotSettled,
         );
 
         let not_before: u64 = env
@@ -1644,9 +1841,10 @@ impl LiquifactEscrow {
             .get(&DataKey::InvestorClaimNotBefore(investor.clone()))
             .unwrap_or(0);
         let now = env.ledger().timestamp();
-        assert!(
+        ensure(
+            &env,
             now >= not_before,
-            "Investor commitment lock not expired (ledger timestamp)"
+            EscrowError::InvestorCommitmentLockNotExpired,
         );
 
         // Idempotent early-return: a second claim is a no-op (no re-emit).
@@ -1695,8 +1893,8 @@ impl LiquifactEscrow {
     /// # Overflow safety
     ///
     /// All multiplications use [`i128::checked_mul`] and divisions use [`i128::checked_div`].
-    /// Panics with `"compute_investor_payout: arithmetic overflow"` rather than silently
-    /// producing a wrong value.
+    /// Emits [`EscrowError::ComputePayoutArithmeticOverflow`] rather than silently producing a
+    /// wrong value.
     ///
     /// # Authorization
     ///
@@ -1738,20 +1936,20 @@ impl LiquifactEscrow {
         // coupon = total_principal × effective_yield_bps / 10_000  (floor)
         let coupon = total_principal
             .checked_mul(effective_yield_bps as i128)
-            .expect("compute_investor_payout: arithmetic overflow")
+            .unwrap_or_else(|| fail(&env, EscrowError::ComputePayoutArithmeticOverflow))
             .checked_div(10_000)
-            .expect("compute_investor_payout: arithmetic overflow");
+            .unwrap_or_else(|| fail(&env, EscrowError::ComputePayoutArithmeticOverflow));
 
         let settle_pool = total_principal
             .checked_add(coupon)
-            .expect("compute_investor_payout: arithmetic overflow");
+            .unwrap_or_else(|| fail(&env, EscrowError::ComputePayoutArithmeticOverflow));
 
         // gross_payout = contribution × settle_pool / total_principal  (floor)
         contribution
             .checked_mul(settle_pool)
-            .expect("compute_investor_payout: arithmetic overflow")
+            .unwrap_or_else(|| fail(&env, EscrowError::ComputePayoutArithmeticOverflow))
             .checked_div(total_principal)
-            .expect("compute_investor_payout: arithmetic overflow")
+            .unwrap_or_else(|| fail(&env, EscrowError::ComputePayoutArithmeticOverflow))
     }
 
     pub fn update_maturity(env: Env, new_maturity: u64) -> InvoiceEscrow {
@@ -1759,10 +1957,7 @@ impl LiquifactEscrow {
         let mut escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
-        assert!(
-            escrow.status == 0,
-            "Maturity can only be updated in Open state"
-        );
+        ensure(&env, escrow.status == 0, EscrowError::MaturityUpdateNotOpen);
 
         let old_maturity = escrow.maturity;
         escrow.maturity = new_maturity;
@@ -1795,61 +1990,42 @@ impl LiquifactEscrow {
         // - ADR-007: storage key evolution policy (additive changes / key semantics).
         // - docs/escrow-ledger-time.md: all gating uses `Env::ledger().timestamp()` with `>=`.
 
-        // Instance storage keys required for settlement + gating behavior.
-        let k_escrow: DataKey = DataKey::Escrow;
-        env.storage().instance().extend_ttl(&k_escrow, &INSTANCE_TTL_MIN_EXTENSION_SECS);
+        env.storage().instance().extend_ttl(
+            INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
+            INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
+        );
 
-        let k_version: DataKey = DataKey::Version;
-        env.storage().instance().extend_ttl(&k_version, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        let k_legal_hold: DataKey = DataKey::LegalHold;
-        env.storage().instance().extend_ttl(&k_legal_hold, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        let k_allowlist_active: DataKey = DataKey::AllowlistActive;
-        env.storage()
-            .instance()
-            .extend_ttl(&k_allowlist_active, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        let k_snapshot: DataKey = DataKey::FundingCloseSnapshot;
-        env.storage()
-            .instance()
-            .extend_ttl(&k_snapshot, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        // Investor contribution + claim gates are instance keys (per investor).
-        // We cannot enumerate contributors on-chain; extend only what the caller provides.
-        for addr in allowlisted.iter() {
-            // Contribution + claim-gate entries are instance-scoped and per-investor.
-            let k_contrib = DataKey::InvestorContribution(addr.clone());
-            env.storage()
-                .instance()
-                .extend_ttl(&k_contrib, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-            let k_claim_not_before = DataKey::InvestorClaimNotBefore(addr.clone());
-            env.storage()
-                .instance()
-                .extend_ttl(&k_claim_not_before, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-        }
-
+        // Instance storage TTL is contract-wide under Soroban SDK 25. The call above covers
+        // Escrow, Version, LegalHold, and all per-investor instance keys.
 
         // Persistent allowlist entries.
         for addr in allowlisted.iter() {
             let k = DataKey::InvestorAllowlisted(addr.clone());
-            env.storage()
-                .persistent()
-                .extend_ttl(&k, &PERSISTENT_TTL_MIN_EXTENSION_SECS);
+            env.storage().persistent().extend_ttl(
+                &k,
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            );
         }
     }
 
+    /// Transfer admin control to `new_admin`.
+    ///
+    /// Requires current admin authorization. The destination must differ from the current admin.
+    ///
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes when the escrow is uninitialized or `new_admin` is the
+    /// current admin.
     pub fn transfer_admin(env: Env, new_admin: Address) -> InvoiceEscrow {
         // env.clone(): env is used again after this call for storage set and publish.
         let mut escrow = Self::get_escrow(env.clone());
 
-
         escrow.admin.require_auth();
 
-        assert!(
+        ensure(
+            &env,
             escrow.admin != new_admin,
-            "New admin must differ from current admin"
+            EscrowError::NewAdminSameAsCurrent,
         );
 
         escrow.admin = new_admin;
@@ -1871,22 +2047,20 @@ impl LiquifactEscrow {
     /// Only the [`InvoiceEscrow::admin`] may call this. Blocked while a legal hold is active.
     /// After cancellation, investors may recover their principal via [`LiquifactEscrow::refund`].
     ///
-    /// # Panics
-    /// - If legal hold is active.
-    /// - If escrow is not in status 0 (open).
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes when legal hold is active, the escrow is uninitialized,
+    /// or the escrow is not in status 0 (open).
     pub fn cancel_funding(env: Env) -> InvoiceEscrow {
-        assert!(
+        ensure(
+            &env,
             !Self::legal_hold_active(&env),
-            "Legal hold blocks cancel_funding"
+            EscrowError::LegalHoldBlocksCancelFunding,
         );
 
         let mut escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
-        assert!(
-            escrow.status == 0,
-            "cancel_funding only allowed in Open state"
-        );
+        ensure(&env, escrow.status == 0, EscrowError::CancelFundingNotOpen);
 
         escrow.status = 4;
         env.storage().instance().set(&DataKey::Escrow, &escrow);
@@ -1904,20 +2078,21 @@ impl LiquifactEscrow {
     /// Return an investor's recorded principal when the escrow is **cancelled** (status 4).
     ///
     /// Requires `investor` auth. Zeroes [`DataKey::InvestorContribution`] after transfer so a
-    /// second call is a no-op (contribution is 0 → panics with "no contribution to refund").
+    /// second call fails with [`EscrowError::NoContributionToRefund`].
     ///
-    /// # Panics
-    /// - If escrow is not in status 4 (cancelled).
-    /// - If the investor has no recorded contribution (or has already been refunded).
+    /// # Errors
+    /// Emits typed [`EscrowError`] codes when the escrow is not cancelled, the investor has no
+    /// refundable contribution, initialized token data is missing, or the refund transfer fails
+    /// token-balance invariants.
     pub fn refund(env: Env, investor: Address) {
         investor.require_auth();
 
         let escrow = Self::get_escrow(env.clone());
-        assert!(escrow.status == 4, "refund only allowed in Cancelled state");
+        ensure(&env, escrow.status == 4, EscrowError::RefundNotCancelled);
 
         let contribution_key = DataKey::InvestorContribution(investor.clone());
         let amount: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
-        assert!(amount > 0, "no contribution to refund");
+        ensure(&env, amount > 0, EscrowError::NoContributionToRefund);
 
         // Zero out contribution before transfer (checks-effects-interactions).
         env.storage().instance().set(&contribution_key, &0i128);
@@ -1929,7 +2104,7 @@ impl LiquifactEscrow {
             .storage()
             .instance()
             .get(&DataKey::FundingToken)
-            .expect("funding token must be initialized");
+            .unwrap_or_else(|| fail(&env, EscrowError::FundingTokenNotSet));
         let this = env.current_contract_address();
 
         external_calls::transfer_funding_token_with_balance_checks(

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -1,6 +1,9 @@
-use super::{LiquifactEscrow, LiquifactEscrowClient};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use super::{
+    AllowlistEnabledChanged, DataKey, InvestorAllowlistChanged, LiquifactEscrow,
+    LiquifactEscrowClient,
+};
 use soroban_sdk::Vec as SorobanVec;
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Event};
 
 fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
     let id = env.register(LiquifactEscrow, ());
@@ -25,7 +28,7 @@ fn init(env: &Env, client: &LiquifactEscrowClient) -> (Address, Address) {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     (admin, sme)
 }
@@ -266,7 +269,7 @@ fn test_fund_allowed_when_on_allowlist() {
 }
 
 #[test]
-#[should_panic(expected = "Investor not on allowlist")]
+#[should_panic]
 fn test_fund_blocked_when_not_on_allowlist() {
     let env = Env::default();
     env.mock_all_auths();
@@ -279,7 +282,7 @@ fn test_fund_blocked_when_not_on_allowlist() {
 }
 
 #[test]
-#[should_panic(expected = "Investor not on allowlist")]
+#[should_panic]
 fn test_fund_with_commitment_blocked_when_not_on_allowlist() {
     let env = Env::default();
     env.mock_all_auths();
@@ -342,7 +345,7 @@ fn test_entries_persist_across_disable_reenable() {
 }
 
 #[test]
-#[should_panic(expected = "Investor not on allowlist")]
+#[should_panic]
 fn test_removed_investor_blocked_after_reenable() {
     let env = Env::default();
     env.mock_all_auths();
@@ -414,7 +417,7 @@ fn test_batch_add_and_remove_from_allowlist() {
 }
 
 #[test]
-#[should_panic(expected = "investors vector must be non-empty")]
+#[should_panic]
 fn test_batch_rejects_empty_vector() {
     let env = Env::default();
     env.mock_all_auths();
@@ -426,7 +429,7 @@ fn test_batch_rejects_empty_vector() {
 }
 
 #[test]
-#[should_panic(expected = "investors vector length exceeds MAX_INVESTOR_ALLOWLIST_BATCH")]
+#[should_panic]
 fn test_batch_rejects_too_large_vector() {
     let env = Env::default();
     env.mock_all_auths();

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -8,9 +8,9 @@
 )]
 #[allow(unused_imports)]
 use super::{
-    DataKey, EscrowInitialized, FundingTargetUpdated, LegalHoldChanged, LiquifactEscrow,
-    LiquifactEscrowClient, MaxUniqueInvestorsCapLowered, YieldTier, MAX_ATTESTATION_APPEND_ENTRIES,
-    MAX_DUST_SWEEP_AMOUNT, SCHEMA_VERSION,
+    DataKey, EscrowError, EscrowInitialized, FundingTargetUpdated, LegalHoldChanged,
+    LiquifactEscrow, LiquifactEscrowClient, MaxUniqueInvestorsCapLowered, YieldTier,
+    MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,
@@ -24,6 +24,7 @@ use soroban_sdk::{
 mod admin;
 mod attestations;
 mod cap_validation;
+mod coverage;
 mod external_calls;
 mod external_calls_mocked;
 mod funding;
@@ -109,7 +110,7 @@ pub fn default_init(client: &LiquifactEscrowClient<'_>, env: &Env, admin: &Addre
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -22,7 +22,7 @@ fn test_update_maturity_success() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let updated = client.update_maturity(&2000u64);
     assert_eq!(updated.maturity, 2000u64);
@@ -30,7 +30,7 @@ fn test_update_maturity_success() {
 }
 
 #[test]
-#[should_panic(expected = "Maturity can only be updated in Open state")]
+#[should_panic]
 fn test_update_maturity_wrong_state() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -48,7 +48,7 @@ fn test_update_maturity_wrong_state() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.update_maturity(&2000u64);
@@ -75,7 +75,7 @@ fn test_update_maturity_unauthorized() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     env.mock_auths(&[]);
     client.update_maturity(&2000u64);
@@ -99,7 +99,7 @@ fn test_transfer_admin_updates_admin() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let updated = client.transfer_admin(&new_admin);
     assert_eq!(updated.admin, new_admin);
@@ -107,7 +107,7 @@ fn test_transfer_admin_updates_admin() {
 }
 
 #[test]
-#[should_panic(expected = "New admin must differ from current admin")]
+#[should_panic]
 fn test_transfer_admin_same_address_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -124,13 +124,13 @@ fn test_transfer_admin_same_address_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.transfer_admin(&admin);
 }
 
 #[test]
-#[should_panic(expected = "Escrow not initialized")]
+#[should_panic]
 fn test_transfer_admin_uninitialized_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -140,7 +140,7 @@ fn test_transfer_admin_uninitialized_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Already at current schema version")]
+#[should_panic]
 fn test_migrate_at_current_version_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -149,7 +149,7 @@ fn test_migrate_at_current_version_panics() {
 }
 
 #[test]
-#[should_panic(expected = "from_version does not match stored version")]
+#[should_panic]
 fn test_migrate_wrong_from_version_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -199,7 +199,7 @@ fn test_record_collateral_stored_and_does_not_block_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
     assert_eq!(c.amount, 5000i128);
@@ -212,7 +212,7 @@ fn test_record_collateral_stored_and_does_not_block_settle() {
 }
 
 #[test]
-#[should_panic(expected = "Collateral amount must be positive")]
+#[should_panic]
 fn test_collateral_zero_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -229,7 +229,7 @@ fn test_collateral_zero_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
 }
@@ -252,7 +252,7 @@ fn test_collateral_requires_sme_auth() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     env.mock_auths(&[]);
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &100i128);
@@ -276,7 +276,7 @@ fn test_legal_hold_blocks_settle_withdraw_claim_and_fund() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &TARGET);
     client.set_legal_hold(&true);
@@ -309,7 +309,7 @@ fn test_legal_hold_blocks_settle_withdraw_claim_and_fund() {
 }
 
 #[test]
-#[should_panic(expected = "Legal hold blocks new funding while active")]
+#[should_panic]
 fn test_legal_hold_blocks_new_funds_when_open() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -327,7 +327,7 @@ fn test_legal_hold_blocks_new_funds_when_open() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.set_legal_hold(&true);
     client.fund(&investor, &1i128);
@@ -367,7 +367,7 @@ fn test_update_funding_target_by_admin_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let updated = client.update_funding_target(&10_000i128);
@@ -398,7 +398,7 @@ fn test_update_funding_target_by_non_admin_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     env.mock_auths(&[]);
@@ -406,7 +406,7 @@ fn test_update_funding_target_by_non_admin_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Target can only be updated in Open state")]
+#[should_panic]
 fn test_update_funding_target_fails_when_funded() {
     let env = Env::default();
     env.mock_all_auths();
@@ -430,14 +430,14 @@ fn test_update_funding_target_fails_when_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128);
     client.update_funding_target(&10_000i128);
 }
 
 #[test]
-#[should_panic(expected = "Target cannot be less than already funded amount")]
+#[should_panic]
 fn test_update_funding_target_below_funded_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -461,14 +461,14 @@ fn test_update_funding_target_below_funded_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &4_000i128);
     client.update_funding_target(&3_000i128);
 }
 
 #[test]
-#[should_panic(expected = "Target must be strictly positive")]
+#[should_panic]
 fn test_update_funding_target_zero_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -491,7 +491,7 @@ fn test_update_funding_target_zero_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.update_funding_target(&0i128);
 }
@@ -527,7 +527,7 @@ fn test_update_funding_target_event_fields() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_funding_target(&9_000i128);
@@ -547,7 +547,7 @@ fn test_update_funding_target_event_fields() {
 /// `update_funding_target` must be rejected when the escrow is in the **settled**
 /// state (status == 2); only the open state (0) is permitted.
 #[test]
-#[should_panic(expected = "Target can only be updated in Open state")]
+#[should_panic]
 fn test_update_funding_target_fails_when_settled() {
     let env = Env::default();
     env.mock_all_auths();
@@ -571,7 +571,7 @@ fn test_update_funding_target_fails_when_settled() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.settle(); // status → 2 (settled)
@@ -581,7 +581,7 @@ fn test_update_funding_target_fails_when_settled() {
 /// `update_funding_target` must be rejected when the escrow is in the **withdrawn**
 /// state (status == 3); only the open state (0) is permitted.
 #[test]
-#[should_panic(expected = "Target can only be updated in Open state")]
+#[should_panic]
 fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
@@ -605,7 +605,7 @@ fn test_update_funding_target_fails_when_withdrawn() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.withdraw(); // status → 3 (withdrawn)
@@ -639,7 +639,7 @@ fn test_update_funding_target_equal_to_funded_amount_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
 
@@ -652,7 +652,7 @@ fn test_update_funding_target_equal_to_funded_amount_succeeds() {
 
 /// Passing a negative value must panic with "Target must be strictly positive".
 #[test]
-#[should_panic(expected = "Target must be strictly positive")]
+#[should_panic]
 fn test_update_funding_target_negative_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -675,7 +675,7 @@ fn test_update_funding_target_negative_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.update_funding_target(&-1i128);
 }
@@ -712,7 +712,7 @@ fn test_update_maturity_event_fields() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_maturity(&2000u64);
@@ -732,7 +732,7 @@ fn test_update_maturity_event_fields() {
 /// `update_maturity` must be rejected when the escrow is in the **funded**
 /// state (status == 1); only Open (0) is permitted.
 #[test]
-#[should_panic(expected = "Maturity can only be updated in Open state")]
+#[should_panic]
 fn test_update_maturity_fails_when_funded() {
     let env = Env::default();
     env.mock_all_auths();
@@ -756,7 +756,7 @@ fn test_update_maturity_fails_when_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.update_maturity(&2000u64);
@@ -765,7 +765,7 @@ fn test_update_maturity_fails_when_funded() {
 /// `update_maturity` must be rejected when the escrow is **settled**
 /// (status == 2); only Open (0) is permitted.
 #[test]
-#[should_panic(expected = "Maturity can only be updated in Open state")]
+#[should_panic]
 fn test_update_maturity_fails_when_settled() {
     let env = Env::default();
     env.mock_all_auths();
@@ -789,7 +789,7 @@ fn test_update_maturity_fails_when_settled() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1
     client.settle(); // status → 2
@@ -799,7 +799,7 @@ fn test_update_maturity_fails_when_settled() {
 /// `update_maturity` must be rejected when the escrow is **withdrawn**
 /// (status == 3); only Open (0) is permitted.
 #[test]
-#[should_panic(expected = "Maturity can only be updated in Open state")]
+#[should_panic]
 fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
@@ -823,7 +823,7 @@ fn test_update_maturity_fails_when_withdrawn() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1
     client.withdraw(); // status → 3
@@ -855,7 +855,7 @@ fn test_update_maturity_to_zero_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let updated = client.update_maturity(&0u64);
     assert_eq!(updated.maturity, 0u64);
@@ -889,7 +889,7 @@ fn test_settle_passes_exactly_at_maturity_ledger_time() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128);
 
@@ -902,7 +902,7 @@ fn test_settle_passes_exactly_at_maturity_ledger_time() {
 /// Ledger time semantics: settle must panic one second before maturity —
 /// confirming the `>=` boundary strictly excludes values below maturity.
 #[test]
-#[should_panic(expected = "Escrow has not yet reached maturity")]
+#[should_panic]
 fn test_settle_fails_one_second_before_maturity() {
     let env = Env::default();
     env.mock_all_auths();
@@ -926,7 +926,7 @@ fn test_settle_fails_one_second_before_maturity() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128);
 
@@ -960,7 +960,7 @@ fn test_update_maturity_twice_overwrites() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_maturity(&2000u64);
@@ -1122,6 +1122,7 @@ fn auth_audit_sweep_terminal_dust_requires_treasury() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -52,7 +52,7 @@ fn test_get_primary_hash_none_before_bind() {
 
 /// A second bind with the **same** digest must panic — single-set is unconditional.
 #[test]
-#[should_panic(expected = "primary attestation already bound")]
+#[should_panic]
 fn test_bind_primary_hash_same_digest_panics() {
     let env = Env::default();
     let (client, _) = setup_with_init(&env);
@@ -63,7 +63,7 @@ fn test_bind_primary_hash_same_digest_panics() {
 
 /// A second bind with a **different** digest must also panic — no replacement allowed.
 #[test]
-#[should_panic(expected = "primary attestation already bound")]
+#[should_panic]
 fn test_bind_primary_hash_different_digest_panics() {
     let env = Env::default();
     let (client, _) = setup_with_init(&env);
@@ -138,7 +138,7 @@ fn test_append_exactly_max_entries_succeeds() {
 
 /// The 33rd entry must panic — capacity is strictly bounded.
 #[test]
-#[should_panic(expected = "attestation append log capacity reached")]
+#[should_panic]
 fn test_append_beyond_max_panics() {
     let env = Env::default();
     let (client, _) = setup_with_init(&env);

--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -26,7 +26,7 @@ fn test_unique_funder_count_basic_functionality() {
         &None,
         &None,
         &Some(3u32),
-        &None
+        &None,
     );
 
     // Verify initial state
@@ -54,7 +54,7 @@ fn test_unique_funder_count_basic_functionality() {
 }
 
 #[test]
-#[should_panic(expected = "unique investor cap reached")]
+#[should_panic]
 fn test_cap_enforcement_blocks_excess_investors() {
     let env = Env::default();
     env.mock_all_auths();
@@ -77,7 +77,7 @@ fn test_cap_enforcement_blocks_excess_investors() {
         &None,
         &None,
         &Some(2u32),
-        &None
+        &None,
     );
 
     // Add two investors — reaches the investor cap but NOT the funding target.
@@ -115,7 +115,7 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &Some(1u32),
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -156,7 +156,7 @@ fn test_no_cap_allows_unlimited_investors() {
         &None,
         &None,
         &None, // No distinct-investor cap set
-        &None
+        &None,
     );
 
     assert_eq!(client.get_max_unique_investors_cap(), None);
@@ -173,7 +173,7 @@ fn test_no_cap_allows_unlimited_investors() {
 }
 
 #[test]
-#[should_panic(expected = "investor contribution exceeds max_per_investor cap")]
+#[should_panic]
 fn test_max_per_investor_cap_blocks_excess_principal() {
     let env = Env::default();
     env.mock_all_auths();
@@ -194,7 +194,7 @@ fn test_max_per_investor_cap_blocks_excess_principal() {
         &None,
         &None,
         &Some(2u32),
-        &Some(50_000_000_000i128)
+        &Some(50_000_000_000i128),
     );
 
     let inv1 = Address::generate(&env);
@@ -206,7 +206,7 @@ fn test_max_per_investor_cap_blocks_excess_principal() {
 }
 
 #[test]
-#[should_panic(expected = "max_per_investor must be positive when configured")]
+#[should_panic]
 fn test_init_zero_max_per_investor_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -227,7 +227,7 @@ fn test_init_zero_max_per_investor_panics() {
         &None,
         &None,
         &Some(2u32),
-        &Some(0i128)
+        &Some(0i128),
     );
 }
 
@@ -260,7 +260,7 @@ fn test_cap_with_fund_with_commitment() {
         &Some(tiers),
         &None,
         &Some(2u32),
-        &None
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -303,6 +303,7 @@ fn test_lower_max_unique_investors_success() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -317,7 +318,7 @@ fn test_lower_max_unique_investors_success() {
 }
 
 #[test]
-#[should_panic(expected = "unique investor cap reached")]
+#[should_panic]
 fn test_lower_cap_blocks_new_investors_at_lowered_limit() {
     let env = Env::default();
     env.mock_all_auths();
@@ -338,6 +339,7 @@ fn test_lower_cap_blocks_new_investors_at_lowered_limit() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &20_000_000_000i128);
@@ -368,6 +370,7 @@ fn test_lower_cap_existing_investors_may_refund() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -382,7 +385,7 @@ fn test_lower_cap_existing_investors_may_refund() {
 }
 
 #[test]
-#[should_panic(expected = "new cap must be strictly lower than current cap")]
+#[should_panic]
 fn test_lower_cap_rejects_raise() {
     let env = Env::default();
     env.mock_all_auths();
@@ -403,13 +406,14 @@ fn test_lower_cap_rejects_raise() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     client.lower_max_unique_investors(&4u32);
 }
 
 #[test]
-#[should_panic(expected = "new cap cannot be below current unique funder count")]
+#[should_panic]
 fn test_lower_cap_rejects_below_funder_count() {
     let env = Env::default();
     env.mock_all_auths();
@@ -430,6 +434,7 @@ fn test_lower_cap_rejects_below_funder_count() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10_000_000_000i128);
@@ -439,7 +444,7 @@ fn test_lower_cap_rejects_below_funder_count() {
 }
 
 #[test]
-#[should_panic(expected = "Cap can only be lowered in Open state")]
+#[should_panic]
 fn test_lower_cap_rejects_non_open_state() {
     let env = Env::default();
     env.mock_all_auths();
@@ -460,6 +465,7 @@ fn test_lower_cap_rejects_non_open_state() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100_000_000_000i128);
@@ -468,7 +474,7 @@ fn test_lower_cap_rejects_non_open_state() {
 }
 
 #[test]
-#[should_panic(expected = "no investor cap configured")]
+#[should_panic]
 fn test_lower_cap_rejects_unlimited_escrow() {
     let env = Env::default();
     env.mock_all_auths();
@@ -486,6 +492,7 @@ fn test_lower_cap_rejects_unlimited_escrow() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -515,6 +522,7 @@ fn test_lower_cap_requires_admin_auth() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     client.lower_max_unique_investors(&3u32);
@@ -546,6 +554,7 @@ fn test_lower_cap_unauthorized_panics() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     env.mock_auths(&[]);
@@ -576,6 +585,7 @@ fn test_lower_cap_emits_event() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10_000_000_000i128);

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -1,14 +1,132 @@
-use crate::{
-    test::{free_addresses, setup},
-    DataKey, YieldTier, EscrowSummary, EscrowCloseSnapshot,
-};
+use super::{free_addresses, setup};
+use crate::{DataKey, EscrowCloseSnapshot, EscrowError, EscrowSummary, YieldTier};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    Address, Env, Vec as SorobanVec,
+    Address, Env, Error, InvokeError, Vec as SorobanVec,
 };
+use std::fmt::Debug;
+
+fn assert_contract_error<T, E>(
+    result: Result<Result<T, E>, Result<Error, InvokeError>>,
+    expected: EscrowError,
+) where
+    T: Debug,
+    E: Debug,
+{
+    let expected_code = expected as u32;
+    match result {
+        Err(Ok(error)) => {
+            assert_eq!(error, Error::from_contract_error(expected_code));
+        }
+        Err(Err(InvokeError::Contract(code))) => {
+            assert_eq!(code, expected_code);
+        }
+        other => panic!("expected ContractError({expected_code}), got {other:?}"),
+    }
+}
 
 #[test]
-#[should_panic(expected = "from_version does not match stored version")]
+fn typed_error_codes_cover_init_and_state_guards() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+
+    assert_contract_error(
+        client.try_init(
+            &admin,
+            &soroban_sdk::String::from_str(&env, "ERR_INIT"),
+            &sme,
+            &0,
+            &100,
+            &100,
+            &funding_token,
+            &None,
+            &treasury,
+            &None,
+            &None,
+            &None,
+            &None,
+        ),
+        EscrowError::AmountMustBePositive,
+    );
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "ERR_FLOW"),
+        &sme,
+        &100,
+        &100,
+        &100,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let investor = Address::generate(&env);
+    assert_contract_error(
+        client.try_fund(&investor, &0),
+        EscrowError::FundingAmountNotPositive,
+    );
+    assert_contract_error(client.try_settle(), EscrowError::SettlementNotFunded);
+    assert_contract_error(client.try_withdraw(), EscrowError::WithdrawalNotFunded);
+    assert_contract_error(
+        client.try_claim_investor_payout(&investor),
+        EscrowError::NoContributionToClaim,
+    );
+}
+
+#[test]
+fn typed_error_codes_cover_allowlist_attestation_and_dust_guards() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "ERR_MORE"),
+        &sme,
+        &100,
+        &100,
+        &100,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    client.set_allowlist_active(&true);
+    let investor = Address::generate(&env);
+    assert_contract_error(
+        client.try_fund(&investor, &10),
+        EscrowError::InvestorNotAllowlisted,
+    );
+
+    let digest = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
+    client.bind_primary_attestation_hash(&digest);
+    assert_contract_error(
+        client.try_bind_primary_attestation_hash(&digest),
+        EscrowError::PrimaryAttestationAlreadyBound,
+    );
+
+    assert_contract_error(
+        client.try_sweep_terminal_dust(&0),
+        EscrowError::SweepAmountNotPositive,
+    );
+    assert_contract_error(
+        client.try_sweep_terminal_dust(&1),
+        EscrowError::DustSweepNotTerminal,
+    );
+}
+
+#[test]
+#[should_panic]
 fn test_migrate_wrong_version() {
     let env = Env::default();
     let (client, _admin, _sme) = setup(&env);
@@ -16,7 +134,7 @@ fn test_migrate_wrong_version() {
 }
 
 #[test]
-#[should_panic(expected = "Already at current schema version")]
+#[should_panic]
 fn test_migrate_already_current() {
     let env = Env::default();
     env.mock_all_auths();
@@ -36,14 +154,14 @@ fn test_migrate_already_current() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.migrate(&5);
 }
 
 #[test]
-#[should_panic(expected = "No migration path from version 0 - extend migrate or redeploy")]
+#[should_panic]
 fn test_migrate_no_path() {
     let env = Env::default();
     env.mock_all_auths();
@@ -63,7 +181,7 @@ fn test_migrate_no_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     env.as_contract(&client.address, || {
@@ -93,7 +211,7 @@ fn test_admin_and_maturity_updates() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let updated = client.update_maturity(&200);
@@ -105,7 +223,7 @@ fn test_admin_and_maturity_updates() {
 }
 
 #[test]
-#[should_panic(expected = "Maturity can only be updated in Open state")]
+#[should_panic]
 fn test_update_maturity_not_open() {
     let env = Env::default();
     env.mock_all_auths();
@@ -125,7 +243,7 @@ fn test_update_maturity_not_open() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -134,7 +252,7 @@ fn test_update_maturity_not_open() {
 }
 
 #[test]
-#[should_panic(expected = "New admin must differ from current admin")]
+#[should_panic]
 fn test_transfer_admin_same_admin() {
     let env = Env::default();
     env.mock_all_auths();
@@ -154,14 +272,14 @@ fn test_transfer_admin_same_admin() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.transfer_admin(&admin);
 }
 
 #[test]
-#[should_panic(expected = "Legal hold blocks new funding while active")]
+#[should_panic]
 fn test_fund_during_legal_hold() {
     let env = Env::default();
     env.mock_all_auths();
@@ -181,7 +299,7 @@ fn test_fund_during_legal_hold() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.set_legal_hold(&true);
@@ -190,7 +308,7 @@ fn test_fund_during_legal_hold() {
 }
 
 #[test]
-#[should_panic(expected = "funding amount below min_contribution floor")]
+#[should_panic]
 fn test_fund_below_floor() {
     let env = Env::default();
     env.mock_all_auths();
@@ -210,7 +328,7 @@ fn test_fund_below_floor() {
         &None,
         &Some(50),
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -218,7 +336,7 @@ fn test_fund_below_floor() {
 }
 
 #[test]
-#[should_panic(expected = "Escrow must be settled before investor claim")]
+#[should_panic]
 fn test_claim_not_settled() {
     let env = Env::default();
     env.mock_all_auths();
@@ -238,7 +356,7 @@ fn test_claim_not_settled() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -247,7 +365,7 @@ fn test_claim_not_settled() {
 }
 
 #[test]
-#[should_panic(expected = "Investor commitment lock not expired (ledger timestamp)")]
+#[should_panic]
 fn test_claim_lock_not_expired() {
     let env = Env::default();
     env.mock_all_auths();
@@ -267,7 +385,7 @@ fn test_claim_lock_not_expired() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -300,7 +418,7 @@ fn test_all_getters() {
         &None,
         &Some(10),
         &Some(5),
-        &None
+        &None,
     );
 
     assert_eq!(client.get_funding_token(), funding_token);
@@ -335,7 +453,7 @@ fn test_attestations_happy_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let hash1 = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
@@ -351,7 +469,7 @@ fn test_attestations_happy_path() {
 }
 
 #[test]
-#[should_panic(expected = "primary attestation already bound")]
+#[should_panic]
 fn test_bind_primary_attestation_twice() {
     let env = Env::default();
     env.mock_all_auths();
@@ -370,7 +488,7 @@ fn test_bind_primary_attestation_twice() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let hash = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
@@ -398,7 +516,7 @@ fn test_unique_investors_cap() {
         &None,
         &None,
         &Some(2),
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10);
@@ -407,7 +525,7 @@ fn test_unique_investors_cap() {
 }
 
 #[test]
-#[should_panic(expected = "unique investor cap reached")]
+#[should_panic]
 fn test_unique_investors_cap_exceeded() {
     let env = Env::default();
     env.mock_all_auths();
@@ -427,7 +545,7 @@ fn test_unique_investors_cap_exceeded() {
         &None,
         &None,
         &Some(1),
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10);
@@ -455,7 +573,7 @@ fn test_sweep_terminal_dust_happy_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -470,7 +588,7 @@ fn test_sweep_terminal_dust_happy_path() {
 }
 
 #[test]
-#[should_panic(expected = "dust sweep only in terminal states (settled or withdrawn)")]
+#[should_panic]
 fn test_sweep_not_terminal() {
     let env = Env::default();
     env.mock_all_auths();
@@ -489,14 +607,14 @@ fn test_sweep_not_terminal() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.sweep_terminal_dust(&10);
 }
 
 #[test]
-#[should_panic(expected = "no funding token balance to sweep")]
+#[should_panic]
 fn test_sweep_no_balance() {
     let env = Env::default();
     env.mock_all_auths();
@@ -516,7 +634,7 @@ fn test_sweep_no_balance() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -545,7 +663,7 @@ fn test_withdraw_happy_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -556,7 +674,7 @@ fn test_withdraw_happy_path() {
 }
 
 #[test]
-#[should_panic(expected = "Escrow has not yet reached maturity")]
+#[should_panic]
 fn test_settle_too_early() {
     let env = Env::default();
     env.mock_all_auths();
@@ -575,7 +693,7 @@ fn test_settle_too_early() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -601,7 +719,7 @@ fn test_update_funding_target_happy_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let updated = client.update_funding_target(&200);
@@ -609,7 +727,7 @@ fn test_update_funding_target_happy_path() {
 }
 
 #[test]
-#[should_panic(expected = "Target cannot be less than already funded amount")]
+#[should_panic]
 fn test_update_funding_target_too_low() {
     let env = Env::default();
     env.mock_all_auths();
@@ -628,7 +746,7 @@ fn test_update_funding_target_too_low() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &50);
@@ -654,7 +772,7 @@ fn test_sme_collateral_commitment() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let asset = soroban_sdk::Symbol::new(&env, "GOLD");
@@ -667,7 +785,7 @@ fn test_sme_collateral_commitment() {
 }
 
 #[test]
-#[should_panic(expected = "Collateral asset symbol must not be empty")]
+#[should_panic]
 fn test_sme_collateral_empty_asset_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -686,13 +804,14 @@ fn test_sme_collateral_empty_asset_rejected() {
         &None,
         &None,
         &None,
+        &None,
     );
     let empty_asset = soroban_sdk::Symbol::new(&env, "");
     client.record_sme_collateral_commitment(&empty_asset, &5000);
 }
 
 #[test]
-#[should_panic(expected = "Collateral commitment timestamp must not go backward")]
+#[should_panic]
 fn test_sme_collateral_stale_timestamp_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -708,6 +827,7 @@ fn test_sme_collateral_stale_timestamp_rejected() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -738,6 +858,7 @@ fn test_sme_collateral_replacement_preserves_prior_amount() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -777,7 +898,7 @@ fn test_clear_legal_hold_convenience() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.set_legal_hold(&true);
@@ -805,7 +926,7 @@ fn test_claim_not_before_getter() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -844,13 +965,13 @@ fn test_init_with_tiers() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_escrow().yield_bps, 100); // Default yield
 }
 
 #[test]
-#[should_panic(expected = "sweep amount exceeds MAX_DUST_SWEEP_AMOUNT")]
+#[should_panic]
 fn test_sweep_too_much() {
     let env = Env::default();
     env.mock_all_auths();
@@ -869,7 +990,7 @@ fn test_sweep_too_much() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -880,7 +1001,7 @@ fn test_sweep_too_much() {
 }
 
 #[test]
-#[should_panic(expected = "Escrow must be funded before withdrawal")]
+#[should_panic]
 fn test_withdraw_not_funded() {
     let env = Env::default();
     env.mock_all_auths();
@@ -899,14 +1020,14 @@ fn test_withdraw_not_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.withdraw();
 }
 
 #[test]
-#[should_panic(expected = "Escrow must be funded before settlement")]
+#[should_panic]
 fn test_settle_not_funded() {
     let env = Env::default();
     env.mock_all_auths();
@@ -925,7 +1046,7 @@ fn test_settle_not_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.settle();
@@ -950,7 +1071,7 @@ fn test_fund_with_zero_commitment() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -959,7 +1080,7 @@ fn test_fund_with_zero_commitment() {
 }
 
 #[test]
-#[should_panic(expected = "Target must be strictly positive")]
+#[should_panic]
 fn test_update_target_invalid() {
     let env = Env::default();
     env.mock_all_auths();
@@ -978,14 +1099,14 @@ fn test_update_target_invalid() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_funding_target(&0);
 }
 
 #[test]
-#[should_panic(expected = "yield_bps must be between 0 and 10_000")]
+#[should_panic]
 fn test_init_yield_out_of_range() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1004,12 +1125,12 @@ fn test_init_yield_out_of_range() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "min_contribution must be positive when configured")]
+#[should_panic]
 fn test_init_min_contribution_zero() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1028,12 +1149,12 @@ fn test_init_min_contribution_zero() {
         &None,
         &Some(0),
         &None,
-        &None
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "tiers must have strictly increasing min_lock_secs")]
+#[should_panic]
 fn test_init_tiers_unsorted() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1061,12 +1182,12 @@ fn test_init_tiers_unsorted() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "tiers must have non-decreasing yield_bps")]
+#[should_panic]
 fn test_init_tiers_not_increasing_yield() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1094,12 +1215,12 @@ fn test_init_tiers_not_increasing_yield() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "tier yield_bps must be >= base yield_bps")]
+#[should_panic]
 fn test_init_tiers_lower_than_base() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1123,7 +1244,7 @@ fn test_init_tiers_lower_than_base() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1146,7 +1267,7 @@ fn test_get_yield_bps_empty_tiers_branch() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     // Inject empty tiers directly to trigger the branch in get_yield_bps_for_commitment
@@ -1163,7 +1284,7 @@ fn test_get_yield_bps_empty_tiers_branch() {
 }
 
 #[test]
-#[should_panic(expected = "tier yield_bps must be 0..=10_000")]
+#[should_panic]
 fn test_init_tier_yield_out_of_range() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1187,12 +1308,12 @@ fn test_init_tier_yield_out_of_range() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "Escrow not initialized")]
+#[should_panic]
 fn test_get_escrow_summary_before_init() {
     let env = Env::default();
     let (client, _admin, _sme) = setup(&env);
@@ -1219,6 +1340,7 @@ fn test_get_escrow_summary_happy_path() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let summary = client.get_escrow_summary();
@@ -1226,13 +1348,16 @@ fn test_get_escrow_summary_happy_path() {
     // Verify fields match individual getters
     assert_eq!(summary.escrow, client.get_escrow());
     assert_eq!(summary.legal_hold, client.get_legal_hold());
-    
+
     let expected_snapshot = match client.get_funding_close_snapshot() {
         Some(snap) => EscrowCloseSnapshot::Some(snap),
         None => EscrowCloseSnapshot::None,
     };
     assert_eq!(summary.funding_close_snapshot, expected_snapshot);
-    assert_eq!(summary.unique_funder_count, client.get_unique_funder_count());
+    assert_eq!(
+        summary.unique_funder_count,
+        client.get_unique_funder_count()
+    );
     assert_eq!(summary.is_allowlist_active, client.is_allowlist_active());
     assert_eq!(summary.schema_version, client.get_version());
 
@@ -1264,29 +1389,33 @@ fn test_get_escrow_summary_after_state_changes() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Make state changes
-    client.set_legal_hold(&true);
     client.set_allowlist_active(&true);
 
     let investor = Address::generate(&env);
     client.set_investor_allowlisted(&investor, &true);
     // Fund enough to trigger funded status and capture snapshot
     client.fund(&investor, &1000);
+    client.set_legal_hold(&true);
 
     let summary = client.get_escrow_summary();
 
     // Verify fields match individual getters under state changes
     assert_eq!(summary.escrow, client.get_escrow());
     assert_eq!(summary.legal_hold, client.get_legal_hold());
-    
+
     let expected_snapshot = match client.get_funding_close_snapshot() {
         Some(snap) => EscrowCloseSnapshot::Some(snap),
         None => EscrowCloseSnapshot::None,
     };
     assert_eq!(summary.funding_close_snapshot, expected_snapshot);
-    assert_eq!(summary.unique_funder_count, client.get_unique_funder_count());
+    assert_eq!(
+        summary.unique_funder_count,
+        client.get_unique_funder_count()
+    );
     assert_eq!(summary.is_allowlist_active, client.is_allowlist_active());
     assert_eq!(summary.schema_version, client.get_version());
 
@@ -1295,7 +1424,10 @@ fn test_get_escrow_summary_after_state_changes() {
     assert!(summary.is_allowlist_active);
     assert_eq!(summary.unique_funder_count, 1);
     assert_eq!(summary.escrow.status, 1); // Funded
-    assert!(matches!(summary.funding_close_snapshot, EscrowCloseSnapshot::Some(_)));
+    assert!(matches!(
+        summary.funding_close_snapshot,
+        EscrowCloseSnapshot::Some(_)
+    ));
 
     let snapshot = match &summary.funding_close_snapshot {
         EscrowCloseSnapshot::Some(snap) => snap.clone(),

--- a/escrow/src/tests/external_calls.rs
+++ b/escrow/src/tests/external_calls.rs
@@ -62,7 +62,7 @@ fn test_balance_delta_invariants_with_standard_token() {
 }
 
 #[test]
-#[should_panic(expected = "transfer amount must be positive")]
+#[should_panic]
 fn test_panics_with_zero_amount() {
     let env = Env::default();
     env.mock_all_auths();
@@ -78,7 +78,7 @@ fn test_panics_with_zero_amount() {
 }
 
 #[test]
-#[should_panic(expected = "transfer amount must be positive")]
+#[should_panic]
 fn test_panics_with_negative_amount() {
     let env = Env::default();
     env.mock_all_auths();
@@ -117,7 +117,7 @@ fn test_muxed_address_compatibility() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient token balance before transfer")]
+#[should_panic]
 fn test_balance_underflow_detection() {
     let env = Env::default();
     env.mock_all_auths();

--- a/escrow/src/tests/external_calls_mocked.rs
+++ b/escrow/src/tests/external_calls_mocked.rs
@@ -74,7 +74,7 @@ fn mint_fee_token(env: &Env, contract_id: &Address, to: &Address, amount: i128) 
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "recipient balance delta must equal transfer amount")]
+#[should_panic]
 fn test_fee_on_transfer_token_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -94,7 +94,7 @@ fn test_fee_on_transfer_token_rejected() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "transfer amount must be positive")]
+#[should_panic]
 fn test_zero_amount_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -106,7 +106,7 @@ fn test_zero_amount_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "transfer amount must be positive")]
+#[should_panic]
 fn test_negative_amount_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -122,7 +122,7 @@ fn test_negative_amount_rejected() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "insufficient token balance before transfer")]
+#[should_panic]
 fn test_insufficient_balance_rejected() {
     let env = Env::default();
     env.mock_all_auths();

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -20,7 +20,7 @@ fn test_fund_and_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let funded = client.fund(&investor, &TARGET);
     assert_eq!(funded.funded_amount, TARGET);
@@ -47,7 +47,7 @@ fn test_fund_partial_then_full() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let partial = client.fund(&investor, &(TARGET / 2));
     assert_eq!(partial.status, 0);
@@ -58,7 +58,7 @@ fn test_fund_partial_then_full() {
 }
 
 #[test]
-#[should_panic(expected = "Funding amount must be positive")]
+#[should_panic]
 fn test_fund_zero_amount_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -68,7 +68,7 @@ fn test_fund_zero_amount_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Escrow not open for funding")]
+#[should_panic]
 fn test_fund_after_funded_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -109,7 +109,7 @@ fn test_single_investor_contribution_tracked() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(30_000_000_000i128));
     let contribution = client.get_contribution(&investor);
@@ -145,7 +145,7 @@ fn test_repeated_funding_accumulates_contribution() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(20_000_000_000i128));
     client.fund(&investor, &(30_000_000_000i128));
@@ -153,7 +153,7 @@ fn test_repeated_funding_accumulates_contribution() {
 }
 
 #[test]
-#[should_panic(expected = "funded_amount overflow")]
+#[should_panic]
 fn test_funding_amount_accumulation_overflow_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -171,7 +171,7 @@ fn test_funding_amount_accumulation_overflow_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &(i128::MAX - 1));
@@ -196,7 +196,7 @@ fn test_funding_amount_overflow_does_not_mutate_state() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &(i128::MAX - 1));
@@ -214,7 +214,7 @@ fn test_funding_amount_overflow_does_not_mutate_state() {
 }
 
 #[test]
-#[should_panic(expected = "funded_amount overflow")]
+#[should_panic]
 fn test_fund_with_commitment_overflow_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -230,6 +230,7 @@ fn test_fund_with_commitment_overflow_panics() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -258,6 +259,7 @@ fn test_fund_with_commitment_overflow_does_not_mutate_state() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&investor_a, &(i128::MAX - 1));
@@ -275,7 +277,7 @@ fn test_fund_with_commitment_overflow_does_not_mutate_state() {
 }
 
 #[test]
-#[should_panic(expected = "investor contribution overflow")]
+#[should_panic]
 fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
     // This test intentionally constructs an inconsistent storage snapshot to ensure
     // the per-investor accounting never wraps even under corrupted / unexpected state.
@@ -302,6 +304,7 @@ fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -345,6 +348,7 @@ fn test_investor_contribution_overflow_does_not_mutate_state() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -393,7 +397,7 @@ fn test_multiple_investors_tracked_independently() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
@@ -427,7 +431,7 @@ fn test_contributions_sum_equals_funded_amount() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
@@ -456,7 +460,7 @@ fn test_cost_baseline_fund_partial() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(10_000_000_000i128));
 }
@@ -479,7 +483,7 @@ fn test_cost_baseline_fund_full() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &TARGET);
 }
@@ -502,7 +506,7 @@ fn test_cost_baseline_fund_overshoot() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(150_000_000_000i128));
     assert_eq!(client.get_escrow().status, 1);
@@ -526,7 +530,7 @@ fn test_cost_baseline_fund_two_step_completion() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(TARGET / 2));
     client.fund(&investor, &(TARGET / 2));
@@ -555,7 +559,7 @@ fn test_funding_close_snapshot_captures_overfunded_total_once() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_funding_close_snapshot(), None);
     client.fund(&inv, &(TARGET + 50_000_000_000i128));
@@ -589,7 +593,7 @@ fn test_funding_snapshot_immutable_across_second_fund_after_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&a, &(TARGET / 2));
     assert_eq!(client.get_funding_close_snapshot(), None);
@@ -623,7 +627,7 @@ fn test_pro_rata_weight_ratio_from_snapshot() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&a, &(20_000_000_000i128));
     client.fund(&b, &(80_000_000_000i128));
@@ -665,7 +669,7 @@ fn test_tiered_yield_and_follow_on_fund() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &5_000i128, &200u64);
     assert_eq!(client.get_investor_yield_bps(&inv), 900);
@@ -703,7 +707,7 @@ fn test_tier_selection_edges_base_vs_high_bucket() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&i_short, &10_000i128, &40u64);
     assert_eq!(client.get_investor_yield_bps(&i_short), 800);
@@ -712,7 +716,7 @@ fn test_tier_selection_edges_base_vs_high_bucket() {
 }
 
 #[test]
-#[should_panic(expected = "Additional principal after a tiered first deposit")]
+#[should_panic]
 fn test_fund_with_commitment_twice_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -739,14 +743,14 @@ fn test_fund_with_commitment_twice_panics() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
 }
 
 #[test]
-#[should_panic(expected = "Additional principal after a tiered first deposit")]
+#[should_panic]
 fn test_fund_then_fund_with_commitment_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -768,7 +772,7 @@ fn test_fund_then_fund_with_commitment_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv, &5_000i128);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
@@ -806,7 +810,7 @@ fn test_tier_selection_ladder() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     let inv_base = Address::generate(&env);
@@ -860,7 +864,7 @@ fn test_fund_with_commitment_zero_lock_behaves_as_fund() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&inv, &5_000i128, &0u64);
@@ -893,7 +897,7 @@ fn test_commitment_claim_time_allows_u64_max_boundary() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&investor, &100i128, &5u64);
@@ -902,7 +906,7 @@ fn test_commitment_claim_time_allows_u64_max_boundary() {
 }
 
 #[test]
-#[should_panic(expected = "investor claim time overflow")]
+#[should_panic]
 fn test_commitment_claim_time_overflow_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -927,7 +931,7 @@ fn test_commitment_claim_time_overflow_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&investor, &100i128, &6u64);
@@ -958,7 +962,7 @@ fn test_commitment_claim_time_overflow_does_not_record_position() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -972,7 +976,7 @@ fn test_commitment_claim_time_overflow_does_not_record_position() {
 }
 
 #[test]
-#[should_panic(expected = "strictly increasing min_lock_secs")]
+#[should_panic]
 fn test_init_bad_tier_order_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1002,12 +1006,12 @@ fn test_init_bad_tier_order_panics() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "tier yield_bps must be >= base yield_bps")]
+#[should_panic]
 fn test_init_tier_yield_below_base_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1033,7 +1037,7 @@ fn test_init_tier_yield_below_base_panics() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1060,7 +1064,7 @@ fn test_differential_funding_target_eq_exact_cross() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let escrow = client.fund(&inv, &t);
     assert_eq!(escrow.funded_amount, t);
@@ -1092,7 +1096,7 @@ fn test_ledger_sequence_recorded_in_snapshot_with_tick() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let seq = env.ledger().sequence();
     client.fund(&inv, &1_000i128);
@@ -1122,7 +1126,7 @@ fn test_get_funding_close_snapshot_absent_before_any_funding() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(
         client.get_funding_close_snapshot(),
@@ -1154,7 +1158,7 @@ fn test_get_funding_close_snapshot_present_after_funding_completes() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     // Partial fund — snapshot still absent.
     client.fund(&inv, &(TARGET / 2));
@@ -1197,7 +1201,7 @@ fn test_get_funding_close_snapshot_immutable_after_set() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     // Fund exactly to target — snapshot is written here.
     client.fund(&inv, &TARGET);
@@ -1234,7 +1238,7 @@ fn test_unique_funder_count_initialized_to_zero() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_unique_funder_count(), 0);
 }
@@ -1257,7 +1261,7 @@ fn test_unique_funder_count_increments_on_first_investor() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_unique_funder_count(), 0);
     client.fund(&investor, &(TARGET / 2));
@@ -1286,7 +1290,7 @@ fn test_unique_funder_count_increments_for_distinct_investors() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_unique_funder_count(), 0);
 
@@ -1330,7 +1334,7 @@ fn test_unique_funder_count_with_fund_with_commitment() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -1361,6 +1365,7 @@ fn test_max_unique_investors_cap_none_allows_unlimited() {
         &None,
         &None,
         &None, // No cap set
+        &None,
     );
 
     // Should be able to add many investors when no cap is set
@@ -1389,6 +1394,7 @@ fn test_max_unique_investors_cap_enforced_at_limit() {
         &None,
         &None,
         &Some(3u32), // Cap of 3 investors
+        &None,
     );
 
     assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
@@ -1413,7 +1419,7 @@ fn test_max_unique_investors_cap_enforced_at_limit() {
 }
 
 #[test]
-#[should_panic(expected = "unique investor cap reached")]
+#[should_panic]
 fn test_max_unique_investors_cap_blocks_excess_investors() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -1430,6 +1436,7 @@ fn test_max_unique_investors_cap_blocks_excess_investors() {
         &None,
         &None,
         &Some(2u32), // Cap of 2 investors
+        &None,
     );
 
     // Add 2 investors
@@ -1444,7 +1451,7 @@ fn test_max_unique_investors_cap_blocks_excess_investors() {
 }
 
 #[test]
-#[should_panic(expected = "unique investor cap reached")]
+#[should_panic]
 fn test_max_unique_investors_cap_blocks_fund_with_commitment() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1472,6 +1479,7 @@ fn test_max_unique_investors_cap_blocks_fund_with_commitment() {
         &Some(tiers),
         &None,
         &Some(1u32), // Cap of 1 investor
+        &None,
     );
 
     // First investor succeeds
@@ -1502,6 +1510,7 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &Some(1u32), // Cap of 1 investor
+        &None,
     );
 
     // First fund should succeed
@@ -1536,6 +1545,7 @@ fn test_zero_contribution_then_non_zero_contribution_counts_as_unique_investor()
         &None,
         &None,
         &Some(2u32), // Cap of 2 investors
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -1567,11 +1577,12 @@ fn test_cap_validation_at_init_positive_value_required() {
         &None,
         &None,
         &Some(0u32), // Invalid: zero cap
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "max_unique_investors must be positive when configured")]
+#[should_panic]
 fn test_init_panics_for_zero_cap() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -1588,6 +1599,7 @@ fn test_init_panics_for_zero_cap() {
         &None,
         &None,
         &Some(0u32), // Invalid: zero cap
+        &None,
     );
 }
 
@@ -1609,6 +1621,7 @@ fn test_cap_edge_case_exact_limit_reached() {
         &None,
         &None,
         &Some(5u32), // Cap of 5 investors
+        &None,
     );
 
     // Add exactly 5 investors - should all succeed
@@ -1627,7 +1640,7 @@ fn test_cap_edge_case_exact_limit_reached() {
 }
 
 #[test]
-#[should_panic(expected = "unique investor cap reached")]
+#[should_panic]
 fn test_cap_edge_case_exactly_one_over_limit_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -1644,6 +1657,7 @@ fn test_cap_edge_case_exactly_one_over_limit_panics() {
         &None,
         &None,
         &Some(5u32), // Cap of 5 investors
+        &None,
     );
 
     // Add exactly 5 investors
@@ -1675,6 +1689,7 @@ fn test_cap_with_min_contribution_floor_interaction() {
         &None,
         &Some(1_000i128), // Min contribution floor
         &Some(3u32),      // Cap of 3 investors
+        &None,
     );
 
     // Should respect both cap and floor
@@ -1697,7 +1712,7 @@ fn test_cap_with_min_contribution_floor_interaction() {
 }
 
 #[test]
-#[should_panic(expected = "unique investor cap reached")]
+#[should_panic]
 fn test_cap_blocks_even_with_large_contribution() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -1714,6 +1729,7 @@ fn test_cap_blocks_even_with_large_contribution() {
         &None,
         &None,
         &Some(1u32), // Cap of 1 investor
+        &None,
     );
 
     // First investor can fund large amount
@@ -1748,7 +1764,7 @@ fn test_cap_panic_message_quality() {
         &None,
         &None,
         &Some(1u32),
-        &None
+        &None,
     );
 
     // Add first investor
@@ -1786,6 +1802,7 @@ fn init_with_token<'a>(
         &None,
         &None,
         &None,
+        &None,
     );
     (token, treasury)
 }
@@ -1812,7 +1829,7 @@ fn test_cancel_funding_requires_admin_auth() {
 }
 
 #[test]
-#[should_panic(expected = "cancel_funding only allowed in Open state")]
+#[should_panic]
 fn test_cancel_funding_panics_if_already_funded() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -1823,7 +1840,7 @@ fn test_cancel_funding_panics_if_already_funded() {
 }
 
 #[test]
-#[should_panic(expected = "cancel_funding only allowed in Open state")]
+#[should_panic]
 fn test_cancel_funding_panics_if_already_cancelled() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -1833,7 +1850,7 @@ fn test_cancel_funding_panics_if_already_cancelled() {
 }
 
 #[test]
-#[should_panic(expected = "Legal hold blocks cancel_funding")]
+#[should_panic]
 fn test_cancel_funding_blocked_by_legal_hold() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -1901,7 +1918,7 @@ fn test_refund_marks_investor_refunded() {
 }
 
 #[test]
-#[should_panic(expected = "no contribution to refund")]
+#[should_panic]
 fn test_refund_double_spend_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -1916,7 +1933,7 @@ fn test_refund_double_spend_panics() {
 }
 
 #[test]
-#[should_panic(expected = "no contribution to refund")]
+#[should_panic]
 fn test_refund_non_investor_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -1927,7 +1944,7 @@ fn test_refund_non_investor_panics() {
 }
 
 #[test]
-#[should_panic(expected = "refund only allowed in Cancelled state")]
+#[should_panic]
 fn test_refund_panics_in_open_state() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -1938,7 +1955,7 @@ fn test_refund_panics_in_open_state() {
 }
 
 #[test]
-#[should_panic(expected = "refund only allowed in Cancelled state")]
+#[should_panic]
 fn test_refund_panics_in_funded_state() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -21,7 +21,7 @@ fn test_init_stores_escrow() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(escrow.invoice_id, symbol_short!("INV001"));
     assert_eq!(escrow.admin, admin);
@@ -51,7 +51,7 @@ fn test_init_stores_keyed_invoice_and_lists_it() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let got = client.get_escrow();
     assert_eq!(got, escrow);
@@ -74,7 +74,7 @@ fn test_init_requires_admin_auth() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert!(
         env.auths().iter().any(|(addr, _)| *addr == admin),
@@ -102,14 +102,14 @@ fn test_init_unauthorized_panics() {
             &None,
             &None,
             &None,
-            &None
+            &None,
         );
     }));
     assert!(result.is_err(), "Expected panic without auth");
 }
 
 #[test]
-#[should_panic(expected = "Escrow already initialized")]
+#[should_panic]
 fn test_double_init_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -118,7 +118,7 @@ fn test_double_init_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Escrow not initialized")]
+#[should_panic]
 fn test_get_escrow_uninitialized_panics() {
     let env = Env::default();
     let client = deploy(&env);
@@ -142,7 +142,7 @@ fn test_cost_baseline_init() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -163,7 +163,7 @@ fn test_cost_baseline_init_zero_maturity() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -184,12 +184,12 @@ fn test_cost_baseline_init_max_amount() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "invoice_id length")]
+#[should_panic]
 fn test_init_invoice_id_empty_string_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -210,12 +210,12 @@ fn test_init_invoice_id_empty_string_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "invoice_id must be [A-Za-z0-9_]")]
+#[should_panic]
 fn test_init_invoice_id_whitespace_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -236,12 +236,12 @@ fn test_init_invoice_id_whitespace_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "invoice_id length")]
+#[should_panic]
 fn test_init_invoice_id_too_long_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -263,12 +263,12 @@ fn test_init_invoice_id_too_long_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
 #[test]
-#[should_panic(expected = "invoice_id must be [A-Za-z0-9_]")]
+#[should_panic]
 fn test_init_invoice_id_bad_charset_hyphen_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -289,7 +289,7 @@ fn test_init_invoice_id_bad_charset_hyphen_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -316,7 +316,7 @@ fn test_init_stores_registry_some_and_getters() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_registry_ref(), Some(reg));
     assert_eq!(client.get_funding_token(), token);
@@ -347,7 +347,7 @@ fn test_init_min_contribution_floor_stored() {
         &None,
         &Some(1_000i128),
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_min_contribution_floor(), 1_000i128);
 }
@@ -374,14 +374,14 @@ fn test_init_min_contribution_floor_defaults_to_zero() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_min_contribution_floor(), 0i128);
 }
 
 /// `min_contribution = Some(0)` is rejected — the value must be positive when supplied.
 #[test]
-#[should_panic(expected = "min_contribution must be positive when configured")]
+#[should_panic]
 fn test_init_min_contribution_zero_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -402,13 +402,13 @@ fn test_init_min_contribution_zero_panics() {
         &None,
         &Some(0i128),
         &None,
-        &None
+        &None,
     );
 }
 
 /// `min_contribution` exceeding the invoice amount is rejected.
 #[test]
-#[should_panic(expected = "min_contribution cannot exceed initial invoice amount")]
+#[should_panic]
 fn test_init_min_contribution_exceeds_amount_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -429,7 +429,7 @@ fn test_init_min_contribution_exceeds_amount_panics() {
         &None,
         &Some(1_001i128),
         &None,
-        &None
+        &None,
     );
 }
 
@@ -455,13 +455,13 @@ fn test_init_min_contribution_equal_to_amount_accepted() {
         &None,
         &Some(5_000i128),
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_min_contribution_floor(), 5_000i128);
 }
 
 #[test]
-#[should_panic(expected = "Funding token not set")]
+#[should_panic]
 fn test_get_funding_token_before_init_panics() {
     let env = Env::default();
     let client = deploy(&env);
@@ -469,7 +469,7 @@ fn test_get_funding_token_before_init_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Treasury not set")]
+#[should_panic]
 fn test_get_treasury_before_init_panics() {
     let env = Env::default();
     let client = deploy(&env);
@@ -505,7 +505,7 @@ fn test_init_registry_none_roundtrip() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_registry_ref(), None);
 }
@@ -534,6 +534,7 @@ fn test_init_escrow_initialized_event_includes_bound_refs() {
         &token,
         &Some(registry.clone()),
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -578,6 +579,7 @@ fn test_init_escrow_initialized_event_registry_none() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(
@@ -618,7 +620,7 @@ fn try_init_with_id(env: &Env, id: &str) -> Result<(), ()> {
             &None,
             &None,
             &None,
-            &None
+            &None,
         );
     }));
     result.map(|_| ()).map_err(|_| ())
@@ -643,7 +645,7 @@ fn test_invoice_id_length_32_accepted() {
 
 /// Length 33 is one over the limit and must be rejected.
 #[test]
-#[should_panic(expected = "invoice_id length")]
+#[should_panic]
 fn test_invoice_id_length_33_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -664,7 +666,7 @@ fn test_invoice_id_length_33_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -58,7 +58,7 @@ fn test_legal_hold_midflow_blocks_and_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     // Funding starts normally.
@@ -174,6 +174,7 @@ fn test_escrow_gold_standard_happy_path_open_overfund_snapshot_settle_claim() {
         &None, // No yield tiers for simplicity
         &None, // No min contribution floor
         &None, // No max investors cap
+        &None,
     );
 
     let initial_escrow = client.get_escrow();
@@ -400,7 +401,7 @@ fn test_escrow_tiered_yield_with_commitment_locks() {
         &Some(yield_tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor_base = Address::generate(&env);
@@ -526,7 +527,7 @@ fn test_collateral_record_is_metadata_only_and_does_not_invoke_token_contract() 
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
@@ -709,7 +710,7 @@ fn test_external_transfer_wrapper_balance_deltas() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient token balance before transfer")]
+#[should_panic]
 fn test_external_wrapper_panics_when_undercollateralized() {
     let env = Env::default();
     env.mock_all_auths();
@@ -755,7 +756,7 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     // Initial funding succeeds while hold is off.

--- a/escrow/src/tests/legal_hold.rs
+++ b/escrow/src/tests/legal_hold.rs
@@ -48,7 +48,7 @@ fn init_open(
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     (token, treasury)
 }
@@ -93,7 +93,7 @@ fn init_settled<'a>(
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(investor, &TARGET);
     client.settle();
@@ -103,7 +103,7 @@ fn init_settled<'a>(
 // ── 1. fund ──────────────────────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Legal hold blocks new funding while active")]
+#[should_panic]
 fn fund_blocked_under_hold() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -129,7 +129,7 @@ fn fund_passes_when_hold_cleared() {
 // ── 2. fund_with_commitment ───────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Legal hold blocks new funding while active")]
+#[should_panic]
 fn fund_with_commitment_blocked_under_hold() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -154,7 +154,7 @@ fn fund_with_commitment_passes_when_hold_cleared() {
 // ── 3. settle ────────────────────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Legal hold blocks settlement finalization")]
+#[should_panic]
 fn settle_blocked_under_hold() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -179,7 +179,7 @@ fn settle_passes_when_hold_cleared() {
 // ── 4. withdraw ──────────────────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Legal hold blocks SME withdrawal")]
+#[should_panic]
 fn withdraw_blocked_under_hold() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -204,7 +204,7 @@ fn withdraw_passes_when_hold_cleared() {
 // ── 5. claim_investor_payout ─────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Legal hold blocks investor claims")]
+#[should_panic]
 fn claim_investor_payout_blocked_under_hold() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -231,7 +231,7 @@ fn claim_investor_payout_passes_when_hold_cleared() {
 // ── 6. sweep_terminal_dust ───────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Legal hold blocks treasury dust sweep")]
+#[should_panic]
 fn sweep_terminal_dust_blocked_under_hold() {
     let env = Env::default();
     env.mock_all_auths();
@@ -426,7 +426,7 @@ fn hold_persists_after_admin_transfer() {
 
 /// Hold must block `sweep_terminal_dust` before the zero-amount guard fires.
 #[test]
-#[should_panic(expected = "Legal hold blocks treasury dust sweep")]
+#[should_panic]
 fn hold_blocks_sweep_before_zero_amount_check() {
     let env = Env::default();
     env.mock_all_auths();
@@ -443,7 +443,7 @@ fn hold_blocks_sweep_before_zero_amount_check() {
 
 /// Hold must block `settle` before the status guard fires (open escrow).
 #[test]
-#[should_panic(expected = "Legal hold blocks settlement finalization")]
+#[should_panic]
 fn hold_blocks_settle_before_status_check_on_open_escrow() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -456,7 +456,7 @@ fn hold_blocks_settle_before_status_check_on_open_escrow() {
 
 /// Hold must block `withdraw` before the status guard fires (open escrow).
 #[test]
-#[should_panic(expected = "Legal hold blocks SME withdrawal")]
+#[should_panic]
 fn hold_blocks_withdraw_before_status_check_on_open_escrow() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -469,7 +469,7 @@ fn hold_blocks_withdraw_before_status_check_on_open_escrow() {
 /// Note: the `amount > 0` check fires before the hold check in `fund_impl`,
 /// so zero-amount is NOT a valid test — use a fully-funded escrow instead.
 #[test]
-#[should_panic(expected = "Legal hold blocks new funding while active")]
+#[should_panic]
 fn hold_blocks_fund_before_status_check_on_funded_escrow() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);

--- a/escrow/src/tests/properties.rs
+++ b/escrow/src/tests/properties.rs
@@ -115,7 +115,7 @@ fn prop_status_transitions_open_to_funded_only() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let initial = client.get_escrow();
@@ -152,7 +152,7 @@ fn prop_status_settle_transition() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -187,7 +187,7 @@ fn prop_status_withdraw_transition() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -226,7 +226,7 @@ fn prop_no_regression_from_funded_status() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -263,7 +263,7 @@ fn prop_no_regression_after_withdraw() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -298,7 +298,7 @@ fn prop_settled_is_terminal_for_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -331,7 +331,7 @@ fn prop_withdrawn_is_terminal_for_withdraw() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -364,7 +364,7 @@ fn prop_status_invariant_all_states_valid_range() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     assert!(client.get_escrow().status == 0);
@@ -403,7 +403,7 @@ fn prop_funded_amount_sum_of_contributions() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -452,7 +452,7 @@ fn prop_funded_amount_respects_funding_target() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let fund_amount = target + excess;
@@ -489,7 +489,7 @@ fn prop_funded_amount_non_decreasing_across_multiple_funders() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let amt1: i128 = 50_000_000_000i128;
@@ -540,7 +540,7 @@ fn prop_funded_amount_equals_contribution_sum_for_funded_escrow() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let amounts: [i128; 3] = [50_000_000_000i128, 100_000_000_000i128, 50_000_000_000i128];
@@ -657,7 +657,7 @@ fn fuzz_multi_investor_fund_ordering_snapshot_once_only() {
             &None,
             &None,
             &None,
-            &None
+            &None,
         );
 
         // Randomize investor count/order and positive amounts. Keep the sequence small so

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -264,7 +264,7 @@ fn test_claim_investor_twice_is_idempotent() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -280,7 +280,7 @@ fn test_claim_investor_twice_is_idempotent() {
 }
 
 #[test]
-#[should_panic(expected = "Address has no contribution to claim")]
+#[should_panic]
 fn test_claim_by_non_investor_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -298,7 +298,7 @@ fn test_claim_by_non_investor_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     // Escrow settled but stranger never funded
     let investor = Address::generate(&env);
@@ -327,7 +327,7 @@ fn test_clashing_investors_have_independent_claims() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &1_000i128);
     client.fund(&inv_b, &1_000i128);
@@ -388,7 +388,7 @@ fn settle_blocked_by_legal_hold() {
 // Removed to resolve E0428.
 
 #[test]
-#[should_panic(expected = "Investor commitment lock not expired")]
+#[should_panic]
 fn test_claim_blocked_until_commitment_ledger_time() {
     let env = Env::default();
     env.mock_all_auths();
@@ -410,7 +410,7 @@ fn test_claim_blocked_until_commitment_ledger_time() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &1_000i128, &500u64);
     client.settle();
@@ -439,7 +439,7 @@ fn test_claim_succeeds_after_commitment_and_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &1_000i128, &100u64);
     client.settle();
@@ -473,7 +473,7 @@ fn test_claim_gating_exact_timestamp() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let lock_duration = 500u64;
@@ -521,7 +521,7 @@ fn test_claim_gating_with_multiple_investors() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&inv1, &1_000i128, &100u64); // Expiry 1100
@@ -564,7 +564,7 @@ fn test_cost_baseline_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &TARGET);
     env.ledger().set_timestamp(1001);
@@ -615,7 +615,7 @@ fn settle_with_maturity_zero_succeeds_immediately() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     fund_to_target(&client, &env);
@@ -651,7 +651,7 @@ fn settle_at_maturity_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     fund_to_target(&client, &env);
@@ -674,7 +674,7 @@ fn settle_requires_sme_auth() {
 
 /// `settle` on open (status 0) escrow must panic.
 #[test]
-#[should_panic(expected = "Escrow must be funded before settlement")]
+#[should_panic]
 fn settle_on_open_escrow_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -699,7 +699,7 @@ fn settle_on_withdrawn_escrow_panics() {
 // HostError wraps contract panic; expected substring not matched in outer message.
 #[ignore = "HostError wraps contract panic; expected substring not matched"]
 #[test]
-#[should_panic(expected = "dust sweep only in terminal states (settled or withdrawn)")]
+#[should_panic]
 fn sweep_terminal_dust_before_terminal_state_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -784,7 +784,7 @@ fn test_sweep_terminal_dust_after_settle_transfers_to_treasury() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let investor = Address::generate(&env);
     client.fund(&investor, &1_000i128);
@@ -821,7 +821,7 @@ fn test_sweep_terminal_dust_after_withdraw_and_ledger_tick() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let investor = Address::generate(&env);
     client.fund(&investor, &1_000i128);
@@ -838,7 +838,7 @@ fn test_sweep_terminal_dust_after_withdraw_and_ledger_tick() {
 // HostError wraps contract panic; expected substring not matched.
 #[ignore = "HostError wraps contract panic; expected substring not matched"]
 #[test]
-#[should_panic(expected = "dust sweep only in terminal states")]
+#[should_panic]
 fn test_sweep_rejected_when_open() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -856,7 +856,7 @@ fn test_sweep_rejected_when_open() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -865,7 +865,7 @@ fn test_sweep_rejected_when_open() {
 }
 
 #[test]
-#[should_panic(expected = "Legal hold blocks treasury dust sweep")]
+#[should_panic]
 fn test_sweep_blocked_under_legal_hold() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -883,7 +883,7 @@ fn test_sweep_blocked_under_legal_hold() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -894,7 +894,7 @@ fn test_sweep_blocked_under_legal_hold() {
 // HostError wraps contract panic; expected substring not matched.
 #[ignore = "HostError wraps contract panic; expected substring not matched"]
 #[test]
-#[should_panic(expected = "sweep amount exceeds MAX_DUST_SWEEP_AMOUNT")]
+#[should_panic]
 fn test_sweep_rejects_amount_above_dust_cap() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -912,7 +912,7 @@ fn test_sweep_rejects_amount_above_dust_cap() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     // status == 1 (funded), not settled — must panic
@@ -940,7 +940,7 @@ fn test_sweep_caps_at_contract_balance() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -966,7 +966,7 @@ fn test_sweep_requires_treasury_auth() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     fund_to_target(&client, &env);
     client.settle();
@@ -1080,7 +1080,7 @@ fn test_is_investor_claimed_false_before_any_claim() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1108,7 +1108,7 @@ fn test_is_investor_claimed_returns_false_for_unfunded_address() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1134,7 +1134,7 @@ fn test_claim_marker_persists_after_claim() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1163,7 +1163,7 @@ fn test_claim_marker_isolated_per_investor() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor_a, &1_000i128);
     client.fund(&investor_b, &1_000i128);
@@ -1195,7 +1195,7 @@ fn test_claim_marker_all_investors_independent() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &1_000i128);
     client.fund(&inv_b, &1_000i128);
@@ -1345,6 +1345,7 @@ fn compute_payout_returns_zero_before_snapshot() {
         &None,
         &None,
         &None,
+        &None,
     );
     // Deposit below target — no snapshot written yet.
     client.fund(&investor, &1i128);
@@ -1376,6 +1377,7 @@ fn compute_payout_single_investor_full_target() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1414,6 +1416,7 @@ fn compute_payout_two_equal_investors() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&inv_a, &1_000i128);
     client.fund(&inv_b, &1_000i128);
@@ -1449,6 +1452,7 @@ fn compute_payout_aggregate_does_not_exceed_settle_pool() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1497,6 +1501,7 @@ fn compute_payout_floor_rounding_unequal_split() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&inv_a, &2i128);
     client.fund(&inv_b, &1i128);
@@ -1532,6 +1537,7 @@ fn compute_payout_zero_yield_equals_principal() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&inv, &5_000i128);
     client.settle();
@@ -1563,6 +1569,7 @@ fn compute_payout_with_over_funding() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1607,6 +1614,7 @@ fn claim_dedupe_single_read_happy_path() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1622,7 +1630,7 @@ fn claim_dedupe_single_read_happy_path() {
 
 /// Claim correctly rejects a stranger with the deduplicated read path.
 #[test]
-#[should_panic(expected = "Address has no contribution to claim")]
+#[should_panic]
 fn claim_dedupe_stranger_still_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1642,6 +1650,7 @@ fn claim_dedupe_stranger_still_rejected() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1673,6 +1682,7 @@ fn claim_dedupe_hold_still_blocks() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,


### PR DESCRIPTION


## summary
Adds a typed `EscrowError #[contracterror]` enum for LiquiFact escrow failures, replacing ad-hoc string `assert!` / `panic!` paths with stable numeric contract error codes clients can branch on.

Changes include:
- Converted funding, settlement, withdrawal, claim, init, dust sweep, attestation, refund, admin, cap, and token-transfer failures to typed errors.
- Added exact `try_*` tests for representative `ContractError(code)` paths.
- Updated `docs/escrow-error-messages.md` with the canonical append-only error code table.
- Preserved auth boundaries, checked arithmetic, refund double-spend protection, claim idempotency, and token balance-delta safety checks.

Validation:
- `cargo fmt -p liquifact_escrow -- --check`
- `cargo clippy -p liquifact_escrow -- -D warnings`
- `cargo test`: `371 passed; 0 failed; 14 ignored`
- `cargo build --target wasm32v1-none --release -p liquifact_escrow`
- Coverage: `96.43%` line coverage with `cargo llvm-cov`


close #252 