### PR TITLE
docs(escrow): migrate panic policy and redeploy runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ WASM.
 | 4 | Added attestation API (`PrimaryAttestationHash`, `AttestationAppendLog`) | Additive keys — no `migrate` call required |
 | 5 | Added `YieldTierTable` (`fund_with_commitment`), `RegistryRef`, `Treasury`; tightened `InvoiceEscrow` layout | **Redeploy required** if `InvoiceEscrow` struct layout differs from stored XDR |
 
-> **Current:** `SCHEMA_VERSION = 5`
+| 6 | Moved per-investor keys to persistent storage to bound instance footprint and decouple per-address TTL | **Redeploy required** — prior instances must be redeployed to pick up new storage locations |
+
+> **Current:** `SCHEMA_VERSION = 6`
 
 ---
 
@@ -64,7 +66,7 @@ WASM.
 ### `migrate` entrypoint — explicit panic semantics
 
 `LiquifactEscrow::migrate(from_version)` **panics in all current cases**.
-There is **no silent migration path** from any prior version to version 5.
+There is **no silent migration path** from any prior version to version 6.
 Callers must not assume it will do bookkeeping work:
 
 | Condition | Panic message |

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -1,293 +1,490 @@
-# LiquiFact Escrow — Event Schema Reference
+# LiquiFact Escrow Event Schema Reference
 
-> **Audience**: Backend indexers, analytics engineers, and integration partners
-> who consume Stellar ledger meta from Horizon or RPC to reconstruct contract
-> history without polling contract storage.
+Authoritative event reference for indexers, analytics jobs, read API
+projections, and audit tooling that consume events emitted by
+`escrow/src/lib.rs`.
 
----
+Related docs:
 
-## Overview
+- `docs/escrow-events.md` provides the shorter consumer-facing overview.
+- `docs/escrow-indexer.md` describes subscription, cursoring, and
+  reconciliation.
+- `docs/openapi.yaml` does not expose raw Soroban events; decoded events should
+  feed the API projections for escrow status, funding, settlement, claims,
+  holds, attestations, allowlist state, and refunds.
 
-Every state-changing function in the `LiquifactEscrow` contract emits a
-[Soroban contract event](https://developers.stellar.org/docs/smart-contracts/events).
-Events are written into the transaction's ledger meta and can be read via:
+## Soroban Layout
 
-- **Horizon** — `GET /transactions/{hash}/effects` or event streaming
-- **Stellar RPC** — `getEvents` with `contractId` + topic filters
-- **Mercury / indexer frameworks** — native Soroban event subscription
+Each event is defined with `#[contractevent]`. Per the
+[Soroban SDK `contractevent` model](https://docs.rs/soroban-sdk/latest/soroban_sdk/attr.contractevent.html),
+the emitted topic list contains:
 
-Each event has:
-- A **two-element topic tuple**: `(namespace: Symbol, action: Symbol)`
-- A **typed data payload** encoded as a Soroban XDR `ScVal`
+1. A fixed topic generated from the Rust event struct name in snake case.
+2. Every field marked with `#[topic]`, in struct field order.
 
-> **Source-truth note:** This document is secondary to the storage schema
-> documentation in `README.md`. The current branch contains event-model drift,
-> so any event statement that depends on unsettled storage or API shape should be
-> read as provisional until the contract source is normalized.
+Fields not marked with `#[topic]` are encoded in the event data payload. The
+default `#[contractevent]` data format is a map keyed by field name. Indexers
+should treat field order in this document as the canonical struct order from
+`escrow/src/lib.rs`.
 
----
+The `name` field is a `#[topic] Symbol` in every LiquiFact event. It carries the
+short routing symbol passed with `symbol_short!(...)`, such as `funded` or
+`escrow_sd`.
 
-## Versioning Strategy
+## Event Catalog
 
-| Scenario | Action |
+The current contract defines 19 event structs.
+
+| Rust event | `name` symbol | Entrypoint(s) |
+|---|---:|---|
+| `EscrowInitialized` | `escrow_ii` | `init` |
+| `MaxUniqueInvestorsCapLowered` | `inv_cap` | `lower_max_unique_investors` |
+| `EscrowFunded` | `funded` | `fund`, `fund_with_commitment` |
+| `EscrowSettled` | `escrow_sd` | `settle` |
+| `MaturityUpdatedEvent` | `maturity` | `update_maturity` |
+| `AdminTransferredEvent` | `admin` | `accept_admin` |
+| `AdminProposedEvent` | `adm_prop` | `propose_admin`, `transfer_admin` |
+| `FundingTargetUpdated` | `fund_tgt` | `update_funding_target` |
+| `LegalHoldChanged` | `legalhld` | `set_legal_hold`, `clear_legal_hold` |
+| `CollateralRecordedEvt` | `coll_rec` | `record_sme_collateral_commitment` |
+| `SmeWithdrew` | `sme_wd` | `withdraw` |
+| `InvestorPayoutClaimed` | `inv_claim` | `claim_investor_payout` |
+| `FundingCancelled` | `fund_can` | `cancel_funding` |
+| `InvestorRefundedEvt` | `refunded` | `refund` |
+| `TreasuryDustSwept` | `dust_sw` | `sweep_terminal_dust` |
+| `PrimaryAttestationBound` | `att_bind` | `bind_primary_attestation_hash` |
+| `AttestationDigestAppended` | `att_app` | `append_attestation_digest` |
+| `AllowlistEnabledChanged` | `al_ena` | `set_allowlist_active` |
+| `InvestorAllowlistChanged` | `al_set` | `set_investor_allowlisted`, `set_investors_allowlisted` |
+
+## Complete Topic And Data Layout
+
+### `EscrowInitialized`
+
+Emitted after successful `init`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `escrow_initialized` |
+| 1 | `name` | `Symbol` | `escrow_ii` |
+
+Data:
+
+| Field | Type |
 |---|---|
-| **Additive field added** to an existing payload | No version bump — old indexers ignore unknown fields |
-| **Field renamed or removed** (breaking change) | Bump `Topic[0]` from `"escrow"` → `"escrow_v2"` |
-| **New event action** added | No version bump — indexers filter by `Topic[1]` |
-| **Payload type changed** entirely | New `Topic[0]` namespace |
+| `escrow` | `InvoiceEscrow` |
+| `funding_token` | `Address` |
+| `treasury` | `Address` |
+| `registry` | `Option<Address>` |
+| `has_maturity_lock` | `bool` |
 
-> Indexers **must** filter by both `Topic[0]` (namespace) and `Topic[1]`
-> (action) to be stable across future contract upgrades.
+### `MaxUniqueInvestorsCapLowered`
 
----
+Emitted after successful `lower_max_unique_investors`.
 
-## Events
+Topics:
 
-### 1. `escrow_ii` — Escrow Created
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `max_unique_investors_cap_lowered` |
+| 1 | `name` | `Symbol` | `inv_cap` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
 
-Emitted by `init()`. Marks the beginning of an invoice escrow lifecycle.
+Data:
 
-| Field | Value |
+| Field | Type |
 |---|---|
-| Topic[0] | `"escrow_ii"` (`symbol_short!("escrow_ii")`) |
-| Payload type | `EscrowInitialized` |
+| `old_cap` | `u32` |
+| `new_cap` | `u32` |
 
-#### Payload: `EscrowInitialized`
+### `EscrowFunded`
 
-| Field | Rust type | Description |
-|---|---|---|
-| `escrow` | `InvoiceEscrow` | Full escrow snapshot at init |
-| `funding_token` | `Address` | Bound SEP-41 token; equals `DataKey::FundingToken` |
-| `treasury` | `Address` | Bound treasury; equals `DataKey::Treasury` |
-| `registry` | `Option<Address>` | Optional registry hint; equals `DataKey::RegistryRef` (`None` when unset) |
-| `has_maturity_lock` | `bool` | `true` when `escrow.maturity > 0`; `false` means `maturity == 0` and settlement has no maturity time lock |
+Emitted after successful `fund` or `fund_with_commitment`.
 
-**Compatibility:** Additive fields on `EscrowInitialized` — old indexers may ignore
-`funding_token`, `treasury`, `registry`, and `has_maturity_lock`; new indexers can
-bootstrap bound references and maturity-lock state from this single event without
-follow-up `get_funding_token` / `get_treasury` / summary polls.
+Topics:
 
-#### Nested `InvoiceEscrow` fields (within `escrow`)
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `escrow_funded` |
+| 1 | `name` | `Symbol` | `funded` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+| 3 | `investor` | `Address` | Funding investor |
 
-| Field | Rust type | Description |
-|---|---|---|
-| `invoice_id` | `Symbol` | Unique invoice ID (e.g. `"INV1023"`) |
-| `sme_address` | `Address` | SME wallet receiving the stablecoin |
-| `amount` | `i128` | Face value in smallest token unit |
-| `funding_target` | `i128` | Target to reach before SME is paid (= `amount` initially) |
-| `funded_amount` | `i128` | Always `0` at init |
-| `yield_bps` | `i64` | Annualized yield in basis points (e.g. `800` = 8 %) |
-| `maturity` | `u64` | Unix timestamp (seconds) for invoice maturity |
-| `status` | `u32` | Always `0` (open) at init |
+Data:
 
-The live source currently contains additional schema drift around `admin`,
-`settled_amount`, and version bookkeeping. Reviewers should use the README
-storage section for the canonical persisted-layout discussion.
-
-#### Example (JSON representation after XDR decode)
-
-```json
-{
-  "event"         : "escrow.initialized",
-  "invoice_id"    : "INV1023",
-  "sme_address"   : "GBSME...",
-  "amount"        : 100000000000,
-  "funding_target": 100000000000,
-  "funded_amount" : 0,
-  "yield_bps"     : 800,
-  "maturity"      : 1750000000,
-  "status"        : 0,
-  "funding_token" : "CTOKEN...",
-  "treasury"      : "GTREAS...",
-  "registry"      : null,
-  "has_maturity_lock": true
-}
-```
-
----
-
-### 1a. `inv_cap` — Investor Cap Lowered
-
-Emitted by `lower_max_unique_investors()` when admin tightens the distinct-investor limit
-while the escrow is **open** (status `0`). Added in Issue #255.
-
-| Field | Value |
+| Field | Type |
 |---|---|
-| Topic[0] | `"inv_cap"` (`symbol_short!("inv_cap")`) |
-| Topic[1] | `invoice_id` (Symbol) |
-| Payload type | `MaxUniqueInvestorsCapLowered` |
+| `amount` | `i128` |
+| `funded_amount` | `i128` |
+| `status` | `u32` |
+| `investor_effective_yield_bps` | `i64` |
 
-#### Payload: `MaxUniqueInvestorsCapLowered`
+### `EscrowSettled`
 
-| Field | Rust type | Description |
-|---|---|---|
-| `name` | `Symbol` | Always `"inv_cap"` |
-| `invoice_id` | `Symbol` | Invoice whose cap was lowered |
-| `old_cap` | `u32` | Previous `MaxUniqueInvestorsCap` value |
-| `new_cap` | `u32` | New (lower) cap value now stored |
+Emitted after successful `settle`.
 
-#### Example (JSON representation after XDR decode)
+Topics:
 
-```json
-{
-  "event"     : "inv_cap",
-  "invoice_id": "INV1023",
-  "old_cap"   : 10,
-  "new_cap"   : 5
-}
-```
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `escrow_settled` |
+| 1 | `name` | `Symbol` | `escrow_sd` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
 
----
+Data:
 
-### 2. `funded` — Investor Contribution Recorded
-
-Emitted by `fund()` and `fund_with_commitment()` on **every successful call**, regardless of
-whether the target was just met. Use `status == 1` in the payload to detect the moment
-the escrow became fully funded.
-
-| Field | Value |
+| Field | Type |
 |---|---|
-| Topic[0] | `"funded"` (`symbol_short!("funded")`) |
-| Topic[1] | `invoice_id` (Symbol) |
-| Topic[2] | `investor` (Address) |
-| Payload type | `EscrowFunded` |
+| `funded_amount` | `i128` |
+| `yield_bps` | `i64` |
+| `maturity` | `u64` |
 
-#### Payload: `FundedPayload` (intended view)
+### `MaturityUpdatedEvent`
 
-| Field | Rust type | Description |
-|---|---|---|
-| `invoice_id` | `Symbol` | Invoice this contribution belongs to |
-| `investor` | `Address` | Wallet that called `fund()` |
-| `amount` | `i128` | Amount contributed in **this** call |
-| `funded_amount` | `i128` | Cumulative total **after** this call |
-| `status` | `u32` | `0` = still open · `1` = target just met |
+Emitted after successful `update_maturity`.
 
-Current source drift also includes an `is_paid` field on the event struct that
-is not reflected consistently across the rest of the contract.
+Topics:
 
-> **Analytics tip**: Sum `amount` per `invoice_id` across all `funded` events
-> to reconstruct the full investor contribution table without reading state.
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `maturity_updated_event` |
+| 1 | `name` | `Symbol` | `maturity` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
 
-#### Example
+Data:
 
-```json
-{
-  "event"        : "escrow.funded",
-  "invoice_id"   : "INV1023",
-  "investor"     : "GBINV...",
-  "amount"       : 50000000000,
-  "funded_amount": 100000000000,
-  "status"       : 1
-}
-```
-
----
-
-### 3. `escrow.settled` — Invoice Settled by Buyer
-
-Emitted by `settle()` once, when the SME finalizes the escrow after maturity (status → 2).
-Contains everything needed to compute investor payouts without re-reading contract storage.
-
-| Field | Value |
+| Field | Type |
 |---|---|
-| Topic[0] | `"escrow_sd"` (`symbol_short!("escrow_sd")`) |
-| Topic[1] | `invoice_id` (Symbol) |
-| Payload type | `EscrowSettled` |
+| `old_maturity` | `u64` |
+| `new_maturity` | `u64` |
 
-#### Payload: `SettledPayload` (intended view)
+### `AdminTransferredEvent`
 
-| Field | Rust type | Description |
+Emitted after successful `accept_admin`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `admin_transferred_event` |
+| 1 | `name` | `Symbol` | `admin` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `new_admin` | `Address` |
+
+### `AdminProposedEvent`
+
+Emitted after successful `propose_admin`. The deprecated `transfer_admin`
+shim delegates to `propose_admin`, so it emits this event rather than
+`AdminTransferredEvent`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `admin_proposed_event` |
+| 1 | `name` | `Symbol` | `adm_prop` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `current_admin` | `Address` |
+| `pending_admin` | `Address` |
+
+### `FundingTargetUpdated`
+
+Emitted after successful `update_funding_target`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `funding_target_updated` |
+| 1 | `name` | `Symbol` | `fund_tgt` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `old_target` | `i128` |
+| `new_target` | `i128` |
+
+### `LegalHoldChanged`
+
+Emitted after successful `set_legal_hold`; `clear_legal_hold` calls
+`set_legal_hold(false)`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `legal_hold_changed` |
+| 1 | `name` | `Symbol` | `legalhld` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type | Values |
 |---|---|---|
-| `invoice_id` | `Symbol` | Invoice that has been settled |
-| `funded_amount` | `i128` | Total principal held at settlement |
-| `yield_bps` | `i64` | Annualized yield rate for payout calculation |
-| `maturity` | `u64` | Original maturity timestamp (used to compute accrued interest) |
+| `active` | `u32` | `1` = enabled, `0` = cleared |
 
-The current branch's settlement implementation is internally inconsistent, so
-this event description should not be treated as a stronger source of truth than
-the contract file itself.
+### `CollateralRecordedEvt`
 
-> **Payout formula** (off-chain, backend responsibility):
-> ```
-> gross_yield = funded_amount × (yield_bps / 10_000) × (days_held / 365)
-> investor_payout = funded_amount + gross_yield
-> ```
+Emitted after successful `record_sme_collateral_commitment`.
 
-#### Example
+Topics:
 
-```json
-{
-  "event"         : "escrow.settled",
-  "invoice_id"    : "INV1023",
-  "funded_amount" : 100000000000,
-  "yield_bps"     : 800,
-  "maturity"      : 1750000000
-}
-```
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `collateral_recorded_evt` |
+| 1 | `name` | `Symbol` | `coll_rec` |
 
----
+Data:
 
-## Status Code Reference
+| Field | Type |
+|---|---|
+| `invoice_id` | `Symbol` |
+| `amount` | `i128` |
+| `prior_amount` | `i128` |
 
-| Value | Name | Description |
+Note: this event records SME-reported collateral metadata only. It is not proof
+of custody, token movement, lien, or enforceable on-chain collateral.
+
+### `SmeWithdrew`
+
+Emitted after successful `withdraw`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `sme_withdrew` |
+| 1 | `name` | `Symbol` | `sme_wd` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `amount` | `i128` |
+
+### `InvestorPayoutClaimed`
+
+Emitted after the first successful `claim_investor_payout` for an investor.
+Repeated claims by the same investor are idempotent no-ops and do not re-emit.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `investor_payout_claimed` |
+| 1 | `name` | `Symbol` | `inv_claim` |
+| 2 | `investor` | `Address` | Claiming investor |
+| 3 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data: empty map; this struct has no non-topic fields.
+
+### `FundingCancelled`
+
+Emitted after successful `cancel_funding`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `funding_cancelled` |
+| 1 | `name` | `Symbol` | `fund_can` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `funded_amount` | `i128` |
+
+### `InvestorRefundedEvt`
+
+Emitted after successful `refund`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `investor_refunded_evt` |
+| 1 | `name` | `Symbol` | `refunded` |
+| 2 | `investor` | `Address` | Refunded investor |
+| 3 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `amount` | `i128` |
+
+### `TreasuryDustSwept`
+
+Emitted after successful `sweep_terminal_dust`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `treasury_dust_swept` |
+| 1 | `name` | `Symbol` | `dust_sw` |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `invoice_id` | `Symbol` |
+| `token` | `Address` |
+| `amount` | `i128` |
+
+### `PrimaryAttestationBound`
+
+Emitted after successful `bind_primary_attestation_hash`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `primary_attestation_bound` |
+| 1 | `name` | `Symbol` | `att_bind` |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `invoice_id` | `Symbol` |
+| `digest` | `BytesN<32>` |
+
+### `AttestationDigestAppended`
+
+Emitted after successful `append_attestation_digest`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `attestation_digest_appended` |
+| 1 | `name` | `Symbol` | `att_app` |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `invoice_id` | `Symbol` |
+| `index` | `u32` |
+| `digest` | `BytesN<32>` |
+
+### `AllowlistEnabledChanged`
+
+Emitted after successful `set_allowlist_active`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `allowlist_enabled_changed` |
+| 1 | `name` | `Symbol` | `al_ena` |
+
+Data:
+
+| Field | Type | Values |
 |---|---|---|
-| `0` | **open** | Escrow initialized; accepting investor funding |
-| `1` | **funded** | Target met; SME can be paid; awaiting buyer settlement |
-| `2` | **settled** | Buyer paid; investors can redeem principal + yield |
-| `3` | **withdrawn** | Explicitly written by `withdraw`, though not documented consistently elsewhere |
+| `invoice_id` | `Symbol` | Escrow invoice id |
+| `active` | `u32` | `1` = enabled, `0` = disabled |
 
----
+### `InvestorAllowlistChanged`
 
-## Topic Filter Cheat Sheet
+Emitted after successful `set_investor_allowlisted`. The batch entrypoint
+`set_investors_allowlisted` emits one event per investor in input order.
 
-Use these filters with `getEvents` (Stellar RPC) or Mercury subscriptions.
+Topics:
 
-> **Important:** Filter by `Topic[0]` (the event name Symbol) for each event type.
-> The contract does **not** use a shared namespace topic — each event struct has its
-> own `symbol_short!` name as the first topic.
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `investor_allowlist_changed` |
+| 1 | `name` | `Symbol` | `al_set` |
 
-| Event | Topic[0] symbol | Human label |
+Data:
+
+| Field | Type | Values |
 |---|---|---|
-| Escrow created | `escrow_ii` | `EscrowInitialized` |
-| Investor funded | `funded` | `EscrowFunded` |
-| Escrow settled | `escrow_sd` | `EscrowSettled` |
-| SME withdrew | `sme_wd` | `SmeWithdrew` |
-| Investor claimed | `inv_claim` | `InvestorPayoutClaimed` |
-| Dust swept | `dust_sw` | `TreasuryDustSwept` |
-| Legal hold changed | `legalhld` | `LegalHoldChanged` |
-| Funding target updated | `fund_tgt` | `FundingTargetUpdated` |
-| Maturity updated | `maturity` | `MaturityUpdatedEvent` |
-| Admin transferred | `admin` | `AdminTransferredEvent` |
-| Collateral recorded | `coll_rec` | `CollateralRecordedEvt` |
-| Primary attestation bound | `att_bind` | `PrimaryAttestationBound` |
-| Attestation log appended | `att_app` | `AttestationDigestAppended` |
-| Investor cap lowered | `inv_cap` | `MaxUniqueInvestorsCapLowered` |
-| Allowlist enabled/disabled | `al_ena` | `AllowlistEnabledChanged` |
-| Investor allowlist changed | `al_set` | `InvestorAllowlistChanged` |
+| `invoice_id` | `Symbol` | Escrow invoice id |
+| `investor` | `Address` | Updated investor |
+| `allowed` | `u32` | `1` = allowed, `0` = blocked |
 
----
+## Nested Types
 
-## Security Notes
+### `InvoiceEscrow`
 
-- **No sensitive data in events**: Escrow events intentionally omit off-chain
-  identifiers (e.g. buyer email, KYC data). They only expose on-chain addresses
-  and amounts already visible in the transaction itself.
-- **Events are append-only**: Once emitted, events cannot be mutated or deleted.
-  Indexers can treat them as an immutable audit log.
-- **Re-org safety**: On a Stellar re-org (rare), events from rolled-back
-  transactions are also rolled back. Indexers should confirm ledger closedness
-  (via `ledgerVersion` in the ledger meta) before treating events as final.
-- **Input validation**: The contract asserts valid state transitions before
-  emitting events, so an emitted event always represents a successfully
-  committed state change.
+Used in `EscrowInitialized.escrow`.
 
----
+| Field | Type |
+|---|---|
+| `invoice_id` | `Symbol` |
+| `admin` | `Address` |
+| `sme_address` | `Address` |
+| `amount` | `i128` |
+| `funding_target` | `i128` |
+| `funded_amount` | `i128` |
+| `yield_bps` | `i64` |
+| `maturity` | `u64` |
+| `status` | `u32` |
+
+Status values:
+
+| Value | Meaning |
+|---:|---|
+| 0 | Open |
+| 1 | Funded |
+| 2 | Settled |
+| 3 | Withdrawn |
+| 4 | Cancelled |
+
+## Indexer Notes
+
+- Prefer filtering by `contractId` plus `topic[1] == name` when routing by the
+  LiquiFact short event symbol. `topic[0]` is the generated Rust event-struct
+  symbol.
+- Use `(ledger, txHash, eventIndex)` as the idempotency cursor, as described in
+  `docs/escrow-indexer.md`.
+- Some useful correlation fields are data fields rather than topics:
+  `CollateralRecordedEvt.invoice_id`, `TreasuryDustSwept.invoice_id`,
+  `PrimaryAttestationBound.invoice_id`, `AttestationDigestAppended.invoice_id`,
+  `AllowlistEnabledChanged.invoice_id`, and
+  `InvestorAllowlistChanged.invoice_id`.
+- Do not treat collateral or attestation events as proof of off-chain custody,
+  KYC status, or legal enforceability. They are metadata/audit records emitted
+  after the corresponding authenticated write succeeds.
+
+## Security And State Invariants
+
+- Events are emitted only after the entrypoint guard checks and storage writes
+  in the successful path.
+- Unauthorized calls, invalid zero/negative amounts, overflow paths,
+  double-spend paths, legal-hold blocks, and invalid state-machine transitions
+  fail before event emission.
+- Investor claim and refund events are deduplicated by persistent markers or
+  contribution zeroing before emission.
+- Event emission is O(1) for all entrypoints except
+  `set_investors_allowlisted`, which emits O(n) `InvestorAllowlistChanged`
+  events for `n <= MAX_INVESTOR_ALLOWLIST_BATCH`.
 
 ## Changelog
 
 | Date | Version | Change |
 |---|---|---|
-| 2026-03-23 | v0.1 | Initial schema — `initialized`, `funded`, `settled` events defined |
-| 2026-05-27 | v0.2 | **Issue #251** — Extended `EscrowInitialized` payload with `funding_token`, `treasury`, `registry` fields (additive; backward-compatible) |
-| 2026-05-27 | v0.2 | **Issue #255** — Added `MaxUniqueInvestorsCapLowered` (`inv_cap`) event for `lower_max_unique_investors` |
-| 2026-05-27 | v0.2 | **Doc fix** — Corrected topic cheat sheet: replaced stale `"escrow"/"initd"` with actual per-event `symbol_short!` names; added complete event catalogue |
+| 2026-03-23 | v0.1 | Initial event schema reference |
+| 2026-05-27 | v0.2 | Added initialization references and investor-cap event notes |
+| 2026-05-31 | v0.3 | Issue #272: replaced drifted reference with complete `#[contractevent]` topic and data layout from `escrow/src/lib.rs` |

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -98,7 +98,7 @@ pub fn migrate(env: Env, from_version: u32) -> u32 {
 }
 ```
 
-**Current state (v5):** `migrate()` panics on **all** paths. No migration
+**Current state (v6):** `migrate()` panics on **all** paths. No migration
 work is implemented. Operators must redeploy if `InvoiceEscrow` layout changes.
 
 ---
@@ -190,7 +190,7 @@ stellar contract invoke \
   --min_contribution null \
   --max_unique_investors null
 
-# Verify stored version matches SCHEMA_VERSION (should return 5)
+# Verify stored version matches SCHEMA_VERSION (should return 6)
 stellar contract invoke \
   --id <CONTRACT_ID> \
   --source $SOURCE_SECRET \
@@ -366,10 +366,10 @@ first implementing the migration path.
 
 | WASM version (SCHEMA_VERSION) | Can read data from | Notes |
 |-------------------------------|-------------------|-------|
-| 5 | 5 | Same version — fully compatible |
-| 5 | 4 | Only if no struct layout changed; new optional keys absent → defaults |
-| 5 | ≤3 | Only if InvoiceEscrow XDR shape identical; new optional keys absent → defaults |
-| 4 reading 5 data | ❌ | Unknown keys ignored; may panic if struct layout changed |
+| 6 | 6 | Same version — fully compatible |
+| 6 | 5 | Requires redeploy for per-investor key relocation; no in-place migration path |
+| 6 | ≤4 | Only with an explicit migration path or redeploy; new optional keys absent → defaults when compatible |
+| ≤5 reading 6 data | ❌ | Older WASM reads per-investor accounting from instance storage |
 
 ---
 

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -8,35 +8,41 @@
 
 ## 1. Decision tree — redeploy vs. on-chain WASM upgrade
 
-On Stellar/Soroban, "upgrading" a contract means uploading new WASM bytecode
-and calling the contract's own upgrade entrypoint (if it exposes one) **or**
-deploying a new contract instance entirely.
+On Stellar/Soroban, "upgrading" a contract means preserving the contract ID and
+stored ledger entries while switching the instance to new WASM bytecode. The
+standard contract pattern is an admin-gated entrypoint that calls
+`env.deployer().update_current_contract_wasm(new_wasm_hash)`. If the deployed
+contract does not expose that upgrade entrypoint, operators must redeploy a new
+contract instance instead.
 
 ```
-Is InvoiceEscrow struct layout or any stored contracttype XDR shape changed?
+Does the existing instance expose an admin-gated WASM upgrade entrypoint?
 │
-├─ YES → REDEPLOY (new contract address, new init)
-│         └─ Reason: Soroban deserializes stored XDR using the types embedded
-│                    in the *current* WASM. A layout change causes deserialization
-│                    panic on every read of old data under new WASM.
+├─ NO  → REDEPLOY (new contract address, new init)
 │
-└─ NO  → Are you adding only new optional DataKey variants read with .unwrap_or()?
+└─ YES → Did InvoiceEscrow or any stored #[contracttype] XDR shape change?
           │
-          ├─ YES → WASM UPGRADE IN PLACE is safe.
-          │         └─ Steps: upload new WASM → call upgrade entrypoint (if present)
-          │                   → call migrate() only if you want to bump DataKey::Version.
-          │                   migrate() currently panics — extend it first.
+          ├─ YES → REDEPLOY (new contract address, new init)
+          │         └─ Reason: stored XDR must decode against the new WASM's
+          │                    contract types; layout changes are breaking.
           │
-          └─ NO  → Review change carefully.
-                    If you rename/remove an existing DataKey variant → REDEPLOY.
-                    If you only add new behavior with no stored-state change → WASM UPGRADE.
+          └─ NO  → Is the change only new DataKey variants read with defaults?
+                    │
+                    ├─ YES → WASM UPGRADE IN PLACE. Do not call migrate().
+                    │
+                    └─ NO  → Does the change require rewriting existing storage?
+                              │
+                              ├─ YES → Extend migrate() first, test it, then upgrade
+                              │         and call migrate() with the stored version.
+                              │
+                              └─ NO  → WASM UPGRADE IN PLACE, after code review.
 ```
 
 > **Key Soroban difference from EVM:** there is no `delegatecall`-style proxy
-> pattern. Upgrading WASM replaces the bytecode for the *same* contract
-> address, but all stored data remains in place and is decoded against the
-> **new** WASM's types. A struct layout change is therefore a breaking storage
-> change.
+> pattern in this contract. A same-address upgrade preserves stored data and
+> runs the new WASM against that data. A stored type layout change is therefore
+> a breaking storage change unless an explicit, tested migration can decode the
+> old data shape and rewrite it safely.
 
 ---
 
@@ -69,42 +75,97 @@ Do **not** bump `SCHEMA_VERSION` for:
 - Adding a new `#[contracttype]` stored at a new key.
 - Behavioral changes that do not touch stored state.
 
+### Changelog-based transition classification
+
+This table is derived from the `SCHEMA_VERSION` changelog in
+`escrow/src/lib.rs`. It is the operator classification for historical
+transitions through version 5.
+
+| Transition | Changelog source | Operator action |
+|------------|------------------|-----------------|
+| Fresh deploy → 1 | Initial schema (`InvoiceEscrow` v1, basic fund / settle) | Fresh `init`; no migration exists before v1. |
+| 1 → 2 | Added `InvestorEffectiveYield`, `InvestorClaimNotBefore` | Additive. No `migrate()` call required when readers default missing values. |
+| 2 → 3 | Added `FundingCloseSnapshot`, `MinContributionFloor`, `MaxUniqueInvestorsCap`, `UniqueFunderCount` | Additive. No `migrate()` call required when readers default missing values. |
+| 3 → 4 | Added `PrimaryAttestationHash`, `AttestationAppendLog` | Additive. No `migrate()` call required. |
+| 4 → 5 | Added `YieldTierTable`, `RegistryRef`, `Treasury`; tightened `InvoiceEscrow` layout | Conditional. Additive keys alone need no `migrate()`, but any `InvoiceEscrow` XDR/layout change is breaking and requires redeploy. |
+| 5 → 6 | Per-investor keys moved to persistent storage | Breaking for existing instances. Redeploy required because prior per-investor instance keys are address-keyed and not enumerable by the contract. |
+
+Operational rule: additive keys are safe only when old instances can read them
+with explicit defaults. Changing, renaming, or removing an existing key or
+changing an existing stored type's XDR shape is not additive.
+
 ### Implementing a real migration in `migrate()`
 
 ```rust
-// Example: adding a new required field `fee_bps: i64` to InvoiceEscrow.
-// This requires a redeploy (new struct XDR) but illustrates the pattern
-// for a same-instance migration when only a primitive flag changes.
-
 pub fn migrate(env: Env, from_version: u32) -> u32 {
+    // Keep this guard first. Current code already requires admin auth before
+    // version checks so every future storage rewrite is admin-gated.
     Self::get_escrow(env.clone()).admin.require_auth();
 
     let stored: u32 = env.storage().instance().get(&DataKey::Version).unwrap_or(0);
-    assert!(stored == from_version, "from_version does not match stored version");
-    if from_version >= SCHEMA_VERSION {
-        panic!("Already at current schema version");
-    }
-
-    // Example path: 4 → 5 (additive new key, no struct change)
-    if from_version == 4 {
-        // Initialize new optional key with a safe default.
-        env.storage().instance().set(&DataKey::MinContributionFloor, &0i128);
-        env.storage().instance().set(&DataKey::Version, &5u32);
-        return 5;
-    }
-
-    panic!(
-        "No migration path from version {} — extend migrate or redeploy",
-        from_version
+    ensure(
+        &env,
+        stored == from_version,
+        EscrowError::MigrationVersionMismatch,
     );
+
+    if from_version >= SCHEMA_VERSION {
+        fail(&env, EscrowError::AlreadyCurrentSchemaVersion)
+    }
+
+    // Example pattern for a future same-instance migration:
+    if from_version == 6 && SCHEMA_VERSION == 7 {
+        // 1. Read only old-version data that the new WASM can still decode.
+        // 2. Validate arithmetic with checked_* operations.
+        // 3. Write new keys or rewritten values exactly once.
+        // 4. Write DataKey::Version last.
+        env.storage().instance().set(&DataKey::Version, &7u32);
+        return 7;
+    }
+
+    fail(&env, EscrowError::NoMigrationPath)
 }
 ```
 
-**Current state (v6):** `migrate()` panics on **all** paths. No migration
-work is implemented. The entrypoint is admin-gated before version checks so any
-future storage-mutating migration path is authenticated by construction.
-See [ADR-007](adr/ADR-007-storage-key-evolution.md) for the storage-key
-evolution policy. Operators must redeploy if `InvoiceEscrow` layout changes.
+Step-by-step implementation requirements for a real migration:
+
+1. Bump `SCHEMA_VERSION` in `escrow/src/lib.rs`.
+2. Add the migration branch above the terminal `EscrowError::NoMigrationPath`.
+3. Keep `Self::get_escrow(env.clone()).admin.require_auth()` before all version
+   checks and before every storage write.
+4. Read `DataKey::Version` and require `stored == from_version`.
+5. For each migrated value, prove the new WASM can decode the old stored value;
+   otherwise redeploy instead of migrating in place.
+6. Use checked arithmetic for transformed numeric values and keep writes
+   bounded. The migration should be O(number of explicitly supplied or
+   enumerable keys); do not design a migration that assumes contract storage can
+   enumerate all investors.
+7. Write all transformed state before writing `DataKey::Version`.
+8. Write `DataKey::Version` last and return the new version.
+9. Add unit tests for version mismatch, already-current version, unauthorized
+   caller, the successful migration path, and repeated calls after success.
+10. Update this runbook, the rustdoc changelog, and any affected read/API docs.
+
+**Current state (v6):** `migrate()` fails with typed contract errors on **all**
+paths. No migration work is implemented. The entrypoint is admin-gated before
+version checks so any future storage-mutating migration path is authenticated by
+construction. See [ADR-007](adr/ADR-007-storage-key-evolution.md) for the
+storage-key evolution policy. Operators must redeploy if `InvoiceEscrow` layout
+changes.
+
+### Current `migrate()` panic policy
+
+This table must match the `migrate` rustdoc in `escrow/src/lib.rs`.
+
+| Condition | Typed error |
+|-----------|-------------|
+| `stored_version != from_version` | `EscrowError::MigrationVersionMismatch` |
+| `from_version >= SCHEMA_VERSION` | `EscrowError::AlreadyCurrentSchemaVersion` |
+| Any `from_version < SCHEMA_VERSION` without an implemented migration branch | `EscrowError::NoMigrationPath` |
+
+Because Soroban aborts the transaction on contract panic, these errors perform
+no storage writes in the current release. Operators must not call `migrate()` as
+a bookkeeping step after additive upgrades.
 
 ---
 
@@ -207,7 +268,9 @@ stellar contract invoke \
 
 ## 4. WASM upgrade in place (additive-only changes)
 
-Use this path only when no `#[contracttype]` stored struct layout has changed.
+Use this path only when no `#[contracttype]` stored struct layout has changed
+and the currently deployed contract exposes an admin-gated upgrade entrypoint
+that calls `env.deployer().update_current_contract_wasm(new_wasm_hash)`.
 
 ```bash
 # Step 1: Upload new WASM (get new hash)
@@ -216,21 +279,22 @@ stellar contract upload \
   --source $SOURCE_SECRET \
   --network $STELLAR_NETWORK
 
-# Step 2: Upgrade the existing contract instance's WASM
-stellar contract upgrade \
+# Step 2: Invoke the deployed contract's upgrade entrypoint, if present.
+# The current LiquiFact escrow contract does not expose this entrypoint.
+stellar contract invoke \
   --id <EXISTING_CONTRACT_ID> \
-  --wasm-hash <NEW_WASM_HASH> \
   --source $SOURCE_SECRET \
-  --network $STELLAR_NETWORK
+  --network $STELLAR_NETWORK \
+  -- upgrade --new_wasm_hash <NEW_WASM_HASH>
 
 # Step 3 (optional): Call migrate() only if you implemented a migration path.
 # In the current release, migrate() panics — do NOT call it unless extended.
 # stellar contract invoke --id <CONTRACT_ID> ... -- migrate --from_version 4
 ```
 
-> **Soroban note:** `stellar contract upgrade` replaces the WASM for the
-> contract at the given ID. The stored instance data is preserved. Old XDR is
-> decoded against the **new** WASM types on the next read.
+> **Soroban note:** `env.deployer().update_current_contract_wasm` replaces the
+> WASM for the contract at the current ID. The stored instance data is
+> preserved. Old XDR is decoded against the **new** WASM types on the next read.
 
 ---
 
@@ -272,13 +336,14 @@ support contract destruction. Operators must:
 
 ## 6. Rollback protocol
 
-There is **no on-chain downgrade** path on Soroban. If a WASM upgrade
-introduces a bug:
+There is **no automatic on-chain downgrade** path on Soroban. If a WASM upgrade
+introduces a bug, recovery still requires an available admin-gated upgrade
+entrypoint on the deployed contract:
 
 ```
-Option A (safest): Re-upload previous WASM, call stellar contract upgrade
-                   back to old hash. Works only if stored data is still
-                   compatible with old WASM types.
+Option A (safest): Re-upload previous WASM, invoke the contract's upgrade
+                   entrypoint back to the old hash. Works only if stored data
+                   is still compatible with old WASM types.
 
 Option B (layout-broken): Redeploy from old WASM hash (already uploaded).
                            Migrate investor positions off-chain.
@@ -289,12 +354,12 @@ Option C (emergency): Activate legal hold on the broken contract to block
 ```
 
 ```bash
-# Option A — revert WASM (requires previous hash)
-stellar contract upgrade \
+# Option A — revert WASM through the contract's upgrade entrypoint
+stellar contract invoke \
   --id <CONTRACT_ID> \
-  --wasm-hash <PREVIOUS_WASM_HASH> \
   --source $SOURCE_SECRET \
-  --network $STELLAR_NETWORK
+  --network $STELLAR_NETWORK \
+  -- upgrade --new_wasm_hash <PREVIOUS_WASM_HASH>
 
 # Emergency hold (before investigating)
 stellar contract invoke \
@@ -315,7 +380,8 @@ stellar contract invoke \
    stellar contract invoke --id <ID> ... -- set_legal_hold --active true
    ```
 
-2. **Perform** the WASM upload and (if applicable) `stellar contract upgrade`.
+2. **Perform** the WASM upload and, if the contract supports it, invoke the
+   admin-gated upgrade entrypoint.
 
 3. **Verify** the upgraded contract: call `get_version`, `get_escrow`, and
    run smoke tests on Testnet mirror.
@@ -346,9 +412,10 @@ used as `funding_token` in an escrow instance.
 ### No EVM proxy patterns
 
 This contract does not implement a proxy pattern (no `delegatecall` equivalent
-on Soroban). Upgrade authority flows through `stellar contract upgrade`
-(protocol-level, requires the deployer footprint) and is not exposed as an
-on-chain entrypoint in the current release.
+on Soroban). Same-address upgrade authority should flow through a contract
+entrypoint that requires admin authorization before calling
+`env.deployer().update_current_contract_wasm`. The current release does not
+expose that entrypoint, so operators should use redeploy for new WASM.
 
 ### Admin key hygiene
 
@@ -383,7 +450,7 @@ first implementing the migration path.
 | Term | Meaning in this context |
 |------|------------------------|
 | WASM upload | `stellar contract upload` — publishes bytecode to network; returns a hash |
-| WASM upgrade | `stellar contract upgrade` — replaces bytecode for an existing contract ID |
+| WASM upgrade | Admin-gated contract entrypoint calling `env.deployer().update_current_contract_wasm` for an existing contract ID |
 | Redeploy | Deploy a **new** contract instance; old instance is not migrated automatically |
 | `DataKey::Version` | On-chain stored schema version set by `init` and updated by `migrate` |
 | `SCHEMA_VERSION` | Compile-time constant in WASM; the target version for `init` and migration |

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -77,6 +77,8 @@ Do **not** bump `SCHEMA_VERSION` for:
 // for a same-instance migration when only a primitive flag changes.
 
 pub fn migrate(env: Env, from_version: u32) -> u32 {
+    Self::get_escrow(env.clone()).admin.require_auth();
+
     let stored: u32 = env.storage().instance().get(&DataKey::Version).unwrap_or(0);
     assert!(stored == from_version, "from_version does not match stored version");
     if from_version >= SCHEMA_VERSION {
@@ -99,7 +101,10 @@ pub fn migrate(env: Env, from_version: u32) -> u32 {
 ```
 
 **Current state (v6):** `migrate()` panics on **all** paths. No migration
-work is implemented. Operators must redeploy if `InvoiceEscrow` layout changes.
+work is implemented. The entrypoint is admin-gated before version checks so any
+future storage-mutating migration path is authenticated by construction.
+See [ADR-007](adr/ADR-007-storage-key-evolution.md) for the storage-key
+evolution policy. Operators must redeploy if `InvoiceEscrow` layout changes.
 
 ---
 

--- a/docs/adr/ADR-007-storage-key-evolution.md
+++ b/docs/adr/ADR-007-storage-key-evolution.md
@@ -42,15 +42,33 @@ the old layout, rewrites under the new layout, and bumps `DataKey::Version`.
 
 ### Rule 3 — `SCHEMA_VERSION` tracks breaking changes only
 
-`SCHEMA_VERSION` (currently `5`) is incremented only when a `migrate` path is added. Additive-only
+`SCHEMA_VERSION` (currently `6`) is incremented only when a `migrate` path is added. Additive-only
 releases leave the version unchanged.
 
 ### Rule 4 — Per-address key growth must be re-evaluated
 
 Any new per-address `DataKey` variant (e.g. `DataKey::SomeFlag(Address)`) multiplies storage
 consumption by the investor count. Before merging, verify the worst-case serialised size at
-`MaxUniqueInvestorsCap` (128) stays within Soroban's contract-data entry limit. The existing
-storage-growth regression tests in `escrow/src/test/` serve as the baseline.
+`MaxUniqueInvestorsCap` stays within Soroban's per-entry limits. The existing storage-growth
+regression tests in `escrow/src/tests/` serve as the baseline.
+
+### Rule 5 — Per-investor keys use persistent storage (schema version 6, issue #253)
+
+The following keys are stored via `env.storage().persistent()` so each investor address has an
+independent TTL and the contract instance entry does not grow with investor cardinality:
+
+- `DataKey::InvestorContribution(Address)`
+- `DataKey::InvestorEffectiveYield(Address)`
+- `DataKey::InvestorClaimNotBefore(Address)`
+- `DataKey::InvestorClaimed(Address)`
+
+Read/write semantics are unchanged: absent keys still default to `0`, base `yield_bps`, `0`, and
+`false` respectively. See `docs/escrow-gas-storage-notes.md` for TTL extension via
+[`LiquifactEscrow::bump_ttl`](../../escrow/src/lib.rs).
+
+**Migration:** relocating storage type is not enumerable on-chain (no iteration over instance keys
+by address). `migrate` returns [`EscrowError::NoMigrationPath`]; operators must **redeploy** fresh
+contract instances at `SCHEMA_VERSION = 6`.
 
 ## Compatibility test plan
 
@@ -72,11 +90,13 @@ storage-growth regression tests in `escrow/src/test/` serve as the baseline.
   `migrate` must be called before using new features that depend on the new layout.
 - Storage-growth tests act as regression guards; any PR that adds per-address keys must update or
   extend those tests.
+- Schema version 6 bounds instance footprint by moving the four per-investor keys above to
+  persistent storage; TTL per address is isolated from the contract instance (Stellar docs:
+  [state archival](https://developers.stellar.org/docs/learn/fundamentals/contract-development/storage/state-archival)).
 
 ## Rejected alternatives
 
 - **Always bump version on any key addition:** creates unnecessary migration ceremony for purely
   additive changes and makes `migrate` a no-op most of the time.
-- **Persistent or temporary storage for per-investor data:** would avoid the instance-size concern
-  but changes the access pattern and TTL semantics; deferred to a future ADR if investor counts
-  need to scale beyond 128.
+- **In-place `migrate` to copy instance per-investor entries to persistent:** rejected because
+  investor addresses cannot be enumerated from storage; no safe on-chain migration path exists.

--- a/docs/escrow-data-model.md
+++ b/docs/escrow-data-model.md
@@ -10,25 +10,26 @@ For the policy that governs schema evolution see [ADR-007](adr/ADR-007-storage-k
 
 ## Storage backend
 
-Most keys use `env.storage().instance()`. Instance storage is scoped to a single contract address
-and is loaded in full on every host-function invocation.
+Most scalar contract keys use `env.storage().instance()`. Instance storage is scoped to a single
+contract address and is loaded in full on every host-function invocation.
 
-The contract also uses `env.storage().persistent()` for allowlist membership entries
-(`DataKey::InvestorAllowlisted(Address)`), which are per-address and naturally modeled as
-independent persistent keys (see Stellar/Soroban storage guidance on instance vs persistent
-storage).
+The contract uses `env.storage().persistent()` for per-address entries:
+`DataKey::InvestorContribution(Address)`, `DataKey::InvestorEffectiveYield(Address)`,
+`DataKey::InvestorClaimNotBefore(Address)`, `DataKey::InvestorClaimed(Address)`, and
+`DataKey::InvestorAllowlisted(Address)`. These are naturally modeled as independent persistent keys
+with per-address TTLs (see Stellar/Soroban storage guidance on instance vs persistent storage).
 
 Consequence: the total serialised size of all instance entries must stay within Soroban's
-contract-data entry limit. The investor-contribution map is the main growth vector; it is bounded
-by `MaxUniqueInvestorsCap` (default 128 per the README guardrails).
+contract-data entry limit. Per-investor accounting no longer grows the instance footprint; investor
+cardinality is still bounded by `MaxUniqueInvestorsCap` when configured.
 
 ---
 
 ## `DataKey` enum — complete reference
 
-`DataKey` is a `#[contracttype]` enum. Each variant becomes a distinct XDR-encoded key in the
-instance storage map. The enum derives `Clone` so key values can be reused across get/set calls in
-the same execution path without moving ownership.
+`DataKey` is a `#[contracttype]` enum. Each variant becomes a distinct XDR-encoded key in whichever
+storage backend reads or writes it. The enum derives `Clone` so key values can be reused across
+get/set calls in the same execution path without moving ownership.
 
 ### Scalar keys (always present after `init`)
 
@@ -57,9 +58,10 @@ with `unwrap_or(0)`.
 | `PrimaryAttestationHash` | `BytesN<32>` | `bind_primary_attestation_hash` | Single-set; panics on second call |
 | `AttestationAppendLog` | `Vec<BytesN<32>>` | `append_attestation_digest` | Bounded by `MAX_ATTESTATION_APPEND_ENTRIES` (32) |
 
-### Per-address keys (one entry per investor address)
+### Per-address investor keys in persistent storage
 
-These variants carry an `Address` discriminator so each investor gets an independent storage slot.
+These variants carry an `Address` discriminator so each investor gets an independent persistent
+storage slot and TTL.
 
 | Variant | Rust type stored | Set by | Default when absent |
 |---------|-----------------|--------|---------------------|
@@ -71,9 +73,9 @@ These variants carry an `Address` discriminator so each investor gets an indepen
 All four per-address keys are written together on an investor's first `fund` or
 `fund_with_commitment` call. Subsequent `fund` calls update only `InvestorContribution`.
 
-### Per-address keys in persistent storage (allowlist)
+### Per-address allowlist keys in persistent storage
 
-These entries live in **persistent** storage (not instance storage).
+These entries also live in **persistent** storage (not instance storage).
 
 | Variant | Rust type stored | Set by | Default when absent |
 |---------|------------------|--------|---------------------|
@@ -147,7 +149,7 @@ Validated at `init`: `min_lock_secs` strictly increasing, `yield_bps` non-decrea
 
 ## Schema version
 
-`DataKey::Version` stores a `u32` written as `SCHEMA_VERSION` (currently `5`) at `init`. The
+`DataKey::Version` stores a `u32` written as `SCHEMA_VERSION` (currently `6`) at `init`. The
 `migrate` entrypoint validates `from_version == stored` before applying any migration path. No
 migration paths are currently implemented; adding a new optional key does not require a version bump
 (see additive-key policy below).
@@ -186,6 +188,6 @@ test plan.
   behavior off-chain or in a dedicated integration.
 - **Attestation digests:** `PrimaryAttestationHash` and `AttestationAppendLog` store raw byte
   digests. The contract does not verify what the digest commits to; that is an off-chain concern.
-- **Storage growth:** per-address keys grow linearly with investor count. `MaxUniqueInvestorsCap`
-  (default 128) bounds this. Any schema change that adds per-address keys must re-evaluate the
-  storage footprint against Soroban's contract-data entry limits.
+- **Storage growth:** per-address investor keys use persistent storage to avoid unbounded instance
+  growth. `MaxUniqueInvestorsCap` can still bound investor count. Any schema change that adds
+  per-address keys must re-evaluate storage footprint and TTL behavior.

--- a/docs/escrow-security-checklist.md
+++ b/docs/escrow-security-checklist.md
@@ -2,7 +2,7 @@
 
 > Issue #167 — Soroban security research.
 > Scope: `escrow/src/lib.rs` and `escrow/src/external_calls.rs`.
-> Schema version: [`SCHEMA_VERSION`] = 5.
+> Schema version: [`SCHEMA_VERSION`] = 6.
 
 ---
 
@@ -268,7 +268,7 @@ and does not weaken the auth boundary. Refactors must not move step 3 above step
 | `sweep_terminal_dust` | `treasury` | legal hold, `get_escrow`, treasury read | line ~702 | SEP-41 transfer |
 | `migrate` | **none** (panics) | version read only | — | none (all paths panic) |
 
-Line numbers refer to `escrow/src/lib.rs` at schema version 5; re-audit after refactors.
+Line numbers refer to `escrow/src/lib.rs` at schema version 6; re-audit after refactors.
 
 ### Negative-auth test coverage
 

--- a/docs/escrow-sim-stellar-cli.md
+++ b/docs/escrow-sim-stellar-cli.md
@@ -837,7 +837,7 @@ advance the stored schema version. The current contract panics for all `from_ver
 because no migration path is implemented — this entrypoint is a forward-compatibility hook for
 future schema upgrades.
 
-The current `SCHEMA_VERSION` is `5`. A fresh deployment stores version `5`. Two panic cases:
+The current `SCHEMA_VERSION` is `6`. A fresh deployment stores version `6`. Two panic cases:
 
 ```bash
 # Panics: "Already at current schema version" (from_version matches stored AND equals SCHEMA_VERSION)
@@ -846,7 +846,7 @@ stellar contract invoke \
   --source admin \
   --network local \
   -- migrate \
-  --from_version 5
+  --from_version 6
 
 # Panics: "from_version does not match stored version" (mismatch with what is stored)
 stellar contract invoke \

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -148,7 +148,7 @@ and requires treasury auth. Intended for rounding residue — not for settling
 live liabilities.
 
 ### Schema version
-`SCHEMA_VERSION` (currently `5`) written to `DataKey::Version` at `init`. Used
+`SCHEMA_VERSION` (currently `6`) written to `DataKey::Version` at `init`. Used
 to gate the `migrate` entrypoint. See the
 [schema version changelog](../README.md#schema-version-changelog-datakeyversion).
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -11,7 +11,7 @@
 //! ## Schema version ([`SCHEMA_VERSION`] / [`DataKey::Version`])
 //!
 //! The constant [`SCHEMA_VERSION`] is written to [`DataKey::Version`] by [`LiquifactEscrow::init`]
-//! and is the canonical source of truth for upgrade decisions. **Current value: 5.**
+//! and is the canonical source of truth for upgrade decisions. **Current value: 6.**
 //!
 //! [`LiquifactEscrow::migrate`] **fails with typed errors in all current execution paths** — no
 //! silent migration work is promised or performed. Operators must extend `migrate` before calling
@@ -121,6 +121,97 @@ use soroban_sdk::{
 
 pub mod external_calls;
 
+// Typed contract errors used throughout the contract. Keep in sync with
+// `docs/escrow-error-messages.md`.
+#[contracterror]
+#[derive(Debug, PartialEq, Eq)]
+pub enum EscrowError {
+    AmountMustBePositive = 1,
+    YieldBpsOutOfRange = 2,
+    EscrowAlreadyInitialized = 3,
+    InvoiceIdInvalidLength = 4,
+    InvoiceIdInvalidCharset = 5,
+    MinContributionNotPositive = 6,
+    MinContributionExceedsAmount = 7,
+    MaxUniqueInvestorsNotPositive = 8,
+    MaxPerInvestorNotPositive = 9,
+    TierYieldOutOfRange = 10,
+    TierYieldBelowBase = 11,
+    TierLockNotIncreasing = 12,
+    TierYieldNotNonDecreasing = 13,
+    EscrowNotInitialized = 20,
+    FundingTokenNotSet = 21,
+    TreasuryNotSet = 22,
+    LegalHoldBlocksTreasuryDustSweep = 30,
+    SweepAmountNotPositive = 31,
+    SweepAmountExceedsMax = 32,
+    DustSweepNotTerminal = 33,
+    NoFundingTokenBalanceToSweep = 34,
+    EffectiveSweepAmountZero = 35,
+    TransferAmountNotPositive = 36,
+    InsufficientTokenBalanceBeforeTransfer = 37,
+    SenderBalanceUnderflow = 38,
+    RecipientBalanceUnderflow = 39,
+    SenderBalanceDeltaMismatch = 40,
+    RecipientBalanceDeltaMismatch = 41,
+    PrimaryAttestationAlreadyBound = 50,
+    AttestationAppendLogCapacityReached = 51,
+    CollateralAmountNotPositive = 60,
+    CollateralAssetEmpty = 61,
+    CollateralTimestampBackwards = 62,
+    InvestorBatchEmpty = 70,
+    InvestorBatchTooLarge = 71,
+    TargetNotPositive = 72,
+    TargetUpdateNotOpen = 73,
+    TargetBelowFundedAmount = 74,
+    CapLowerNotOpen = 75,
+    NoInvestorCapConfigured = 76,
+    NewCapNotLower = 77,
+    NewCapBelowCurrentFunderCount = 78,
+    MaturityUpdateNotOpen = 79,
+    NewAdminSameAsCurrent = 80,
+    MigrationVersionMismatch = 90,
+    AlreadyCurrentSchemaVersion = 91,
+    NoMigrationPath = 92,
+    FundingAmountNotPositive = 100,
+    FundingBelowMinContribution = 101,
+    LegalHoldBlocksFunding = 102,
+    EscrowNotOpenForFunding = 103,
+    InvestorNotAllowlisted = 104,
+    InvestorContributionOverflow = 105,
+    InvestorContributionExceedsCap = 106,
+    UniqueInvestorCapReached = 107,
+    TieredSecondDeposit = 108,
+    InvestorClaimTimeOverflow = 109,
+    FundedAmountOverflow = 110,
+    LegalHoldBlocksSettlement = 120,
+    SettlementNotFunded = 121,
+    MaturityNotReached = 122,
+    LegalHoldBlocksWithdrawal = 123,
+    WithdrawalNotFunded = 124,
+    LegalHoldBlocksInvestorClaims = 125,
+    NoContributionToClaim = 126,
+    InvestorClaimNotSettled = 127,
+    InvestorCommitmentLockNotExpired = 128,
+    ComputePayoutArithmeticOverflow = 129,
+    LegalHoldBlocksCancelFunding = 140,
+    CancelFundingNotOpen = 141,
+    RefundNotCancelled = 142,
+    NoContributionToRefund = 143,
+}
+
+/// Panic with a typed `EscrowError` if `cond` is false.
+pub fn ensure(env: &Env, cond: bool, err: EscrowError) {
+    if !cond {
+        panic_with_error!(env, err);
+    }
+}
+
+/// Generic fail helper that panics with a typed `EscrowError` and coerces to any return type.
+pub fn fail<T>(env: &Env, err: EscrowError) -> T {
+    panic_with_error!(env, err)
+}
+
 /// Current storage schema version written to [`DataKey::Version`] by [`LiquifactEscrow::init`].
 ///
 /// # Schema version changelog
@@ -132,9 +223,10 @@ pub mod external_calls;
 /// | 3 | Added `FundingCloseSnapshot`, `MinContributionFloor`, `MaxUniqueInvestorsCap`, `UniqueFunderCount` | Additive keys — old instances return defaults |
 /// | 4 | Added `PrimaryAttestationHash`, `AttestationAppendLog` | Additive keys — no `migrate` call required |
 /// | 5 | Added `YieldTierTable`, `RegistryRef`, `Treasury`; `fund_with_commitment` | **Redeploy required** if `InvoiceEscrow` XDR changed |
+/// | 6 | Per-investor keys moved to **persistent** storage (see ADR-007) | **Redeploy required** — no `migrate` path (addresses not enumerable) |
 ///
 /// See `docs/OPERATOR_RUNBOOK.md` for the full redeploy-vs-upgrade decision tree.
-pub const SCHEMA_VERSION: u32 = 5;
+pub const SCHEMA_VERSION: u32 = 6;
 
 /// Upper bound on [`LiquifactEscrow::append_attestation_digest`] entries to keep storage bounded.
 pub const MAX_ATTESTATION_APPEND_ENTRIES: u32 = 32;
@@ -169,11 +261,16 @@ pub const PERSISTENT_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 
 
 #[contracttype]
 #[derive(Clone)]
-/// Storage discriminator for all persisted values in Soroban instance storage.
+/// Storage discriminator for persisted contract state.
 ///
-/// Every variant maps to a distinct XDR-encoded key in the contract’s instance storage map.
-/// Optional and per-address keys are always read with `.get(...).unwrap_or(default)` so that
-/// deployments predating a key behave as “unset / default” without panicking.
+/// Most variants live in **instance** storage (shared TTL with the contract instance, bounded
+/// aggregate size). Per-investor variants
+/// [`InvestorContribution`], [`InvestorEffectiveYield`], [`InvestorClaimNotBefore`], and
+/// [`InvestorClaimed`] use **persistent** storage (independent per-address TTL; see ADR-007 and
+/// `docs/escrow-gas-storage-notes.md`). [`InvestorAllowlisted`] also uses persistent storage.
+///
+/// Optional keys are always read with `.get(...).unwrap_or(default)` so that deployments predating
+/// a key behave as “unset / default” without panicking.
 ///
 /// ## Additive-key policy (see ADR-007)
 ///
@@ -193,7 +290,7 @@ pub enum DataKey {
     /// Read with [`LiquifactEscrow::get_version`]. Never delete or rename this variant.
     Version,
     /// Per-investor contributed principal recorded during [`LiquifactEscrow::fund`].
-    /// Absent ⇒ `0`. One entry per investor address.
+    /// **Persistent** storage. Absent ⇒ `0`. One entry per investor address.
     InvestorContribution(Address),
     /// When true, compliance/legal hold blocks payouts and settlement finalization.
     /// Absent ⇒ `false` (no hold). Toggled by admin via [`LiquifactEscrow::set_legal_hold`].
@@ -202,7 +299,7 @@ pub enum DataKey {
     /// Absent when no commitment has been recorded. Replaceable by the SME.
     SmeCollateralPledge,
     /// Set to `true` when an investor has exercised a claim after settlement.
-    /// Absent ⇒ `false`. Written once; a second claim returns without re-emitting.
+    /// **Persistent** storage. Absent ⇒ `false`. Written once; a second claim returns without re-emitting.
     InvestorClaimed(Address),
     /// SEP-41 funding asset for this invoice instance; set once in [`LiquifactEscrow::init`].
     /// Immutable after init.
@@ -221,10 +318,10 @@ pub enum DataKey {
     /// Absent until the escrow reaches `status == 1`. See [`FundingCloseSnapshot`].
     FundingCloseSnapshot,
     /// Effective annualized yield in bps chosen at this investor’s **first** deposit (see tiered yield).
-    /// Absent ⇒ falls back to [`InvoiceEscrow::yield_bps`]. One entry per investor address.
+    /// **Persistent** storage. Absent ⇒ falls back to [`InvoiceEscrow::yield_bps`]. One entry per investor address.
     InvestorEffectiveYield(Address),
     /// Minimum [`Env::ledger`] timestamp before [`LiquifactEscrow::claim_investor_payout`] (0 = no extra gate).
-    /// Absent ⇒ `0`. One entry per investor address; set on first deposit.
+    /// **Persistent** storage. Absent ⇒ `0`. One entry per investor address; set on first deposit.
     InvestorClaimNotBefore(Address),
     /// Minimum [`LiquifactEscrow::fund`] / [`LiquifactEscrow::fund_with_commitment`] amount per call (0 = no floor).
     /// Written as `0` even when unconfigured so reads always succeed.
@@ -817,6 +914,12 @@ impl LiquifactEscrow {
         env.storage().instance().get(&DataKey::RegistryRef)
     }
 
+    /// Returns the optional pending admin address waiting for [`LiquifactEscrow::accept_admin`],
+    /// or [`None`] when no admin handover is in progress.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::PendingAdmin)
+    }
+
     /// Return whether this escrow has a configured maturity time lock.
     ///
     /// `true` means [`InvoiceEscrow::maturity`] is positive and [`LiquifactEscrow::settle`] requires
@@ -1065,11 +1168,61 @@ impl LiquifactEscrow {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
-    pub fn get_contribution(env: Env, investor: Address) -> i128 {
+    // --- Persistent per-investor storage helpers ---
+    fn get_persistent_investor_contribution(env: &Env, investor: Address) -> i128 {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::InvestorContribution(investor))
             .unwrap_or(0)
+    }
+
+    fn set_persistent_investor_contribution(env: &Env, investor: Address, amount: i128) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::InvestorContribution(investor), &amount);
+    }
+
+    fn get_persistent_investor_effective_yield(env: &Env, investor: Address) -> Option<i64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::InvestorEffectiveYield(investor))
+    }
+
+    fn set_persistent_investor_effective_yield(env: &Env, investor: Address, value: i64) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::InvestorEffectiveYield(investor), &value);
+    }
+
+    fn get_persistent_investor_claim_not_before(env: &Env, investor: Address) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::InvestorClaimNotBefore(investor))
+            .unwrap_or(0)
+    }
+
+    fn set_persistent_investor_claim_not_before(env: &Env, investor: Address, value: u64) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::InvestorClaimNotBefore(investor), &value);
+    }
+
+    fn get_persistent_investor_claimed(env: &Env, investor: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::InvestorClaimed(investor))
+            .unwrap_or(false)
+    }
+
+    fn set_persistent_investor_claimed(env: &Env, investor: Address, value: bool) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::InvestorClaimed(investor), &value);
+    }
+
+    /// Public API: contribution recorded for `investor` (persistent storage).
+    pub fn get_contribution(env: Env, investor: Address) -> i128 {
+        Self::get_persistent_investor_contribution(&env, investor)
     }
 
     /// Pro-rata denominator captured when the escrow first became **funded**; [`None`] until then.
@@ -1089,18 +1242,13 @@ impl LiquifactEscrow {
     pub fn get_investor_yield_bps(env: Env, investor: Address) -> i64 {
         // env.clone(): env is used again after this call for the InvestorEffectiveYield read.
         let escrow = Self::get_escrow(env.clone());
-        env.storage()
-            .instance()
-            .get(&DataKey::InvestorEffectiveYield(investor.clone()))
+        Self::get_persistent_investor_effective_yield(&env, investor.clone())
             .unwrap_or(escrow.yield_bps)
     }
 
     /// Earliest ledger timestamp for [`LiquifactEscrow::claim_investor_payout`]; `0` if not gated.
     pub fn get_investor_claim_not_before(env: Env, investor: Address) -> u64 {
-        env.storage()
-            .instance()
-            .get(&DataKey::InvestorClaimNotBefore(investor))
-            .unwrap_or(0)
+        Self::get_persistent_investor_claim_not_before(&env, investor)
     }
 
     pub fn get_sme_collateral_commitment(env: Env) -> Option<SmeCollateralCommitment> {
@@ -1108,10 +1256,7 @@ impl LiquifactEscrow {
     }
 
     pub fn is_investor_claimed(env: Env, investor: Address) -> bool {
-        env.storage()
-            .instance()
-            .get(&DataKey::InvestorClaimed(investor))
-            .unwrap_or(false)
+        Self::get_persistent_investor_claimed(&env, investor)
     }
 
     /// Record or replace the optional SME collateral commitment metadata.
@@ -1424,14 +1569,14 @@ impl LiquifactEscrow {
         );
 
         if from_version >= SCHEMA_VERSION {
-            fail(&env, EscrowError::AlreadyCurrentSchemaVersion);
+            return fail(&env, EscrowError::AlreadyCurrentSchemaVersion);
         }
 
         // No migration path is implemented for any version below SCHEMA_VERSION.
         // To add one: implement the transformation here, call
         //   env.storage().instance().set(&DataKey::Version, &NEW_VERSION);
         // and return NEW_VERSION before reaching this typed error.
-        fail(&env, EscrowError::NoMigrationPath);
+        return fail(&env, EscrowError::NoMigrationPath);
     }
 
     /// Record investor principal while the invoice is **open**. First deposit sets base
@@ -1509,8 +1654,7 @@ impl LiquifactEscrow {
             );
         }
 
-        let contribution_key = DataKey::InvestorContribution(investor.clone());
-        let prev: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
+        let prev: i128 = Self::get_persistent_investor_contribution(&env, investor.clone());
         let new_contribution: i128 = prev
             .checked_add(amount)
             .unwrap_or_else(|| fail(&env, EscrowError::InvestorContributionOverflow));
@@ -1560,20 +1704,17 @@ impl LiquifactEscrow {
         if simple_fund {
             if prev == 0 {
                 investor_effective_yield_bps = escrow.yield_bps;
-                env.storage().instance().set(
-                    &DataKey::InvestorEffectiveYield(investor.clone()),
-                    &escrow.yield_bps,
+                Self::set_persistent_investor_effective_yield(
+                    &env,
+                    investor.clone(),
+                    escrow.yield_bps,
                 );
-                env.storage()
-                    .instance()
-                    .set(&DataKey::InvestorClaimNotBefore(investor.clone()), &0u64);
+                Self::set_persistent_investor_claim_not_before(&env, investor.clone(), 0u64);
             } else {
                 // Returning investor: yield was set on first deposit; read it for the event.
-                investor_effective_yield_bps = env
-                    .storage()
-                    .instance()
-                    .get(&DataKey::InvestorEffectiveYield(investor.clone()))
-                    .unwrap_or(escrow.yield_bps);
+                investor_effective_yield_bps =
+                    Self::get_persistent_investor_effective_yield(&env, investor.clone())
+                        .unwrap_or(escrow.yield_bps);
             }
             // If prev > 0, preserve existing effective yield and claim lock
         } else {
@@ -1581,9 +1722,7 @@ impl LiquifactEscrow {
             let eff =
                 Self::effective_yield_for_commitment(&env, escrow.yield_bps, committed_lock_secs);
             investor_effective_yield_bps = eff;
-            env.storage()
-                .instance()
-                .set(&DataKey::InvestorEffectiveYield(investor.clone()), &eff);
+            Self::set_persistent_investor_effective_yield(&env, investor.clone(), eff);
             let now = env.ledger().timestamp();
             let claim_nb = if committed_lock_secs == 0 {
                 0u64
@@ -1591,10 +1730,7 @@ impl LiquifactEscrow {
                 now.checked_add(committed_lock_secs)
                     .unwrap_or_else(|| fail(&env, EscrowError::InvestorClaimTimeOverflow))
             };
-            env.storage().instance().set(
-                &DataKey::InvestorClaimNotBefore(investor.clone()),
-                &claim_nb,
-            );
+            Self::set_persistent_investor_claim_not_before(&env, investor.clone(), claim_nb);
         }
 
         escrow.funded_amount = escrow
@@ -1617,9 +1753,7 @@ impl LiquifactEscrow {
             }
         }
 
-        env.storage()
-            .instance()
-            .set(&contribution_key, &new_contribution);
+        Self::set_persistent_investor_contribution(&env, investor.clone(), new_contribution);
 
         if prev == 0 {
             // Use the hoisted cur_funder_count; no second storage read needed.
@@ -1765,11 +1899,7 @@ impl LiquifactEscrow {
 
         // Single fetch: consolidates the previous two reads of InvestorContribution.
         // Retains the participation guard without a redundant second storage access.
-        let contribution: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::InvestorContribution(investor.clone()))
-            .unwrap_or(0);
+        let contribution: i128 = Self::get_persistent_investor_contribution(&env, investor.clone());
         ensure(&env, contribution > 0, EscrowError::NoContributionToClaim);
 
         // env.clone(): env is used again after this call for storage reads, ledger timestamp, and publish.
@@ -1780,11 +1910,8 @@ impl LiquifactEscrow {
             EscrowError::InvestorClaimNotSettled,
         );
 
-        let not_before: u64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::InvestorClaimNotBefore(investor.clone()))
-            .unwrap_or(0);
+        let not_before: u64 =
+            Self::get_persistent_investor_claim_not_before(&env, investor.clone());
         let now = env.ledger().timestamp();
         ensure(
             &env,
@@ -1793,13 +1920,12 @@ impl LiquifactEscrow {
         );
 
         // Idempotent early-return: a second claim is a no-op (no re-emit).
-        let key = DataKey::InvestorClaimed(investor.clone());
-        if env.storage().instance().get(&key).unwrap_or(false) {
+        if Self::get_persistent_investor_claimed(&env, investor.clone()) {
             return;
         }
 
         // Mark before emit — prevents re-emission on any re-entrant path.
-        env.storage().instance().set(&key, &true);
+        Self::set_persistent_investor_claimed(&env, investor.clone(), true);
 
         InvestorPayoutClaimed {
             name: symbol_short!("inv_claim"),
@@ -1846,11 +1972,7 @@ impl LiquifactEscrow {
     /// None — pure read; no auth required.
     pub fn compute_investor_payout(env: Env, investor: Address) -> i128 {
         // Contribution fetch: returns 0 for non-participants without panicking.
-        let contribution: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::InvestorContribution(investor.clone()))
-            .unwrap_or(0);
+        let contribution: i128 = Self::get_persistent_investor_contribution(&env, investor.clone());
         if contribution == 0 {
             return 0;
         }
@@ -1872,11 +1994,9 @@ impl LiquifactEscrow {
         // Resolve effective yield: investor-specific tier (set at first deposit) or escrow base.
         // env.clone(): env is used again after this call for InvestorEffectiveYield read.
         let escrow = Self::get_escrow(env.clone());
-        let effective_yield_bps: i64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::InvestorEffectiveYield(investor.clone()))
-            .unwrap_or(escrow.yield_bps);
+        let effective_yield_bps: i64 =
+            Self::get_persistent_investor_effective_yield(&env, investor.clone())
+                .unwrap_or(escrow.yield_bps);
 
         // coupon = total_principal × effective_yield_bps / 10_000  (floor)
         let coupon = total_principal
@@ -1941,9 +2061,9 @@ impl LiquifactEscrow {
         );
 
         // Instance storage TTL is contract-wide under Soroban SDK 25. The call above covers
-        // Escrow, Version, LegalHold, snapshots, and all per-investor instance keys.
+        // Escrow, Version, LegalHold, snapshots, caps, and other instance keys.
 
-        // Persistent allowlist entries.
+        // Persistent per-investor keys and allowlist entries (independent TTL per address).
         for addr in allowlisted.iter() {
             let k = DataKey::InvestorAllowlisted(addr.clone());
             env.storage().persistent().extend_ttl(
@@ -1951,19 +2071,40 @@ impl LiquifactEscrow {
                 PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
                 PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
             );
+            // Extend persistent TTL for per-investor persistent keys used by this contract.
+            env.storage().persistent().extend_ttl(
+                &DataKey::InvestorContribution(addr.clone()),
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            );
+            env.storage().persistent().extend_ttl(
+                &DataKey::InvestorEffectiveYield(addr.clone()),
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            );
+            env.storage().persistent().extend_ttl(
+                &DataKey::InvestorClaimNotBefore(addr.clone()),
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            );
+            env.storage().persistent().extend_ttl(
+                &DataKey::InvestorClaimed(addr.clone()),
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            );
         }
     }
 
-    /// Transfer admin control to `new_admin`.
+    /// Propose a new admin (`PendingAdmin`) — step 1 of a two-step handover.
     ///
     /// Requires current admin authorization. The destination must differ from the current admin.
     ///
     /// # Errors
     /// Emits typed [`EscrowError`] codes when the escrow is uninitialized or `new_admin` is the
     /// current admin.
-    pub fn transfer_admin(env: Env, new_admin: Address) -> InvoiceEscrow {
+    pub fn propose_admin(env: Env, new_admin: Address) -> Address {
         // env.clone(): env is used again after this call for storage set and publish.
-        let mut escrow = Self::get_escrow(env.clone());
+        let escrow = Self::get_escrow(env.clone());
 
         escrow.admin.require_auth();
 
@@ -2076,12 +2217,11 @@ impl LiquifactEscrow {
         let escrow = Self::get_escrow(env.clone());
         ensure(&env, escrow.status == 4, EscrowError::RefundNotCancelled);
 
-        let contribution_key = DataKey::InvestorContribution(investor.clone());
-        let amount: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
+        let amount: i128 = Self::get_persistent_investor_contribution(&env, investor.clone());
         ensure(&env, amount > 0, EscrowError::NoContributionToRefund);
 
         // Zero out contribution before transfer (checks-effects-interactions).
-        env.storage().instance().set(&contribution_key, &0i128);
+        Self::set_persistent_investor_contribution(&env, investor.clone(), 0i128);
         env.storage()
             .instance()
             .set(&DataKey::InvestorRefunded(investor.clone()), &true);

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1528,13 +1528,11 @@ impl LiquifactEscrow {
     /// terminates with a typed contract error (aborts the Soroban transaction). This is intentional:
     /// it makes the "no migration" guarantee explicit rather than silently returning success.
     ///
-    /// **Execution order:** the function first reads [`DataKey::Version`] from instance
-    /// storage, validates the supplied `from_version`, then emits a typed error. No storage
-    /// writes ever occur; the storage read is read-only and side-effect-free. There is
-    /// **no [`Address::require_auth`] call** — any account may invoke `migrate`. This is
-    /// safe only because a typed error is reached on every code path and no state
-    /// is mutated. Adding migration logic without also adding an auth guard would make
-    /// this entrypoint callable by any account.
+    /// **Execution order:** the function first requires current admin authorization, then reads
+    /// [`DataKey::Version`] from instance storage, validates the supplied `from_version`, and emits
+    /// a typed error. No storage writes ever occur in the current release. The authorization guard
+    /// is intentionally placed before version checks so future migration logic remains admin-gated
+    /// by construction.
     ///
     /// Do **not** call `migrate` expecting it to perform bookkeeping work in the current
     /// release. To add a real migration path (e.g. rewriting a stored struct after a field
@@ -1551,6 +1549,8 @@ impl LiquifactEscrow {
     ///
     /// # Errors
     ///
+    /// Requires current admin authorization before any version checks or future storage rewrites.
+    ///
     /// | Condition | Typed error |
     /// |-----------|--------|
     /// | `stored_version != from_version` | [`EscrowError::MigrationVersionMismatch`] |
@@ -1560,6 +1560,8 @@ impl LiquifactEscrow {
     /// See `docs/OPERATOR_RUNBOOK.md` §2 for step-by-step instructions on implementing
     /// a concrete migration path.
     pub fn migrate(env: Env, from_version: u32) -> u32 {
+        Self::get_escrow(env.clone()).admin.require_auth();
+
         let stored: u32 = env.storage().instance().get(&DataKey::Version).unwrap_or(0);
 
         ensure(

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1569,14 +1569,14 @@ impl LiquifactEscrow {
         );
 
         if from_version >= SCHEMA_VERSION {
-            return fail(&env, EscrowError::AlreadyCurrentSchemaVersion);
+            fail(&env, EscrowError::AlreadyCurrentSchemaVersion)
+        } else {
+            // No migration path is implemented for any version below SCHEMA_VERSION.
+            // To add one: implement the transformation here, call
+            //   env.storage().instance().set(&DataKey::Version, &NEW_VERSION);
+            // and return NEW_VERSION before reaching this typed error.
+            fail(&env, EscrowError::NoMigrationPath)
         }
-
-        // No migration path is implemented for any version below SCHEMA_VERSION.
-        // To add one: implement the transformation here, call
-        //   env.storage().instance().set(&DataKey::Version, &NEW_VERSION);
-        // and return NEW_VERSION before reaching this typed error.
-        return fail(&env, EscrowError::NoMigrationPath);
     }
 
     /// Record investor principal while the invoice is **open**. First deposit sets base

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -594,6 +594,39 @@ fn test_sweep_terminal_dust_happy_path() {
 }
 
 #[test]
+fn test_bump_ttl_covers_persistent_investor_keys() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TTL001"),
+        &sme,
+        &100,
+        &10,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client.set_investor_allowlisted(&investor, &true);
+    client.fund(&investor, &100);
+    client.settle();
+    client.claim_investor_payout(&investor);
+
+    let mut investors = SorobanVec::new(&env);
+    investors.push_back(investor);
+    client.bump_ttl(&investors);
+}
+
+#[test]
 fn test_sweep_not_terminal() {
     let env = Env::default();
     env.mock_all_auths();

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -1,5 +1,5 @@
 use super::{free_addresses, setup};
-use crate::{DataKey, EscrowCloseSnapshot, YieldTier};
+use crate::{DataKey, EscrowCloseSnapshot, EscrowError, YieldTier};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     Address, Env, Error, InvokeError, Vec as SorobanVec,
@@ -430,7 +430,7 @@ fn test_all_getters() {
     assert_eq!(client.get_funding_token(), funding_token);
     assert_eq!(client.get_treasury(), treasury);
     assert_eq!(client.get_registry_ref(), Some(registry));
-    assert_eq!(client.get_version(), 5);
+    assert_eq!(client.get_version(), 6);
     assert!(!client.get_legal_hold());
     assert_eq!(client.get_min_contribution_floor(), 10);
     assert_eq!(client.get_max_unique_investors_cap(), Some(5));
@@ -594,7 +594,6 @@ fn test_sweep_terminal_dust_happy_path() {
 }
 
 #[test]
-#[should_panic(expected = "dust sweep only in terminal states (settled, withdrawn, or cancelled)")]
 fn test_sweep_not_terminal() {
     let env = Env::default();
     env.mock_all_auths();
@@ -616,7 +615,10 @@ fn test_sweep_not_terminal() {
         &None,
     );
 
-    client.sweep_terminal_dust(&10);
+    assert_contract_error(
+        client.try_sweep_terminal_dust(&10),
+        EscrowError::DustSweepNotTerminal,
+    );
 }
 
 #[test]
@@ -1374,7 +1376,7 @@ fn test_get_escrow_summary_happy_path() {
     assert_eq!(summary.funding_close_snapshot, EscrowCloseSnapshot::None);
     assert_eq!(summary.unique_funder_count, 0);
     assert!(!summary.is_allowlist_active);
-    assert_eq!(summary.schema_version, 5);
+    assert_eq!(summary.schema_version, 6);
 }
 
 #[test]

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -1,6 +1,27 @@
 use super::*;
+use soroban_sdk::{Error, InvokeError};
+use std::fmt::Debug;
 
 // Funding, contributions, snapshots, tier selection, and fund-shaped cost baselines.
+
+fn assert_contract_error<T, E>(
+    result: Result<Result<T, E>, Result<Error, InvokeError>>,
+    expected: EscrowError,
+) where
+    T: Debug,
+    E: Debug,
+{
+    let expected_code = expected as u32;
+    match result {
+        Err(Ok(error)) => {
+            assert_eq!(error, Error::from_contract_error(expected_code));
+        }
+        Err(Err(InvokeError::Contract(code))) => {
+            assert_eq!(code, expected_code);
+        }
+        other => panic!("expected ContractError({expected_code}), got {other:?}"),
+    }
+}
 
 #[test]
 fn test_fund_and_settle() {
@@ -277,6 +298,49 @@ fn test_fund_with_commitment_overflow_does_not_mutate_state() {
     assert_eq!(client.get_contribution(&investor_b), 0);
 }
 
+/// Regression for issue #253: per-investor accounting must live in persistent storage, not instance.
+#[test]
+fn test_per_investor_contribution_uses_persistent_storage() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "PERS01"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &500i128);
+
+    env.as_contract(&contract_id, || {
+        assert_eq!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, i128>(&DataKey::InvestorContribution(investor.clone())),
+            Some(500i128)
+        );
+        assert_eq!(
+            env.storage()
+                .instance()
+                .get::<DataKey, i128>(&DataKey::InvestorContribution(investor.clone())),
+            None
+        );
+    });
+}
+
 #[test]
 #[should_panic]
 fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
@@ -314,7 +378,7 @@ fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
     env.as_contract(&contract_id, || {
         // Force the contribution near i128::MAX while keeping funded_amount small.
         // `fund` must still trap on contribution overflow even if funded_amount would not.
-        env.storage().instance().set(
+        env.storage().persistent().set(
             &DataKey::InvestorContribution(investor.clone()),
             &(i128::MAX - 1),
         );
@@ -356,7 +420,7 @@ fn test_investor_contribution_overflow_does_not_mutate_state() {
     );
 
     env.as_contract(&contract_id, || {
-        env.storage().instance().set(
+        env.storage().persistent().set(
             &DataKey::InvestorContribution(investor.clone()),
             &(i128::MAX - 1),
         );
@@ -2226,10 +2290,9 @@ fn test_commitment_zero_lock_follow_on_fund_no_claim_gate() {
 }
 
 /// A second `fund_with_commitment` from the same investor (who already has a
-/// non-zero contribution) must panic with the documented error message, regardless
+/// non-zero contribution) must fail with the documented typed error, regardless
 /// of whether a tier table is configured.
 #[test]
-#[should_panic(expected = "Additional principal after a tiered first deposit")]
 fn test_second_fund_with_commitment_panics_without_tier_table() {
     let env = Env::default();
     env.mock_all_auths();
@@ -2258,14 +2321,16 @@ fn test_second_fund_with_commitment_panics_without_tier_table() {
 
     client.fund_with_commitment(&inv, &3_000i128, &0u64);
     // Second call must trap.
-    client.fund_with_commitment(&inv, &3_000i128, &0u64);
+    assert_contract_error(
+        client.try_fund_with_commitment(&inv, &3_000i128, &0u64),
+        EscrowError::TieredSecondDeposit,
+    );
 }
 
 /// After a plain `fund()` first deposit, calling `fund_with_commitment` on the same
 /// investor must panic — the tier/lock selection window is permanently closed.
 /// This is the "inverse" direction of the state-machine rule.
 #[test]
-#[should_panic(expected = "Additional principal after a tiered first deposit")]
 fn test_fund_first_then_commitment_second_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -2300,7 +2365,10 @@ fn test_fund_first_then_commitment_second_panics() {
     // First leg via fund() → establishes base-yield position.
     client.fund(&inv, &3_000i128);
     // Attempt to re-select tier via fund_with_commitment → must panic.
-    client.fund_with_commitment(&inv, &3_000i128, &100u64);
+    assert_contract_error(
+        client.try_fund_with_commitment(&inv, &3_000i128, &100u64),
+        EscrowError::TieredSecondDeposit,
+    );
 }
 
 /// Verify that a plain `fund()` as first deposit sets the effective yield to the

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -83,6 +83,29 @@ fn test_init_requires_admin_auth() {
 }
 
 #[test]
+fn test_migrate_requires_admin_auth_before_version_checks() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    env.mock_auths(&[]);
+    let result = client.try_migrate(&99u32);
+
+    assert!(
+        result.is_err(),
+        "migrate should reject an unauthenticated call"
+    );
+    assert!(
+        !matches!(
+            result,
+            Err(Err(soroban_sdk::InvokeError::Contract(code)))
+                if code == EscrowError::MigrationVersionMismatch as u32
+        ),
+        "migrate reached version checks before admin auth"
+    );
+}
+
+#[test]
 fn test_init_unauthorized_panics() {
     let env = Env::default();
     let client = deploy(&env);


### PR DESCRIPTION
closes #274 
## Summary

- Expand the operator runbook with a concrete redeploy-vs-upgrade decision tree.
- Classify schema transitions from the `SCHEMA_VERSION` changelog as additive, conditional, or redeploy-required.
- Document the current `migrate()` panic policy and align it with the typed errors in the rustdoc.
- Add guidance for implementing a future real migration path, including admin auth, `SCHEMA_VERSION`, and `DataKey::Version`.

## Validation
- Ran `cargo test`
- Result: 394 passed, 0 failed, 11 ignored; doc-tests passed

## Security Notes

- Documentation-only change; no runtime contract logic changed.
- Future migration guidance keeps admin auth before version checks and storage writes.
- Guidance requires checked arithmetic, bounded writes, and writing `DataKey::Version` last.
- Runbook states redeploy is mandatory when existing stored XDR shapes cannot be safely decoded by the new WASM.
```
