### PR TITLE
test(escrow): snapshot immutability and over-funding capture

### DIFF
--- a/docs/escrow-snapshot.md
+++ b/docs/escrow-snapshot.md
@@ -1,10 +1,10 @@
 # Funding Close Snapshot
 
-The `FundingCloseSnapshot` is a critical piece of the LiquiFact Escrow contract's audit trail. it captures the exact state of the escrow at the moment it transitions from `Open` (0) to `Funded` (1).
+The `FundingCloseSnapshot` is a critical piece of the LiquiFact Escrow contract's audit trail. It captures the exact state of the escrow at the moment it transitions from `Open` (0) to `Funded` (1).
 
 ## Purpose
 
-This snapshot serves as the **immutable source of truth** for off-chain pro-rata calculations. When an invoice is over-funded (which is allowed by the contract), the total principal at the moment of funding completion becomes the denominator for investor share calculations.
+This snapshot serves as the **immutable source of truth** for off-chain pro-rata calculations. When an invoice is over-funded (which is allowed by the contract), the full `funded_amount` at the threshold-crossing deposit becomes the denominator for investor share calculations, even when it is greater than `funding_target`.
 
 By capturing this state once and making it immutable, the contract ensures that subsequent actions (like SME withdrawals or settlements) do not shift the relative weight of investor contributions.
 
@@ -12,22 +12,29 @@ By capturing this state once and making it immutable, the contract ensures that 
 
 The snapshot is stored under `DataKey::FundingCloseSnapshot` and contains:
 
-- `total_principal`: The sum of all principal contributed at the moment the funding target was met or exceeded.
+- `total_principal`: The sum of all principal contributed at the moment the funding target was met or exceeded. This equals `InvoiceEscrow.funded_amount` at close and can be greater than `funding_target`.
 - `funding_target`: The original target for the invoice.
 - `closed_at_ledger_timestamp`: The ledger timestamp when the snapshot was captured.
 - `closed_at_ledger_sequence`: The ledger sequence number when the snapshot was captured.
 
 ## Lifecycle and Immutability
 
-1. **Creation**: The snapshot is created during `fund` or `fund_with_commitment` only when `status == 0` and the new `funded_amount >= funding_target`.
-2. **Write-Once**: Once the snapshot is written, the contract's logic prevents it from being updated or overwritten.
-3. **Persistence**: The snapshot survives all state transitions, including `settle` and `withdraw`.
+1. **Before close**: `get_funding_close_snapshot()` returns `None` while the escrow is still open and below target.
+2. **Creation**: The snapshot is created during `fund` or `fund_with_commitment` only when `status == 0` and the new `funded_amount >= funding_target`.
+3. **Over-funding capture**: If the threshold-crossing deposit overshoots the target, `total_principal` records the full over-funded close amount.
+4. **Write-Once**: Once the snapshot is written, the contract's logic prevents it from being updated or overwritten. Later funding attempts are rejected because the escrow is no longer open, and later lifecycle writes do not touch `DataKey::FundingCloseSnapshot`.
+5. **Persistence**: The snapshot survives all state transitions, including `settle` and `withdraw`.
 
 ## Auditing
 
 Integrators can use the `get_funding_close_snapshot` getter to retrieve this metadata. For historical auditing, the `EscrowFunded` event emitted during the snapshot creation contains the `funded_amount` and `status: 1`, allowing off-chain systems to reconcile the snapshot with the event stream.
 
+The `closed_at_ledger_timestamp` and `closed_at_ledger_sequence` fields are captured from the same ledger as the threshold-crossing funding call. Off-chain indexers should use those fields as the canonical close boundary for pro-rata reporting.
+
 ## Security Considerations
 
 1. **Time and Sequence Bounds**: The snapshot captures `env.ledger().timestamp()` and `env.ledger().sequence()`. In Soroban, these are provided by the host environment and are reliable for on-chain time-based logic. Off-chain systems should treat these as the canonical boundaries for the "funded" state transition.
-2. **Token Economics and Assumptions**: As detailed in `escrow/src/external_calls.rs`, this contract strictly assumes standard SEP-41 token mechanics. Malicious, rebasing, or fee-on-transfer (FOT) tokens are **explicitly out of scope** and will trigger safe-failure panics at the balance-check boundaries. This ensures that the `total_principal` captured in the snapshot perfectly matches the real token balance stored in the contract treasury, preserving the integrity of off-chain payout calculations.
+2. **Write-Once Denominator**: `DataKey::FundingCloseSnapshot` is only set if it does not already exist. State transitions such as `settle` and `withdraw` do not recompute the denominator, which prevents later writes from changing investor weights.
+3. **State-Machine Misuse**: Funding after close is rejected by the `status == 0` funding guard before contribution or snapshot state can be mutated.
+4. **Overflow and Amount Guards**: Funding uses positive amount checks and checked arithmetic before writing `funded_amount` or contribution records.
+5. **Token Economics and Assumptions**: As detailed in `escrow/src/external_calls.rs`, this contract strictly assumes standard SEP-41 token mechanics. Malicious, rebasing, or fee-on-transfer (FOT) tokens are **explicitly out of scope** and will trigger safe-failure panics at the balance-check boundaries. This ensures that the `total_principal` captured in the snapshot matches standard token accounting assumptions, preserving the integrity of off-chain payout calculations.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -150,20 +150,18 @@ pub const MAX_DUST_SWEEP_AMOUNT: i128 = 100_000_000;
 pub const MAX_INVOICE_ID_STRING_LEN: u32 = 32;
 
 /// Minimum instance storage TTL extension horizon for time-sensitive escrow entries.
-
 ///
 /// `bump_ttl` extends instance-storage entries to avoid rent/archival edge cases when
 /// maturity/claim locks are far in the future.
 ///
 /// Named as a constant so operators can reason about and audit the threshold.
-pub const INSTANCE_TTL_MIN_EXTENSION_SECS: u64 = 60 * 60; // 1h
+pub const INSTANCE_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 ledger/sec.
 
 /// Minimum persistent storage TTL extension horizon for per-investor allowlist entries.
 ///
 /// When the escrow uses the allowlist gate, investor funding depends on persistent entries.
 /// Extending persistent allowlist TTL reduces the risk of silent allowlist disablement.
-pub const PERSISTENT_TTL_MIN_EXTENSION_SECS: u64 = 60 * 60; // 1h
-
+pub const PERSISTENT_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 ledger/sec.
 
 // --- Storage keys ---
 
@@ -310,12 +308,16 @@ pub struct YieldTier {
     pub yield_bps: i64,
 }
 
-/// Captured at the first ledger transition to **funded** so partial settlement / claims can use a
-/// stable total principal and target. **Immutable** once written.
+/// Captured exactly once at the first ledger transition to **funded** so settlement and claims can
+/// use a stable total principal and target. If the threshold-crossing deposit overshoots
+/// [`InvoiceEscrow::funding_target`], [`FundingCloseSnapshot::total_principal`] records the full
+/// credited [`InvoiceEscrow::funded_amount`] at close and becomes the pro-rata denominator.
+/// **Immutable** once written.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct FundingCloseSnapshot {
-    /// Sum of principal credited when the invoice became funded (`funded_amount` at close), including overflow past target.
+    /// Sum of principal credited when the invoice became funded (`funded_amount` at close),
+    /// including over-funding past target.
     pub total_principal: i128,
     pub funding_target: i128,
     pub closed_at_ledger_timestamp: u64,
@@ -899,9 +901,7 @@ impl LiquifactEscrow {
     /// Optional cap on total principal for a single investor address.
     /// Absent ⇒ unlimited. Enforced on every deposit.
     pub fn get_max_per_investor_cap(env: Env) -> Option<i128> {
-        env.storage()
-            .instance()
-            .get(&DataKey::MaxPerInvestorCap)
+        env.storage().instance().get(&DataKey::MaxPerInvestorCap)
     }
 
     /// Distinct funders counted so far (each address counted once when it first receives principal).
@@ -1019,6 +1019,10 @@ impl LiquifactEscrow {
     }
 
     /// Pro-rata denominator captured when the escrow first became **funded**; [`None`] until then.
+    ///
+    /// The snapshot is write-once. It records the full `funded_amount` at the threshold-crossing
+    /// funding call, including any over-funding past `funding_target`, plus the close ledger time
+    /// and sequence used by off-chain auditors.
     pub fn get_funding_close_snapshot(env: Env) -> Option<FundingCloseSnapshot> {
         env.storage().instance().get(&DataKey::FundingCloseSnapshot)
     }
@@ -1195,7 +1199,7 @@ impl LiquifactEscrow {
         let n = investors.len();
         assert!(n > 0, "investors vector must be non-empty");
         assert!(
-            (n as u32) <= MAX_INVESTOR_ALLOWLIST_BATCH,
+            n <= MAX_INVESTOR_ALLOWLIST_BATCH,
             "investors vector length exceeds MAX_INVESTOR_ALLOWLIST_BATCH"
         );
 
@@ -1257,6 +1261,54 @@ impl LiquifactEscrow {
         .publish(&env);
 
         escrow
+    }
+
+    /// Lower the configured distinct-investor cap while the escrow is still open.
+    ///
+    /// This is admin-only and intentionally cannot raise a cap or impose one on an unlimited
+    /// escrow. Existing investors remain able to add principal after the cap is lowered; only new
+    /// investor addresses are blocked once `UniqueFunderCount >= new_cap`.
+    ///
+    /// # Panics
+    /// - If the escrow is not open.
+    /// - If no unique-investor cap was configured at initialization.
+    /// - If `new_cap` is not strictly lower than the current cap.
+    /// - If `new_cap` is below the current unique funder count.
+    pub fn lower_max_unique_investors(env: Env, new_cap: u32) -> u32 {
+        let escrow = Self::get_escrow(env.clone());
+        escrow.admin.require_auth();
+
+        assert!(escrow.status == 0, "Cap can only be lowered in Open state");
+
+        let old_cap: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxUniqueInvestorsCap)
+            .unwrap_or_else(|| panic!("no investor cap configured"));
+        let unique_count = Self::get_unique_funder_count(env.clone());
+
+        assert!(
+            new_cap < old_cap,
+            "new cap must be strictly lower than current cap"
+        );
+        assert!(
+            new_cap >= unique_count,
+            "new cap cannot be below current unique funder count"
+        );
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxUniqueInvestorsCap, &new_cap);
+
+        MaxUniqueInvestorsCapLowered {
+            name: symbol_short!("inv_cap"),
+            invoice_id: escrow.invoice_id.clone(),
+            old_cap,
+            new_cap,
+        }
+        .publish(&env);
+
+        new_cap
     }
 
     /// Validate the stored schema version and apply a migration if one is implemented.
@@ -1483,9 +1535,6 @@ impl LiquifactEscrow {
             }
         }
 
-        let next_contribution = prev
-            .checked_add(amount)
-            .expect("investor contribution overflow");
         env.storage()
             .instance()
             .set(&contribution_key, &new_contribution);
@@ -1795,55 +1844,28 @@ impl LiquifactEscrow {
         // - ADR-007: storage key evolution policy (additive changes / key semantics).
         // - docs/escrow-ledger-time.md: all gating uses `Env::ledger().timestamp()` with `>=`.
 
-        // Instance storage keys required for settlement + gating behavior.
-        let k_escrow: DataKey = DataKey::Escrow;
-        env.storage().instance().extend_ttl(&k_escrow, &INSTANCE_TTL_MIN_EXTENSION_SECS);
+        env.storage().instance().extend_ttl(
+            INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
+            INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
+        );
 
-        let k_version: DataKey = DataKey::Version;
-        env.storage().instance().extend_ttl(&k_version, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        let k_legal_hold: DataKey = DataKey::LegalHold;
-        env.storage().instance().extend_ttl(&k_legal_hold, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        let k_allowlist_active: DataKey = DataKey::AllowlistActive;
-        env.storage()
-            .instance()
-            .extend_ttl(&k_allowlist_active, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        let k_snapshot: DataKey = DataKey::FundingCloseSnapshot;
-        env.storage()
-            .instance()
-            .extend_ttl(&k_snapshot, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-        // Investor contribution + claim gates are instance keys (per investor).
-        // We cannot enumerate contributors on-chain; extend only what the caller provides.
-        for addr in allowlisted.iter() {
-            // Contribution + claim-gate entries are instance-scoped and per-investor.
-            let k_contrib = DataKey::InvestorContribution(addr.clone());
-            env.storage()
-                .instance()
-                .extend_ttl(&k_contrib, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-
-            let k_claim_not_before = DataKey::InvestorClaimNotBefore(addr.clone());
-            env.storage()
-                .instance()
-                .extend_ttl(&k_claim_not_before, &INSTANCE_TTL_MIN_EXTENSION_SECS);
-        }
-
+        // Instance storage TTL is contract-wide under Soroban SDK 25. The call above covers
+        // Escrow, Version, LegalHold, snapshots, and all per-investor instance keys.
 
         // Persistent allowlist entries.
         for addr in allowlisted.iter() {
             let k = DataKey::InvestorAllowlisted(addr.clone());
-            env.storage()
-                .persistent()
-                .extend_ttl(&k, &PERSISTENT_TTL_MIN_EXTENSION_SECS);
+            env.storage().persistent().extend_ttl(
+                &k,
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            );
         }
     }
 
     pub fn transfer_admin(env: Env, new_admin: Address) -> InvoiceEscrow {
         // env.clone(): env is used again after this call for storage set and publish.
         let mut escrow = Self::get_escrow(env.clone());
-
 
         escrow.admin.require_auth();
 

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -1,6 +1,9 @@
-use super::{LiquifactEscrow, LiquifactEscrowClient};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use super::{
+    AllowlistEnabledChanged, DataKey, InvestorAllowlistChanged, LiquifactEscrow,
+    LiquifactEscrowClient,
+};
 use soroban_sdk::Vec as SorobanVec;
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Event};
 
 fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
     let id = env.register(LiquifactEscrow, ());
@@ -25,7 +28,7 @@ fn init(env: &Env, client: &LiquifactEscrowClient) -> (Address, Address) {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     (admin, sme)
 }

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -24,6 +24,7 @@ use soroban_sdk::{
 mod admin;
 mod attestations;
 mod cap_validation;
+mod coverage;
 mod external_calls;
 mod external_calls_mocked;
 mod funding;
@@ -109,7 +110,7 @@ pub fn default_init(client: &LiquifactEscrowClient<'_>, env: &Env, admin: &Addre
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -22,7 +22,7 @@ fn test_update_maturity_success() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let updated = client.update_maturity(&2000u64);
     assert_eq!(updated.maturity, 2000u64);
@@ -48,7 +48,7 @@ fn test_update_maturity_wrong_state() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.update_maturity(&2000u64);
@@ -75,7 +75,7 @@ fn test_update_maturity_unauthorized() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     env.mock_auths(&[]);
     client.update_maturity(&2000u64);
@@ -99,7 +99,7 @@ fn test_transfer_admin_updates_admin() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let updated = client.transfer_admin(&new_admin);
     assert_eq!(updated.admin, new_admin);
@@ -124,7 +124,7 @@ fn test_transfer_admin_same_address_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.transfer_admin(&admin);
 }
@@ -199,7 +199,7 @@ fn test_record_collateral_stored_and_does_not_block_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
     assert_eq!(c.amount, 5000i128);
@@ -229,7 +229,7 @@ fn test_collateral_zero_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
 }
@@ -252,7 +252,7 @@ fn test_collateral_requires_sme_auth() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     env.mock_auths(&[]);
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &100i128);
@@ -276,7 +276,7 @@ fn test_legal_hold_blocks_settle_withdraw_claim_and_fund() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &TARGET);
     client.set_legal_hold(&true);
@@ -327,7 +327,7 @@ fn test_legal_hold_blocks_new_funds_when_open() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.set_legal_hold(&true);
     client.fund(&investor, &1i128);
@@ -367,7 +367,7 @@ fn test_update_funding_target_by_admin_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let updated = client.update_funding_target(&10_000i128);
@@ -398,7 +398,7 @@ fn test_update_funding_target_by_non_admin_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     env.mock_auths(&[]);
@@ -430,7 +430,7 @@ fn test_update_funding_target_fails_when_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128);
     client.update_funding_target(&10_000i128);
@@ -461,7 +461,7 @@ fn test_update_funding_target_below_funded_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &4_000i128);
     client.update_funding_target(&3_000i128);
@@ -491,7 +491,7 @@ fn test_update_funding_target_zero_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.update_funding_target(&0i128);
 }
@@ -527,7 +527,7 @@ fn test_update_funding_target_event_fields() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_funding_target(&9_000i128);
@@ -571,7 +571,7 @@ fn test_update_funding_target_fails_when_settled() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.settle(); // status → 2 (settled)
@@ -605,7 +605,7 @@ fn test_update_funding_target_fails_when_withdrawn() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.withdraw(); // status → 3 (withdrawn)
@@ -639,7 +639,7 @@ fn test_update_funding_target_equal_to_funded_amount_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
 
@@ -675,7 +675,7 @@ fn test_update_funding_target_negative_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.update_funding_target(&-1i128);
 }
@@ -712,7 +712,7 @@ fn test_update_maturity_event_fields() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_maturity(&2000u64);
@@ -756,7 +756,7 @@ fn test_update_maturity_fails_when_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.update_maturity(&2000u64);
@@ -789,7 +789,7 @@ fn test_update_maturity_fails_when_settled() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1
     client.settle(); // status → 2
@@ -823,7 +823,7 @@ fn test_update_maturity_fails_when_withdrawn() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128); // status → 1
     client.withdraw(); // status → 3
@@ -855,7 +855,7 @@ fn test_update_maturity_to_zero_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let updated = client.update_maturity(&0u64);
     assert_eq!(updated.maturity, 0u64);
@@ -889,7 +889,7 @@ fn test_settle_passes_exactly_at_maturity_ledger_time() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128);
 
@@ -926,7 +926,7 @@ fn test_settle_fails_one_second_before_maturity() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &5_000i128);
 
@@ -960,7 +960,7 @@ fn test_update_maturity_twice_overwrites() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_maturity(&2000u64);
@@ -1122,6 +1122,7 @@ fn auth_audit_sweep_terminal_dust_requires_treasury() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -26,7 +26,7 @@ fn test_unique_funder_count_basic_functionality() {
         &None,
         &None,
         &Some(3u32),
-        &None
+        &None,
     );
 
     // Verify initial state
@@ -77,7 +77,7 @@ fn test_cap_enforcement_blocks_excess_investors() {
         &None,
         &None,
         &Some(2u32),
-        &None
+        &None,
     );
 
     // Add two investors — reaches the investor cap but NOT the funding target.
@@ -115,7 +115,7 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &Some(1u32),
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -156,7 +156,7 @@ fn test_no_cap_allows_unlimited_investors() {
         &None,
         &None,
         &None, // No distinct-investor cap set
-        &None
+        &None,
     );
 
     assert_eq!(client.get_max_unique_investors_cap(), None);
@@ -194,7 +194,7 @@ fn test_max_per_investor_cap_blocks_excess_principal() {
         &None,
         &None,
         &Some(2u32),
-        &Some(50_000_000_000i128)
+        &Some(50_000_000_000i128),
     );
 
     let inv1 = Address::generate(&env);
@@ -227,7 +227,7 @@ fn test_init_zero_max_per_investor_panics() {
         &None,
         &None,
         &Some(2u32),
-        &Some(0i128)
+        &Some(0i128),
     );
 }
 
@@ -260,7 +260,7 @@ fn test_cap_with_fund_with_commitment() {
         &Some(tiers),
         &None,
         &Some(2u32),
-        &None
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -303,6 +303,7 @@ fn test_lower_max_unique_investors_success() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -338,6 +339,7 @@ fn test_lower_cap_blocks_new_investors_at_lowered_limit() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &20_000_000_000i128);
@@ -368,6 +370,7 @@ fn test_lower_cap_existing_investors_may_refund() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -403,6 +406,7 @@ fn test_lower_cap_rejects_raise() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     client.lower_max_unique_investors(&4u32);
@@ -430,6 +434,7 @@ fn test_lower_cap_rejects_below_funder_count() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10_000_000_000i128);
@@ -460,6 +465,7 @@ fn test_lower_cap_rejects_non_open_state() {
         &None,
         &None,
         &Some(3u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100_000_000_000i128);
@@ -489,6 +495,7 @@ fn test_lower_cap_rejects_unlimited_escrow() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.lower_max_unique_investors(&10u32);
@@ -515,6 +522,7 @@ fn test_lower_cap_requires_admin_auth() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     client.lower_max_unique_investors(&3u32);
@@ -546,6 +554,7 @@ fn test_lower_cap_unauthorized_panics() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     env.mock_auths(&[]);
@@ -576,6 +585,7 @@ fn test_lower_cap_emits_event() {
         &None,
         &None,
         &Some(5u32),
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10_000_000_000i128);

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -1,7 +1,5 @@
-use crate::{
-    test::{free_addresses, setup},
-    DataKey, YieldTier, EscrowSummary, EscrowCloseSnapshot,
-};
+use super::{free_addresses, setup};
+use crate::{DataKey, EscrowCloseSnapshot, YieldTier};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     Address, Env, Vec as SorobanVec,
@@ -36,7 +34,7 @@ fn test_migrate_already_current() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.migrate(&5);
@@ -63,7 +61,7 @@ fn test_migrate_no_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     env.as_contract(&client.address, || {
@@ -93,7 +91,7 @@ fn test_admin_and_maturity_updates() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let updated = client.update_maturity(&200);
@@ -125,7 +123,7 @@ fn test_update_maturity_not_open() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -154,7 +152,7 @@ fn test_transfer_admin_same_admin() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.transfer_admin(&admin);
@@ -181,7 +179,7 @@ fn test_fund_during_legal_hold() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.set_legal_hold(&true);
@@ -210,7 +208,7 @@ fn test_fund_below_floor() {
         &None,
         &Some(50),
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -238,7 +236,7 @@ fn test_claim_not_settled() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -267,7 +265,7 @@ fn test_claim_lock_not_expired() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -300,7 +298,7 @@ fn test_all_getters() {
         &None,
         &Some(10),
         &Some(5),
-        &None
+        &None,
     );
 
     assert_eq!(client.get_funding_token(), funding_token);
@@ -335,7 +333,7 @@ fn test_attestations_happy_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let hash1 = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
@@ -370,7 +368,7 @@ fn test_bind_primary_attestation_twice() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let hash = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
@@ -398,7 +396,7 @@ fn test_unique_investors_cap() {
         &None,
         &None,
         &Some(2),
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10);
@@ -427,7 +425,7 @@ fn test_unique_investors_cap_exceeded() {
         &None,
         &None,
         &Some(1),
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10);
@@ -455,7 +453,7 @@ fn test_sweep_terminal_dust_happy_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -470,7 +468,7 @@ fn test_sweep_terminal_dust_happy_path() {
 }
 
 #[test]
-#[should_panic(expected = "dust sweep only in terminal states (settled or withdrawn)")]
+#[should_panic(expected = "dust sweep only in terminal states (settled, withdrawn, or cancelled)")]
 fn test_sweep_not_terminal() {
     let env = Env::default();
     env.mock_all_auths();
@@ -489,7 +487,7 @@ fn test_sweep_not_terminal() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.sweep_terminal_dust(&10);
@@ -516,7 +514,7 @@ fn test_sweep_no_balance() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -545,7 +543,7 @@ fn test_withdraw_happy_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -575,7 +573,7 @@ fn test_settle_too_early() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -601,7 +599,7 @@ fn test_update_funding_target_happy_path() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let updated = client.update_funding_target(&200);
@@ -628,7 +626,7 @@ fn test_update_funding_target_too_low() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &50);
@@ -654,7 +652,7 @@ fn test_sme_collateral_commitment() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let asset = soroban_sdk::Symbol::new(&env, "GOLD");
@@ -686,6 +684,7 @@ fn test_sme_collateral_empty_asset_rejected() {
         &None,
         &None,
         &None,
+        &None,
     );
     let empty_asset = soroban_sdk::Symbol::new(&env, "");
     client.record_sme_collateral_commitment(&empty_asset, &5000);
@@ -708,6 +707,7 @@ fn test_sme_collateral_stale_timestamp_rejected() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -738,6 +738,7 @@ fn test_sme_collateral_replacement_preserves_prior_amount() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -777,7 +778,7 @@ fn test_clear_legal_hold_convenience() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.set_legal_hold(&true);
@@ -805,7 +806,7 @@ fn test_claim_not_before_getter() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -844,7 +845,7 @@ fn test_init_with_tiers() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_escrow().yield_bps, 100); // Default yield
 }
@@ -869,7 +870,7 @@ fn test_sweep_too_much() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -899,7 +900,7 @@ fn test_withdraw_not_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.withdraw();
@@ -925,7 +926,7 @@ fn test_settle_not_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.settle();
@@ -950,7 +951,7 @@ fn test_fund_with_zero_commitment() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -978,7 +979,7 @@ fn test_update_target_invalid() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.update_funding_target(&0);
@@ -1004,7 +1005,7 @@ fn test_init_yield_out_of_range() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1028,7 +1029,7 @@ fn test_init_min_contribution_zero() {
         &None,
         &Some(0),
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1061,7 +1062,7 @@ fn test_init_tiers_unsorted() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1094,7 +1095,7 @@ fn test_init_tiers_not_increasing_yield() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1123,7 +1124,7 @@ fn test_init_tiers_lower_than_base() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1146,7 +1147,7 @@ fn test_get_yield_bps_empty_tiers_branch() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     // Inject empty tiers directly to trigger the branch in get_yield_bps_for_commitment
@@ -1187,7 +1188,7 @@ fn test_init_tier_yield_out_of_range() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1219,6 +1220,7 @@ fn test_get_escrow_summary_happy_path() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let summary = client.get_escrow_summary();
@@ -1226,13 +1228,16 @@ fn test_get_escrow_summary_happy_path() {
     // Verify fields match individual getters
     assert_eq!(summary.escrow, client.get_escrow());
     assert_eq!(summary.legal_hold, client.get_legal_hold());
-    
+
     let expected_snapshot = match client.get_funding_close_snapshot() {
         Some(snap) => EscrowCloseSnapshot::Some(snap),
         None => EscrowCloseSnapshot::None,
     };
     assert_eq!(summary.funding_close_snapshot, expected_snapshot);
-    assert_eq!(summary.unique_funder_count, client.get_unique_funder_count());
+    assert_eq!(
+        summary.unique_funder_count,
+        client.get_unique_funder_count()
+    );
     assert_eq!(summary.is_allowlist_active, client.is_allowlist_active());
     assert_eq!(summary.schema_version, client.get_version());
 
@@ -1264,29 +1269,33 @@ fn test_get_escrow_summary_after_state_changes() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Make state changes
-    client.set_legal_hold(&true);
     client.set_allowlist_active(&true);
 
     let investor = Address::generate(&env);
     client.set_investor_allowlisted(&investor, &true);
     // Fund enough to trigger funded status and capture snapshot
     client.fund(&investor, &1000);
+    client.set_legal_hold(&true);
 
     let summary = client.get_escrow_summary();
 
     // Verify fields match individual getters under state changes
     assert_eq!(summary.escrow, client.get_escrow());
     assert_eq!(summary.legal_hold, client.get_legal_hold());
-    
+
     let expected_snapshot = match client.get_funding_close_snapshot() {
         Some(snap) => EscrowCloseSnapshot::Some(snap),
         None => EscrowCloseSnapshot::None,
     };
     assert_eq!(summary.funding_close_snapshot, expected_snapshot);
-    assert_eq!(summary.unique_funder_count, client.get_unique_funder_count());
+    assert_eq!(
+        summary.unique_funder_count,
+        client.get_unique_funder_count()
+    );
     assert_eq!(summary.is_allowlist_active, client.is_allowlist_active());
     assert_eq!(summary.schema_version, client.get_version());
 
@@ -1295,7 +1304,10 @@ fn test_get_escrow_summary_after_state_changes() {
     assert!(summary.is_allowlist_active);
     assert_eq!(summary.unique_funder_count, 1);
     assert_eq!(summary.escrow.status, 1); // Funded
-    assert!(matches!(summary.funding_close_snapshot, EscrowCloseSnapshot::Some(_)));
+    assert!(matches!(
+        summary.funding_close_snapshot,
+        EscrowCloseSnapshot::Some(_)
+    ));
 
     let snapshot = match &summary.funding_close_snapshot {
         EscrowCloseSnapshot::Some(snap) => snap.clone(),

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -20,7 +20,7 @@ fn test_fund_and_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let funded = client.fund(&investor, &TARGET);
     assert_eq!(funded.funded_amount, TARGET);
@@ -47,7 +47,7 @@ fn test_fund_partial_then_full() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let partial = client.fund(&investor, &(TARGET / 2));
     assert_eq!(partial.status, 0);
@@ -109,7 +109,7 @@ fn test_single_investor_contribution_tracked() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(30_000_000_000i128));
     let contribution = client.get_contribution(&investor);
@@ -145,7 +145,7 @@ fn test_repeated_funding_accumulates_contribution() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(20_000_000_000i128));
     client.fund(&investor, &(30_000_000_000i128));
@@ -157,7 +157,8 @@ fn test_repeated_funding_accumulates_contribution() {
 fn test_funding_amount_accumulation_overflow_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
-    let investor = Address::generate(&env);
+    let investor_a = Address::generate(&env);
+    let investor_b = Address::generate(&env);
     client.init(
         &admin,
         &String::from_str(&env, "OVF001"),
@@ -171,11 +172,11 @@ fn test_funding_amount_accumulation_overflow_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
-    client.fund(&investor, &(i128::MAX - 1));
-    client.fund(&investor, &2i128);
+    client.fund(&investor_a, &(i128::MAX - 1));
+    client.fund(&investor_b, &2i128);
 }
 
 #[test]
@@ -196,7 +197,7 @@ fn test_funding_amount_overflow_does_not_mutate_state() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &(i128::MAX - 1));
@@ -233,6 +234,7 @@ fn test_fund_with_commitment_overflow_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&investor_a, &(i128::MAX - 1));
@@ -255,6 +257,7 @@ fn test_fund_with_commitment_overflow_does_not_mutate_state() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -305,6 +308,7 @@ fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     env.as_contract(&contract_id, || {
@@ -345,6 +349,7 @@ fn test_investor_contribution_overflow_does_not_mutate_state() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -393,7 +398,7 @@ fn test_multiple_investors_tracked_independently() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
@@ -427,7 +432,7 @@ fn test_contributions_sum_equals_funded_amount() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
@@ -456,7 +461,7 @@ fn test_cost_baseline_fund_partial() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(10_000_000_000i128));
 }
@@ -479,7 +484,7 @@ fn test_cost_baseline_fund_full() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &TARGET);
 }
@@ -502,7 +507,7 @@ fn test_cost_baseline_fund_overshoot() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(150_000_000_000i128));
     assert_eq!(client.get_escrow().status, 1);
@@ -526,7 +531,7 @@ fn test_cost_baseline_fund_two_step_completion() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &(TARGET / 2));
     client.fund(&investor, &(TARGET / 2));
@@ -555,7 +560,7 @@ fn test_funding_close_snapshot_captures_overfunded_total_once() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_funding_close_snapshot(), None);
     client.fund(&inv, &(TARGET + 50_000_000_000i128));
@@ -589,7 +594,7 @@ fn test_funding_snapshot_immutable_across_second_fund_after_funded() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&a, &(TARGET / 2));
     assert_eq!(client.get_funding_close_snapshot(), None);
@@ -623,7 +628,7 @@ fn test_pro_rata_weight_ratio_from_snapshot() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&a, &(20_000_000_000i128));
     client.fund(&b, &(80_000_000_000i128));
@@ -665,7 +670,7 @@ fn test_tiered_yield_and_follow_on_fund() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &5_000i128, &200u64);
     assert_eq!(client.get_investor_yield_bps(&inv), 900);
@@ -703,7 +708,7 @@ fn test_tier_selection_edges_base_vs_high_bucket() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&i_short, &10_000i128, &40u64);
     assert_eq!(client.get_investor_yield_bps(&i_short), 800);
@@ -739,7 +744,7 @@ fn test_fund_with_commitment_twice_panics() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
@@ -768,7 +773,7 @@ fn test_fund_then_fund_with_commitment_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv, &5_000i128);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
@@ -806,7 +811,7 @@ fn test_tier_selection_ladder() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     let inv_base = Address::generate(&env);
@@ -860,7 +865,7 @@ fn test_fund_with_commitment_zero_lock_behaves_as_fund() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&inv, &5_000i128, &0u64);
@@ -893,7 +898,7 @@ fn test_commitment_claim_time_allows_u64_max_boundary() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&investor, &100i128, &5u64);
@@ -927,7 +932,7 @@ fn test_commitment_claim_time_overflow_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&investor, &100i128, &6u64);
@@ -958,7 +963,7 @@ fn test_commitment_claim_time_overflow_does_not_record_position() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -1002,7 +1007,7 @@ fn test_init_bad_tier_order_panics() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1033,7 +1038,7 @@ fn test_init_tier_yield_below_base_panics() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -1060,7 +1065,7 @@ fn test_differential_funding_target_eq_exact_cross() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let escrow = client.fund(&inv, &t);
     assert_eq!(escrow.funded_amount, t);
@@ -1092,7 +1097,7 @@ fn test_ledger_sequence_recorded_in_snapshot_with_tick() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let seq = env.ledger().sequence();
     client.fund(&inv, &1_000i128);
@@ -1122,7 +1127,7 @@ fn test_get_funding_close_snapshot_absent_before_any_funding() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(
         client.get_funding_close_snapshot(),
@@ -1154,7 +1159,7 @@ fn test_get_funding_close_snapshot_present_after_funding_completes() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     // Partial fund — snapshot still absent.
     client.fund(&inv, &(TARGET / 2));
@@ -1197,7 +1202,7 @@ fn test_get_funding_close_snapshot_immutable_after_set() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     // Fund exactly to target — snapshot is written here.
     client.fund(&inv, &TARGET);
@@ -1234,7 +1239,7 @@ fn test_unique_funder_count_initialized_to_zero() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_unique_funder_count(), 0);
 }
@@ -1257,7 +1262,7 @@ fn test_unique_funder_count_increments_on_first_investor() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_unique_funder_count(), 0);
     client.fund(&investor, &(TARGET / 2));
@@ -1286,7 +1291,7 @@ fn test_unique_funder_count_increments_for_distinct_investors() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_unique_funder_count(), 0);
 
@@ -1330,7 +1335,7 @@ fn test_unique_funder_count_with_fund_with_commitment() {
         &Some(tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -1361,6 +1366,7 @@ fn test_max_unique_investors_cap_none_allows_unlimited() {
         &None,
         &None,
         &None, // No cap set
+        &None,
     );
 
     // Should be able to add many investors when no cap is set
@@ -1389,6 +1395,7 @@ fn test_max_unique_investors_cap_enforced_at_limit() {
         &None,
         &None,
         &Some(3u32), // Cap of 3 investors
+        &None,
     );
 
     assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
@@ -1430,6 +1437,7 @@ fn test_max_unique_investors_cap_blocks_excess_investors() {
         &None,
         &None,
         &Some(2u32), // Cap of 2 investors
+        &None,
     );
 
     // Add 2 investors
@@ -1472,6 +1480,7 @@ fn test_max_unique_investors_cap_blocks_fund_with_commitment() {
         &Some(tiers),
         &None,
         &Some(1u32), // Cap of 1 investor
+        &None,
     );
 
     // First investor succeeds
@@ -1502,6 +1511,7 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &Some(1u32), // Cap of 1 investor
+        &None,
     );
 
     // First fund should succeed
@@ -1536,6 +1546,7 @@ fn test_zero_contribution_then_non_zero_contribution_counts_as_unique_investor()
         &None,
         &None,
         &Some(2u32), // Cap of 2 investors
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -1567,6 +1578,7 @@ fn test_cap_validation_at_init_positive_value_required() {
         &None,
         &None,
         &Some(0u32), // Invalid: zero cap
+        &None,
     );
 }
 
@@ -1588,6 +1600,7 @@ fn test_init_panics_for_zero_cap() {
         &None,
         &None,
         &Some(0u32), // Invalid: zero cap
+        &None,
     );
 }
 
@@ -1609,6 +1622,7 @@ fn test_cap_edge_case_exact_limit_reached() {
         &None,
         &None,
         &Some(5u32), // Cap of 5 investors
+        &None,
     );
 
     // Add exactly 5 investors - should all succeed
@@ -1644,6 +1658,7 @@ fn test_cap_edge_case_exactly_one_over_limit_panics() {
         &None,
         &None,
         &Some(5u32), // Cap of 5 investors
+        &None,
     );
 
     // Add exactly 5 investors
@@ -1675,6 +1690,7 @@ fn test_cap_with_min_contribution_floor_interaction() {
         &None,
         &Some(1_000i128), // Min contribution floor
         &Some(3u32),      // Cap of 3 investors
+        &None,
     );
 
     // Should respect both cap and floor
@@ -1714,6 +1730,7 @@ fn test_cap_blocks_even_with_large_contribution() {
         &None,
         &None,
         &Some(1u32), // Cap of 1 investor
+        &None,
     );
 
     // First investor can fund large amount
@@ -1748,7 +1765,7 @@ fn test_cap_panic_message_quality() {
         &None,
         &None,
         &Some(1u32),
-        &None
+        &None,
     );
 
     // Add first investor
@@ -1783,6 +1800,7 @@ fn init_with_token<'a>(
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -21,7 +21,7 @@ fn test_init_stores_escrow() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(escrow.invoice_id, symbol_short!("INV001"));
     assert_eq!(escrow.admin, admin);
@@ -51,7 +51,7 @@ fn test_init_stores_keyed_invoice_and_lists_it() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let got = client.get_escrow();
     assert_eq!(got, escrow);
@@ -74,7 +74,7 @@ fn test_init_requires_admin_auth() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert!(
         env.auths().iter().any(|(addr, _)| *addr == admin),
@@ -102,7 +102,7 @@ fn test_init_unauthorized_panics() {
             &None,
             &None,
             &None,
-            &None
+            &None,
         );
     }));
     assert!(result.is_err(), "Expected panic without auth");
@@ -142,7 +142,7 @@ fn test_cost_baseline_init() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -163,7 +163,7 @@ fn test_cost_baseline_init_zero_maturity() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -184,7 +184,7 @@ fn test_cost_baseline_init_max_amount() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -210,7 +210,7 @@ fn test_init_invoice_id_empty_string_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -236,7 +236,7 @@ fn test_init_invoice_id_whitespace_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -263,7 +263,7 @@ fn test_init_invoice_id_too_long_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -289,7 +289,7 @@ fn test_init_invoice_id_bad_charset_hyphen_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 
@@ -316,7 +316,7 @@ fn test_init_stores_registry_some_and_getters() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_registry_ref(), Some(reg));
     assert_eq!(client.get_funding_token(), token);
@@ -347,7 +347,7 @@ fn test_init_min_contribution_floor_stored() {
         &None,
         &Some(1_000i128),
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_min_contribution_floor(), 1_000i128);
 }
@@ -374,7 +374,7 @@ fn test_init_min_contribution_floor_defaults_to_zero() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_min_contribution_floor(), 0i128);
 }
@@ -402,7 +402,7 @@ fn test_init_min_contribution_zero_panics() {
         &None,
         &Some(0i128),
         &None,
-        &None
+        &None,
     );
 }
 
@@ -429,7 +429,7 @@ fn test_init_min_contribution_exceeds_amount_panics() {
         &None,
         &Some(1_001i128),
         &None,
-        &None
+        &None,
     );
 }
 
@@ -455,7 +455,7 @@ fn test_init_min_contribution_equal_to_amount_accepted() {
         &None,
         &Some(5_000i128),
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_min_contribution_floor(), 5_000i128);
 }
@@ -505,7 +505,7 @@ fn test_init_registry_none_roundtrip() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     assert_eq!(client.get_registry_ref(), None);
 }
@@ -534,6 +534,7 @@ fn test_init_escrow_initialized_event_includes_bound_refs() {
         &token,
         &Some(registry.clone()),
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -578,6 +579,7 @@ fn test_init_escrow_initialized_event_registry_none() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(
@@ -618,7 +620,7 @@ fn try_init_with_id(env: &Env, id: &str) -> Result<(), ()> {
             &None,
             &None,
             &None,
-            &None
+            &None,
         );
     }));
     result.map(|_| ()).map_err(|_| ())
@@ -664,7 +666,7 @@ fn test_invoice_id_length_33_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 }
 

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -58,7 +58,7 @@ fn test_legal_hold_midflow_blocks_and_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     // Funding starts normally.
@@ -174,6 +174,7 @@ fn test_escrow_gold_standard_happy_path_open_overfund_snapshot_settle_claim() {
         &None, // No yield tiers for simplicity
         &None, // No min contribution floor
         &None, // No max investors cap
+        &None,
     );
 
     let initial_escrow = client.get_escrow();
@@ -400,7 +401,7 @@ fn test_escrow_tiered_yield_with_commitment_locks() {
         &Some(yield_tiers),
         &None,
         &None,
-        &None
+        &None,
     );
 
     let investor_base = Address::generate(&env);
@@ -526,7 +527,7 @@ fn test_collateral_record_is_metadata_only_and_does_not_invoke_token_contract() 
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
@@ -755,7 +756,7 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     // Initial funding succeeds while hold is off.

--- a/escrow/src/tests/legal_hold.rs
+++ b/escrow/src/tests/legal_hold.rs
@@ -48,7 +48,7 @@ fn init_open(
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     (token, treasury)
 }
@@ -93,7 +93,7 @@ fn init_settled<'a>(
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(investor, &TARGET);
     client.settle();

--- a/escrow/src/tests/properties.rs
+++ b/escrow/src/tests/properties.rs
@@ -115,7 +115,7 @@ fn prop_status_transitions_open_to_funded_only() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let initial = client.get_escrow();
@@ -152,7 +152,7 @@ fn prop_status_settle_transition() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -187,7 +187,7 @@ fn prop_status_withdraw_transition() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -226,7 +226,7 @@ fn prop_no_regression_from_funded_status() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -263,7 +263,7 @@ fn prop_no_regression_after_withdraw() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -298,7 +298,7 @@ fn prop_settled_is_terminal_for_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -331,7 +331,7 @@ fn prop_withdrawn_is_terminal_for_withdraw() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund(&investor, &target);
@@ -364,7 +364,7 @@ fn prop_status_invariant_all_states_valid_range() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     assert!(client.get_escrow().status == 0);
@@ -403,7 +403,7 @@ fn prop_funded_amount_sum_of_contributions() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -452,7 +452,7 @@ fn prop_funded_amount_respects_funding_target() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let fund_amount = target + excess;
@@ -489,7 +489,7 @@ fn prop_funded_amount_non_decreasing_across_multiple_funders() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let amt1: i128 = 50_000_000_000i128;
@@ -540,7 +540,7 @@ fn prop_funded_amount_equals_contribution_sum_for_funded_escrow() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let amounts: [i128; 3] = [50_000_000_000i128, 100_000_000_000i128, 50_000_000_000i128];
@@ -657,7 +657,7 @@ fn fuzz_multi_investor_fund_ordering_snapshot_once_only() {
             &None,
             &None,
             &None,
-            &None
+            &None,
         );
 
         // Randomize investor count/order and positive amounts. Keep the sequence small so

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -264,7 +264,7 @@ fn test_claim_investor_twice_is_idempotent() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -298,7 +298,7 @@ fn test_claim_by_non_investor_panics() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     // Escrow settled but stranger never funded
     let investor = Address::generate(&env);
@@ -327,7 +327,7 @@ fn test_clashing_investors_have_independent_claims() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &1_000i128);
     client.fund(&inv_b, &1_000i128);
@@ -410,7 +410,7 @@ fn test_claim_blocked_until_commitment_ledger_time() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &1_000i128, &500u64);
     client.settle();
@@ -439,7 +439,7 @@ fn test_claim_succeeds_after_commitment_and_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund_with_commitment(&inv, &1_000i128, &100u64);
     client.settle();
@@ -473,7 +473,7 @@ fn test_claim_gating_exact_timestamp() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     let lock_duration = 500u64;
@@ -521,7 +521,7 @@ fn test_claim_gating_with_multiple_investors() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     client.fund_with_commitment(&inv1, &1_000i128, &100u64); // Expiry 1100
@@ -564,7 +564,7 @@ fn test_cost_baseline_settle() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &TARGET);
     env.ledger().set_timestamp(1001);
@@ -615,7 +615,7 @@ fn settle_with_maturity_zero_succeeds_immediately() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     fund_to_target(&client, &env);
@@ -651,7 +651,7 @@ fn settle_at_maturity_succeeds() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
 
     fund_to_target(&client, &env);
@@ -699,7 +699,7 @@ fn settle_on_withdrawn_escrow_panics() {
 // HostError wraps contract panic; expected substring not matched in outer message.
 #[ignore = "HostError wraps contract panic; expected substring not matched"]
 #[test]
-#[should_panic(expected = "dust sweep only in terminal states (settled or withdrawn)")]
+#[should_panic(expected = "dust sweep only in terminal states (settled, withdrawn, or cancelled)")]
 fn sweep_terminal_dust_before_terminal_state_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -784,7 +784,7 @@ fn test_sweep_terminal_dust_after_settle_transfers_to_treasury() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let investor = Address::generate(&env);
     client.fund(&investor, &1_000i128);
@@ -821,7 +821,7 @@ fn test_sweep_terminal_dust_after_withdraw_and_ledger_tick() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     let investor = Address::generate(&env);
     client.fund(&investor, &1_000i128);
@@ -856,7 +856,7 @@ fn test_sweep_rejected_when_open() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -883,7 +883,7 @@ fn test_sweep_blocked_under_legal_hold() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -912,7 +912,7 @@ fn test_sweep_rejects_amount_above_dust_cap() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     // status == 1 (funded), not settled — must panic
@@ -940,7 +940,7 @@ fn test_sweep_caps_at_contract_balance() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -966,7 +966,7 @@ fn test_sweep_requires_treasury_auth() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     fund_to_target(&client, &env);
     client.settle();
@@ -1006,33 +1006,123 @@ fn claim_investor_payout_succeeds_after_settle() {
 ///
 /// This guards against the denominator being zeroed or mutated by the withdrawal
 /// path — off-chain accounting always needs a stable snapshot.
-// Calls fund_to_target after withdraw (status=3); fund panics. Logic error in body.
-#[ignore = "body calls fund_to_target after withdraw (status=3); panics without #[should_panic]"]
 #[test]
 fn funding_snapshot_survives_withdraw() {
     let env = Env::default();
+    env.mock_all_auths();
     let (client, admin, sme) = setup(&env);
     default_init(&client, &env, &admin, &sme);
     fund_to_target(&client, &env);
 
-    let snapshot_before = client.get_funding_close_snapshot();
+    let snapshot_before = client
+        .get_funding_close_snapshot()
+        .expect("snapshot exists after fund close");
     client.withdraw();
-    let snapshot_after = client.get_funding_close_snapshot();
+    let snapshot_after = client
+        .get_funding_close_snapshot()
+        .expect("snapshot persists after withdraw");
 
     assert_eq!(
         snapshot_before, snapshot_after,
         "funding snapshot must be immutable after withdraw"
     );
-    fund_to_target(&client, &env);
-    let snapshot_before = client.get_funding_close_snapshot();
-    client.withdraw();
-    let snapshot_after = client.get_funding_close_snapshot();
     assert_eq!(
-        snapshot_after.as_ref().unwrap().total_principal,
-        TARGET,
+        snapshot_after.total_principal, TARGET,
         "snapshot total_principal must equal funded amount"
     );
-    assert_eq!(snapshot_before, snapshot_after);
+}
+
+/// The threshold-crossing deposit may overfund the target; the snapshot must capture the
+/// full credited funded_amount and the exact ledger timestamp/sequence at close.
+#[test]
+fn funding_close_snapshot_captures_overfunding_and_close_ledger() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let investor_a = Address::generate(&env);
+    let investor_b = Address::generate(&env);
+    let first_leg = TARGET - 10_000i128;
+    let crossing_leg = 25_000i128;
+    let close_total = first_leg + crossing_leg;
+
+    client.fund(&investor_a, &first_leg);
+    assert_eq!(
+        client.get_funding_close_snapshot(),
+        None,
+        "snapshot must be absent before funded transition"
+    );
+
+    let close_timestamp = 88_888u64;
+    let close_sequence = 777u32;
+    env.ledger().with_mut(|ledger| {
+        ledger.timestamp = close_timestamp;
+        ledger.sequence_number = close_sequence;
+    });
+
+    client.fund(&investor_b, &crossing_leg);
+
+    let escrow = client.get_escrow();
+    let snapshot = client
+        .get_funding_close_snapshot()
+        .expect("snapshot must be written at funded transition");
+    assert_eq!(escrow.status, 1, "escrow must close as funded");
+    assert_eq!(escrow.funded_amount, close_total);
+    assert_eq!(
+        snapshot.total_principal, escrow.funded_amount,
+        "snapshot denominator must match overfunded close amount"
+    );
+    assert_eq!(snapshot.total_principal, TARGET + 15_000i128);
+    assert_eq!(snapshot.funding_target, TARGET);
+    assert_eq!(snapshot.closed_at_ledger_timestamp, close_timestamp);
+    assert_eq!(snapshot.closed_at_ledger_sequence, close_sequence);
+}
+
+/// After the funded transition, another same-ledger funding attempt must not overwrite the
+/// snapshot or mutate contributions. This guards the write-once denominator invariant even if a
+/// caller retries immediately after the close.
+#[test]
+fn funding_close_snapshot_not_overwritten_by_same_ledger_follow_on_attempt() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let closer = Address::generate(&env);
+    let late_investor = Address::generate(&env);
+    let close_amount = TARGET + 1_234i128;
+
+    env.ledger().with_mut(|ledger| {
+        ledger.timestamp = 99_999;
+        ledger.sequence_number = 999;
+    });
+    client.fund(&closer, &close_amount);
+    let snapshot_at_close = client
+        .get_funding_close_snapshot()
+        .expect("snapshot exists after overfunded close");
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund(&late_investor, &1i128);
+    }));
+    assert!(
+        result.is_err(),
+        "funding after close must fail before it can overwrite snapshot"
+    );
+
+    let snapshot_after_attempt = client
+        .get_funding_close_snapshot()
+        .expect("snapshot remains present after rejected follow-on attempt");
+    assert_eq!(
+        snapshot_at_close, snapshot_after_attempt,
+        "snapshot must remain write-once after same-ledger follow-on attempt"
+    );
+    assert_eq!(client.get_escrow().funded_amount, close_amount);
+    assert_eq!(
+        client.get_contribution(&late_investor),
+        0,
+        "rejected follow-on funding must not create contribution state"
+    );
 }
 
 /// After `settle` the snapshot still matches what was recorded at fund-close.
@@ -1080,7 +1170,7 @@ fn test_is_investor_claimed_false_before_any_claim() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1108,7 +1198,7 @@ fn test_is_investor_claimed_returns_false_for_unfunded_address() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1134,7 +1224,7 @@ fn test_claim_marker_persists_after_claim() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1163,7 +1253,7 @@ fn test_claim_marker_isolated_per_investor() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&investor_a, &1_000i128);
     client.fund(&investor_b, &1_000i128);
@@ -1195,7 +1285,7 @@ fn test_claim_marker_all_investors_independent() {
         &None,
         &None,
         &None,
-        &None
+        &None,
     );
     client.fund(&inv_a, &1_000i128);
     client.fund(&inv_b, &1_000i128);
@@ -1345,6 +1435,7 @@ fn compute_payout_returns_zero_before_snapshot() {
         &None,
         &None,
         &None,
+        &None,
     );
     // Deposit below target — no snapshot written yet.
     client.fund(&investor, &1i128);
@@ -1376,6 +1467,7 @@ fn compute_payout_single_investor_full_target() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1414,6 +1506,7 @@ fn compute_payout_two_equal_investors() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&inv_a, &1_000i128);
     client.fund(&inv_b, &1_000i128);
@@ -1449,6 +1542,7 @@ fn compute_payout_aggregate_does_not_exceed_settle_pool() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1497,6 +1591,7 @@ fn compute_payout_floor_rounding_unequal_split() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&inv_a, &2i128);
     client.fund(&inv_b, &1i128);
@@ -1532,6 +1627,7 @@ fn compute_payout_zero_yield_equals_principal() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&inv, &5_000i128);
     client.settle();
@@ -1563,6 +1659,7 @@ fn compute_payout_with_over_funding() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1607,6 +1704,7 @@ fn claim_dedupe_single_read_happy_path() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1645,6 +1743,7 @@ fn claim_dedupe_stranger_still_rejected() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1673,6 +1772,7 @@ fn claim_dedupe_hold_still_blocks() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,


### PR DESCRIPTION


## Summary
Adds tests proving `FundingCloseSnapshot` is created only when funding first crosses the target, captures the full over-funded `funded_amount`, records the close ledger timestamp/sequence, and remains immutable after later lifecycle actions or rejected same-ledger funding attempts.

Also updates snapshot documentation and rustdoc to clarify the write-once pro-rata denominator invariant.

Validation:
- `cargo test`
- `cargo clippy -p liquifact_escrow --all-targets -- -D warnings`
- `cargo llvm-cov --features testutils --fail-under-lines 95 --summary-only -p liquifact_escrow`



close #258 