### PR TITLE
feat(escrow): enforce liability floor on terminal dust sweep

### DIFF
--- a/docs/adr/ADR-006-dust-sweep-and-token-safety.md
+++ b/docs/adr/ADR-006-dust-sweep-and-token-safety.md
@@ -2,7 +2,8 @@
 
 **Status:** Accepted  
 **Date:** 2026-03-28  
-**Refs:** `escrow/src/lib.rs` — `sweep_terminal_dust`, `DataKey::FundingToken`, `DataKey::Treasury`; `escrow/src/external_calls.rs` — `transfer_funding_token_with_balance_checks`
+**Updated:** 2026-05-28 — liability floor invariant  
+**Refs:** `escrow/src/lib.rs` — `sweep_terminal_dust`, `refund`, `DataKey::FundingToken`, `DataKey::Treasury`, `DataKey::DistributedPrincipal`; `escrow/src/external_calls.rs` — `transfer_funding_token_with_balance_checks`
 
 ---
 
@@ -10,14 +11,31 @@
 
 After settlement or withdrawal, small residual token balances (rounding dust, stray transfers) may remain in the contract. A recovery path is needed that cannot be abused to drain live principal.
 
+The original design relied on off-chain reconciliation to ensure sweeps only touched true dust. This left an on-chain gap: nothing prevented the treasury from sweeping tokens that were still owed to unredeemed investors in a cancelled escrow.
+
 ## Decision
 
 `sweep_terminal_dust(amount)` transfers `min(amount, balance, MAX_DUST_SWEEP_AMOUNT)` of the bound funding token to the immutable treasury address. Guards:
 
-1. `status` must be `2` (settled) or `3` (withdrawn) — open/funded escrows are rejected.
+1. `status` must be `2` (settled), `3` (withdrawn), or `4` (cancelled) — open/funded escrows are rejected.
 2. `amount <= MAX_DUST_SWEEP_AMOUNT` (100,000,000 base units) — caps blast radius per call.
 3. Legal hold blocks the sweep.
 4. Treasury auth required.
+5. **Liability floor (new):** the sweep is rejected if it would reduce the contract balance below outstanding investor liabilities.
+
+### Liability floor invariant
+
+The floor only applies in **cancelled (status 4)** escrows, where `refund` is the on-chain redemption path. In settled (2) and withdrawn (3) states, disbursement is off-chain and `distributed_principal` stays `0`, so the floor is not applicable.
+
+```
+outstanding = funded_amount - distributed_principal
+assert balance - sweep_amt >= outstanding   [only when status == 4]
+```
+
+`DataKey::DistributedPrincipal` is a running total incremented atomically by `refund` each time an investor's principal is returned. This makes the invariant computable on-chain without iterating over all investor addresses.
+
+- In a **settled** or **withdrawn** escrow, `funded_amount` reflects the total principal committed. If the integration has not yet disbursed principal off-chain, `distributed_principal` remains `0` and `outstanding == funded_amount`. The sweep is blocked until the balance genuinely exceeds liabilities.
+- In a **cancelled** escrow, each `refund` call increments `distributed_principal`, reducing `outstanding`. Once all investors are refunded, `outstanding == 0` and any remaining balance is true dust.
 
 All token transfers go through `external_calls::transfer_funding_token_with_balance_checks`, which:
 - Records sender and recipient balances before the transfer.
@@ -32,17 +50,31 @@ This catches fee-on-transfer tokens and malicious implementations at the host bo
 
 - Only the configured SEP-41 funding token can be swept; other assets sent to the contract are untouched.
 - Soroban does not allow classic EVM-style synchronous reentrancy, but the pre/post balance check still catches non-standard token economics.
-- Integrations that custody principal on-chain must keep token balances reconciled with `funded_amount` so sweeps cannot pull user funds.
+- `DataKey::DistributedPrincipal` is an additive key (absent ⇒ `0`), backward-compatible per ADR-007.
+- Integrations that custody principal on-chain must keep token balances reconciled with `funded_amount`. The liability floor now enforces this on-chain for the cancelled-state refund path.
+- For settled/withdrawn escrows where disbursement is off-chain, the floor does not apply and dust sweeps work as before.
 
 ## Rejected alternatives
 
 - **Unrestricted sweep in any state:** would allow draining live principal as "dust."
 - **No balance delta check:** would silently accept fee-on-transfer tokens and produce incorrect accounting.
 - **Admin auth on sweep instead of treasury:** admin and treasury are separate roles by design; conflating them reduces separation of concerns.
+- **Iterate all investor contributions to compute outstanding:** unbounded gas cost; the `DistributedPrincipal` counter achieves the same result in O(1).
 
 ## Test Coverage
 
-Tests live in `escrow/src/tests/external_calls_mocked.rs` and verify every guard:
+Liability floor tests live in `escrow/src/tests/external_calls.rs`:
+
+| Test name | What it checks | Expected result |
+|-----------|---------------|-----------------|
+| `sweep_liability_floor_allows_true_dust_after_all_refunded` | All refunded → outstanding = 0, dust swept | Passes |
+| `sweep_liability_floor_blocks_sweep_when_investor_not_yet_refunded` | No refunds, balance = outstanding | Panics |
+| `sweep_liability_floor_allows_sweep_of_excess_above_outstanding` | Partial refund, sweep only the surplus | Passes |
+| `sweep_liability_floor_blocks_sweep_that_would_eat_into_outstanding` | Sweep exceeds surplus | Panics |
+| `sweep_liability_floor_zero_funded_amount_allows_sweep` | Cancelled before any funding, stray tokens | Passes |
+| `distributed_principal_accumulates_across_multiple_refunds` | Counter increments correctly per refund | Passes |
+
+Balance-delta invariant tests live in `escrow/src/tests/external_calls_mocked.rs`:
 
 | Test name | What it checks | Expected result |
 |-----------|---------------|-----------------|
@@ -55,4 +87,3 @@ Tests live in `escrow/src/tests/external_calls_mocked.rs` and verify every guard
 | `test_balance_delta_invariants_with_multiple_recipients` | Two sequential transfers | Passes |
 
 **Core invariant:** value is always conserved exactly, or the call panics. There is no partial-credit success path.
-

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -165,6 +165,112 @@ pub const INSTANCE_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 
 /// Extending persistent allowlist TTL reduces the risk of silent allowlist disablement.
 pub const PERSISTENT_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 ledger/sec.
 
+/// Stable typed errors emitted by LiquiFact escrow entrypoints.
+///
+/// Codes are append-only: never reuse or renumber a variant. Client SDKs should branch on the
+/// numeric code rather than legacy panic strings. See `docs/escrow-error-messages.md`.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum EscrowError {
+    AmountMustBePositive = 1,
+    YieldBpsOutOfRange = 2,
+    EscrowAlreadyInitialized = 3,
+    InvoiceIdInvalidLength = 4,
+    InvoiceIdInvalidCharset = 5,
+    MinContributionNotPositive = 6,
+    MinContributionExceedsAmount = 7,
+    MaxUniqueInvestorsNotPositive = 8,
+    MaxPerInvestorNotPositive = 9,
+    TierYieldOutOfRange = 10,
+    TierYieldBelowBase = 11,
+    TierLockNotIncreasing = 12,
+    TierYieldNotNonDecreasing = 13,
+
+    EscrowNotInitialized = 20,
+    FundingTokenNotSet = 21,
+    TreasuryNotSet = 22,
+
+    LegalHoldBlocksTreasuryDustSweep = 30,
+    SweepAmountNotPositive = 31,
+    SweepAmountExceedsMax = 32,
+    DustSweepNotTerminal = 33,
+    NoFundingTokenBalanceToSweep = 34,
+    EffectiveSweepAmountZero = 35,
+    TransferAmountNotPositive = 36,
+    InsufficientTokenBalanceBeforeTransfer = 37,
+    SenderBalanceUnderflow = 38,
+    RecipientBalanceUnderflow = 39,
+    SenderBalanceDeltaMismatch = 40,
+    RecipientBalanceDeltaMismatch = 41,
+    /// Sweep would reduce the contract balance below outstanding investor liabilities.
+    /// `balance - sweep_amt` must be `>= funded_amount - distributed_principal`.
+    SweepExceedsLiabilityFloor = 42,
+
+    PrimaryAttestationAlreadyBound = 50,
+    AttestationAppendLogCapacityReached = 51,
+
+    CollateralAmountNotPositive = 60,
+    CollateralAssetEmpty = 61,
+    CollateralTimestampBackwards = 62,
+
+    InvestorBatchEmpty = 70,
+    InvestorBatchTooLarge = 71,
+    TargetNotPositive = 72,
+    TargetUpdateNotOpen = 73,
+    TargetBelowFundedAmount = 74,
+    CapLowerNotOpen = 75,
+    NoInvestorCapConfigured = 76,
+    NewCapNotLower = 77,
+    NewCapBelowCurrentFunderCount = 78,
+    MaturityUpdateNotOpen = 79,
+    NewAdminSameAsCurrent = 80,
+
+    MigrationVersionMismatch = 90,
+    AlreadyCurrentSchemaVersion = 91,
+    NoMigrationPath = 92,
+
+    FundingAmountNotPositive = 100,
+    FundingBelowMinContribution = 101,
+    LegalHoldBlocksFunding = 102,
+    EscrowNotOpenForFunding = 103,
+    InvestorNotAllowlisted = 104,
+    InvestorContributionOverflow = 105,
+    InvestorContributionExceedsCap = 106,
+    UniqueInvestorCapReached = 107,
+    TieredSecondDeposit = 108,
+    InvestorClaimTimeOverflow = 109,
+    FundedAmountOverflow = 110,
+
+    LegalHoldBlocksSettlement = 120,
+    SettlementNotFunded = 121,
+    MaturityNotReached = 122,
+    LegalHoldBlocksWithdrawal = 123,
+    WithdrawalNotFunded = 124,
+    LegalHoldBlocksInvestorClaims = 125,
+    NoContributionToClaim = 126,
+    InvestorClaimNotSettled = 127,
+    InvestorCommitmentLockNotExpired = 128,
+    ComputePayoutArithmeticOverflow = 129,
+
+    LegalHoldBlocksCancelFunding = 140,
+    CancelFundingNotOpen = 141,
+    RefundNotCancelled = 142,
+    NoContributionToRefund = 143,
+}
+
+#[inline(always)]
+pub(crate) fn fail(env: &Env, error: EscrowError) -> ! {
+    panic_with_error!(env, error)
+}
+
+#[inline(always)]
+pub(crate) fn ensure(env: &Env, condition: bool, error: EscrowError) {
+    if !condition {
+        fail(env, error);
+    }
+}
+
 // --- Storage keys ---
 
 #[contracttype]
@@ -254,6 +360,11 @@ pub enum DataKey {
     /// Set to `true` once an investor's principal has been refunded in a cancelled escrow.
     /// Absent ⇒ `false`. Written once; prevents double-refund.
     InvestorRefunded(Address),
+    /// Running total of principal already returned to investors via [`LiquifactEscrow::refund`].
+    /// Absent ⇒ `0`. Incremented atomically with each successful refund transfer.
+    /// Used by [`LiquifactEscrow::sweep_terminal_dust`] to compute outstanding liabilities:
+    /// `outstanding = funded_amount - distributed_principal`.
+    DistributedPrincipal,
 }
 
 // --- Data types ---
@@ -835,6 +946,23 @@ impl LiquifactEscrow {
     /// **4 (cancelled)**. Open (0) or funded (1) states reject the call so live principal cannot
     /// be swept as dust.
     ///
+    /// # Liability floor invariant
+    /// In **cancelled** (status 4) escrows, the sweep is rejected if it would reduce the
+    /// contract's token balance below the amount still owed to investors who have not yet
+    /// called [`LiquifactEscrow::refund`]:
+    ///
+    /// ```text
+    /// outstanding = funded_amount - distributed_principal
+    /// assert balance - sweep_amt >= outstanding
+    /// ```
+    ///
+    /// `distributed_principal` ([`DataKey::DistributedPrincipal`]) is incremented atomically
+    /// by [`LiquifactEscrow::refund`] each time an investor's principal is returned. This makes
+    /// the invariant computable on-chain without iterating over all investor addresses.
+    ///
+    /// In **settled** (2) and **withdrawn** (3) states, disbursement is off-chain and this
+    /// floor does not apply.
+    ///
     /// # Authorization
     /// The configured **treasury** account must authorize this call; the admin cannot sweep unless
     /// it is also the treasury.
@@ -843,7 +971,8 @@ impl LiquifactEscrow {
     ///
     /// # Errors
     /// Emits typed [`EscrowError`] codes for legal hold, invalid sweep amount, non-terminal state,
-    /// missing initialized addresses, empty balances, and token transfer invariant failures.
+    /// missing initialized addresses, empty balances, liability floor violation, and token
+    /// transfer invariant failures.
     pub fn sweep_terminal_dust(env: Env, amount: i128) -> i128 {
         ensure(
             &env,
@@ -884,6 +1013,32 @@ impl LiquifactEscrow {
         ensure(&env, balance > 0, EscrowError::NoFundingTokenBalanceToSweep);
         let sweep_amt = amount.min(balance);
         ensure(&env, sweep_amt > 0, EscrowError::EffectiveSweepAmountZero);
+
+        // Liability floor (cancelled escrows only): sweep must not reduce the balance below
+        // principal still owed to investors who have not yet called refund().
+        //
+        // In settled (2) and withdrawn (3) states, disbursement is off-chain and
+        // distributed_principal stays 0, so the floor is not applicable there.
+        // In cancelled (4) state, refund() is the on-chain redemption path and increments
+        // distributed_principal atomically, making the invariant computable here.
+        //
+        // outstanding = funded_amount - distributed_principal
+        // Invariant: balance - sweep_amt >= outstanding
+        if escrow.status == 4 {
+            let distributed: i128 = env
+                .storage()
+                .instance()
+                .get(&DataKey::DistributedPrincipal)
+                .unwrap_or(0);
+            let outstanding = escrow.funded_amount.saturating_sub(distributed);
+            // sweep_amt <= balance (from amount.min(balance) above), so this subtraction is safe.
+            let balance_after_sweep = balance - sweep_amt;
+            ensure(
+                &env,
+                balance_after_sweep >= outstanding,
+                EscrowError::SweepExceedsLiabilityFloor,
+            );
+        }
 
         external_calls::transfer_funding_token_with_balance_checks(
             &env,
@@ -2086,6 +2241,16 @@ impl LiquifactEscrow {
             .instance()
             .set(&DataKey::InvestorRefunded(investor.clone()), &true);
 
+        // Track distributed principal so sweep_terminal_dust can enforce the liability floor.
+        let prev_distributed: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DistributedPrincipal)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::DistributedPrincipal, &prev_distributed.saturating_add(amount));
+
         let token_addr: Address = env
             .storage()
             .instance()
@@ -2116,6 +2281,17 @@ impl LiquifactEscrow {
             .instance()
             .get(&DataKey::InvestorRefunded(investor))
             .unwrap_or(false)
+    }
+
+    /// Total principal already returned to investors via [`LiquifactEscrow::refund`].
+    ///
+    /// Used by [`LiquifactEscrow::sweep_terminal_dust`] to compute outstanding liabilities.
+    /// Absent ⇒ `0` (no refunds have occurred).
+    pub fn get_distributed_principal(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::DistributedPrincipal)
+            .unwrap_or(0)
     }
 }
 

--- a/escrow/src/tests/external_calls.rs
+++ b/escrow/src/tests/external_calls.rs
@@ -198,3 +198,247 @@ fn test_edge_case_maximum_amount_transfer() {
     assert_eq!(holder_after, 0i128);
     assert_eq!(treasury_after, large_amount);
 }
+
+// ── Liability floor tests for sweep_terminal_dust ────────────────────────────
+
+fn setup_cancelled_with_token<'a>(
+    env: &'a Env,
+    client: &LiquifactEscrowClient<'a>,
+    admin: &Address,
+    sme: &Address,
+    investor: &Address,
+    fund_amount: i128,
+) -> (crate::tests::StellarTestToken<'a>, Address) {
+    let token = install_stellar_asset_token(env);
+    let treasury = Address::generate(env);
+    client.init(
+        admin,
+        &soroban_sdk::String::from_str(env, "FLOOR01"),
+        sme,
+        &fund_amount,
+        &0i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    // Mint tokens into the contract to simulate on-chain custody
+    token.stellar.mint(&client.address, &fund_amount);
+    client.fund(investor, &fund_amount);
+    client.cancel_funding();
+    (token, treasury)
+}
+
+#[test]
+fn sweep_liability_floor_allows_true_dust_after_all_refunded() {
+    // After all investors are refunded, outstanding = 0, so any dust can be swept.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let fund_amount = 1_000i128;
+    let (token, treasury) = setup_cancelled_with_token(&env, &client, &admin, &sme, &investor, fund_amount);
+
+    // Mint 1 extra unit of dust on top of the principal
+    token.stellar.mint(&client.address, &1i128);
+
+    // Refund the investor — this increments DistributedPrincipal by fund_amount
+    client.refund(&investor);
+
+    // Now outstanding = funded_amount - distributed = 1000 - 1000 = 0
+    // balance = 1 (the dust), sweep_amt = 1, floor check: 1 - 1 >= 0 ✓
+    let swept = client.sweep_terminal_dust(&1i128);
+    assert_eq!(swept, 1i128);
+    assert_eq!(token.token.balance(&treasury), 1i128);
+    assert_eq!(client.get_distributed_principal(), fund_amount);
+}
+
+#[test]
+#[should_panic]
+fn sweep_liability_floor_blocks_sweep_when_investor_not_yet_refunded() {
+    // No refunds yet: outstanding = funded_amount, balance = funded_amount.
+    // Any sweep would dip below the floor.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let fund_amount = 1_000i128;
+    let (token, _treasury) = setup_cancelled_with_token(&env, &client, &admin, &sme, &investor, fund_amount);
+
+    // balance == outstanding == 1000; sweep of even 1 unit violates the floor
+    client.sweep_terminal_dust(&1i128);
+}
+
+#[test]
+fn sweep_liability_floor_allows_sweep_of_excess_above_outstanding() {
+    // Two investors fund 500 each. One is refunded. 500 outstanding remains.
+    // Contract has 1001 tokens (500 refunded, 500 outstanding, 1 dust).
+    // Sweep of 1 is allowed; sweep of 501 is not.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let investor_a = Address::generate(&env);
+    let investor_b = Address::generate(&env);
+    let token = install_stellar_asset_token(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FLOOR02"),
+        &sme,
+        &1_000i128,
+        &0i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Mint 1001 into contract: 500 for A, 500 for B, 1 dust
+    token.stellar.mint(&client.address, &1_001i128);
+    client.fund(&investor_a, &500i128);
+    client.fund(&investor_b, &500i128);
+    client.cancel_funding();
+
+    // Refund investor_a → distributed = 500, outstanding = 500
+    client.refund(&investor_a);
+    assert_eq!(client.get_distributed_principal(), 500i128);
+
+    // balance = 501 (500 for B + 1 dust), outstanding = 500
+    // sweep of 1: 501 - 1 = 500 >= 500 ✓
+    let swept = client.sweep_terminal_dust(&1i128);
+    assert_eq!(swept, 1i128);
+    assert_eq!(token.token.balance(&treasury), 1i128);
+}
+
+#[test]
+#[should_panic]
+fn sweep_liability_floor_blocks_sweep_that_would_eat_into_outstanding() {
+    // Same setup as above but try to sweep 2 (which would leave 499 < 500 outstanding).
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let investor_a = Address::generate(&env);
+    let investor_b = Address::generate(&env);
+    let token = install_stellar_asset_token(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FLOOR03"),
+        &sme,
+        &1_000i128,
+        &0i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    token.stellar.mint(&client.address, &1_001i128);
+    client.fund(&investor_a, &500i128);
+    client.fund(&investor_b, &500i128);
+    client.cancel_funding();
+    client.refund(&investor_a);
+
+    // balance = 501, outstanding = 500; sweep of 2 → 501 - 2 = 499 < 500 ✗
+    client.sweep_terminal_dust(&2i128);
+}
+
+#[test]
+fn sweep_liability_floor_zero_funded_amount_allows_sweep() {
+    // Edge case: escrow cancelled before any funding. funded_amount = 0,
+    // distributed = 0, outstanding = 0. Any dust can be swept.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let token = install_stellar_asset_token(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FLOOR04"),
+        &sme,
+        &1_000i128,
+        &0i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client.cancel_funding();
+
+    // Stray airdrop of 50 tokens
+    token.stellar.mint(&client.address, &50i128);
+
+    let swept = client.sweep_terminal_dust(&50i128);
+    assert_eq!(swept, 50i128);
+    assert_eq!(token.token.balance(&treasury), 50i128);
+}
+
+#[test]
+fn distributed_principal_accumulates_across_multiple_refunds() {
+    // Three investors; refund them one by one and verify the counter.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+    let inv_c = Address::generate(&env);
+    let token = install_stellar_asset_token(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FLOOR05"),
+        &sme,
+        &900i128,
+        &0i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    token.stellar.mint(&client.address, &900i128);
+    client.fund(&inv_a, &300i128);
+    client.fund(&inv_b, &300i128);
+    client.fund(&inv_c, &300i128);
+    client.cancel_funding();
+
+    assert_eq!(client.get_distributed_principal(), 0i128);
+
+    client.refund(&inv_a);
+    assert_eq!(client.get_distributed_principal(), 300i128);
+
+    client.refund(&inv_b);
+    assert_eq!(client.get_distributed_principal(), 600i128);
+
+    client.refund(&inv_c);
+    assert_eq!(client.get_distributed_principal(), 900i128);
+
+    // All refunded — outstanding = 0, any dust can be swept
+    token.stellar.mint(&client.address, &5i128);
+    let swept = client.sweep_terminal_dust(&5i128);
+    assert_eq!(swept, 5i128);
+}


### PR DESCRIPTION
Closes #267

---

## Summary

Implements the on-chain invariant check: `sweep_terminal_dust` can no longer reduce the contract balance below outstanding investor liabilities in cancelled escrows.

## Problem

In a cancelled escrow (status 4), investors reclaim principal via `refund()`. Nothing previously prevented the treasury from calling `sweep_terminal_dust` and draining tokens still owed to investors who hadn't refunded yet.

Also fixes: `EscrowError` enum, `ensure`, and `fail` helpers were accidentally removed from HEAD — the codebase would not compile.

## Changes

### `escrow/src/lib.rs`
- **Restored** `EscrowError` enum, `ensure`, `fail` (accidentally deleted from HEAD)
- **Added** `EscrowError::SweepExceedsLiabilityFloor = 42`
- **Added** `DataKey::DistributedPrincipal` — additive key (absent ⇒ 0, backward-compatible per ADR-007)
- **Updated `refund()`** — increments `DistributedPrincipal` atomically before token transfer
- **Updated `sweep_terminal_dust()`** — in cancelled (status 4) only, asserts:
  ```
  outstanding = funded_amount - distributed_principal
  balance - sweep_amt >= outstanding
  ```
- **Added** `get_distributed_principal()` read-only accessor

### `escrow/src/tests/external_calls.rs`
Six new tests covering: all-refunded allows dust, no-refunds blocks sweep, partial refund allows only surplus, sweep eating outstanding blocked, zero funded_amount edge case, counter accumulation across refunds.

### `docs/adr/ADR-006-dust-sweep-and-token-safety.md`
Updated with liability floor decision, scoping rationale, and test table.

## Security notes
- Floor scoped to status 4 only — settled/withdrawn disbursement is off-chain
- `saturating_sub` / `saturating_add` throughout — overflow-safe
- Checks-effects-interactions order preserved in `refund()`
- All existing sweep tests verified unaffected