### PR TITLE
Document tiered yield worked examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ See [`docs/escrow-sme-collateral.md`](docs/escrow-sme-collateral.md) for the ris
   equality checks.
 - **Tiered yield / claim locks:** first-deposit discipline prevents changing
   an investor's tier after their initial leg; claim timestamps are ledger-based.
+  See [`docs/adr/ADR-005-tiered-yield.md`](docs/adr/ADR-005-tiered-yield.md)
+  for tier-selection and claim-lock worked examples.
 - **Funding snapshot:** single-write immutability avoids shifting pro-rata
   denominators after close.
 - **Registry ref:** stored for discoverability only; must not be used as

--- a/docs/adr/ADR-005-tiered-yield.md
+++ b/docs/adr/ADR-005-tiered-yield.md
@@ -34,6 +34,96 @@ Some invoice products offer higher yield to investors who commit to a longer loc
 - If no tier table is set, `fund_with_commitment` with `committed_lock_secs == 0` behaves identically to `fund`.
 - Yield values are integer basis points only; fractional coupon math belongs off-chain.
 
+## Worked Examples
+
+Assume an escrow is initialized with `yield_bps = 500` (5%) and this tier table:
+
+| Tier | `min_lock_secs` | `yield_bps` | Meaning |
+|---:|---:|---:|---|
+| 1 | `2_592_000` | `650` | 30-day commitment earns 6.5% |
+| 2 | `7_776_000` | `800` | 90-day commitment earns 8.0% |
+| 3 | `15_552_000` | `950` | 180-day commitment earns 9.5% |
+
+### Tier-table validation
+
+The table is accepted because:
+
+- every tier yield is in `0..=10_000`;
+- every tier yield is `>= base yield_bps` (`500`);
+- `min_lock_secs` strictly increases (`30d < 90d < 180d`);
+- `yield_bps` is non-decreasing (`650 <= 800 <= 950`).
+
+Rejected examples:
+
+| Invalid table fragment | Rejection |
+|---|---|
+| `[{ min_lock_secs: 2_592_000, yield_bps: 400 }]` | `TierYieldBelowBase` because `400 < base 500` |
+| `[{ min_lock_secs: 2_592_000, yield_bps: 650 }, { min_lock_secs: 2_592_000, yield_bps: 800 }]` | `TierLockNotIncreasing` because lock thresholds must be strictly increasing |
+| `[{ min_lock_secs: 2_592_000, yield_bps: 800 }, { min_lock_secs: 7_776_000, yield_bps: 700 }]` | `TierYieldNotNonDecreasing` because later tiers must not reduce yield |
+
+### First deposit selects the effective yield
+
+At ledger timestamp `1_710_000_000`, an investor calls:
+
+```text
+fund_with_commitment(investor, 1_000_000_000, 7_776_000)
+```
+
+The commitment is 90 days, so `effective_yield_for_commitment` selects tier 2:
+
+| Stored key | Stored value |
+|---|---:|
+| `InvestorEffectiveYield(investor)` | `800` |
+| `InvestorClaimNotBefore(investor)` | `1_717_776_000` |
+
+The emitted `EscrowFunded` event includes:
+
+| Field | Value |
+|---|---:|
+| `investor_effective_yield_bps` | `800` |
+| `tier_lock_secs` | `7_776_000` |
+
+### Commitments between thresholds
+
+If the same tier table receives `committed_lock_secs = 5_184_000` (60 days), the
+best matching threshold is the 30-day tier, not the 90-day tier:
+
+| Input commitment | Matched `tier_lock_secs` | Effective yield |
+|---:|---:|---:|
+| `0` | `0` | `500` |
+| `2_592_000` | `2_592_000` | `650` |
+| `5_184_000` | `2_592_000` | `650` |
+| `7_776_000` | `7_776_000` | `800` |
+| `15_552_000` | `15_552_000` | `950` |
+
+### Follow-on principal must use `fund`
+
+After a first `fund_with_commitment`, a second `fund_with_commitment` from the
+same investor is rejected with `TieredSecondDeposit`. The investor may add
+principal only through `fund`, which preserves the stored effective yield and
+claim lock.
+
+Example:
+
+1. First call: `fund_with_commitment(investor, 1_000_000_000, 7_776_000)` stores
+   `InvestorEffectiveYield = 800` and `InvestorClaimNotBefore = 1_717_776_000`.
+2. Follow-on call: `fund(investor, 250_000_000)` increases contribution but
+   keeps the same `InvestorEffectiveYield` and `InvestorClaimNotBefore`.
+3. Invalid call: `fund_with_commitment(investor, 250_000_000, 15_552_000)` is
+   rejected; the investor cannot upgrade to the 180-day tier after the first leg.
+
+### Claim lock enforcement
+
+`claim_investor_payout` compares the current ledger timestamp against
+`InvestorClaimNotBefore`.
+
+| Ledger timestamp | Result |
+|---:|---|
+| `1_717_775_999` | rejected with `InvestorCommitmentLockNotExpired` |
+| `1_717_776_000` | allowed if the escrow is settled and the investor has contribution |
+
+The comparison is inclusive: `now >= InvestorClaimNotBefore` is sufficient.
+
 ## Rejected alternatives
 
 - **Mutable tier selection:** allows gaming; immutability after first deposit is the fairness guarantee.
@@ -55,4 +145,3 @@ The state-machine rules above are verified in `escrow/src/tests/funding.rs`:
 | `test_fund_with_commitment_zero_lock_behaves_as_fund` | `committed_lock_secs == 0` → base yield, `InvestorClaimNotBefore == 0` |
 | `test_commitment_zero_lock_follow_on_fund_no_claim_gate` | Follow-on `fund()` after zero-lock preserves both zero guards |
 | `test_fund_first_deposit_sets_base_yield_and_no_claim_gate` | Plain `fund()` first deposit → base yield, no claim gate |
-

--- a/docs/escrow-numeric-model.md
+++ b/docs/escrow-numeric-model.md
@@ -19,10 +19,42 @@ This contract uses Soroban host values and Rust integer types directly. It does 
 - A zero commitment stores `0`, meaning no additional investor claim-time gate.
 - Boundary values are inclusive: a timestamp plus commitment that equals `u64::MAX` is representable; only values above `u64::MAX` fail.
 
+### Tiered-yield examples
+
+Tiered yield uses integer basis points. A base yield of `500` means 5%, and a
+tier yield of `800` means 8%. The contract stores the selected yield in
+`InvestorEffectiveYield(Address)` on the investor's first deposit.
+
+With this tier table:
+
+| `min_lock_secs` | `yield_bps` |
+|---:|---:|
+| `2_592_000` | `650` |
+| `7_776_000` | `800` |
+| `15_552_000` | `950` |
+
+and base `yield_bps = 500`, the selection rules are:
+
+| `committed_lock_secs` | Stored effective yield | Stored claim lock |
+|---:|---:|---|
+| `0` | `500` | `0` |
+| `2_592_000` | `650` | `ledger.timestamp() + 2_592_000` |
+| `5_184_000` | `650` | `ledger.timestamp() + 5_184_000` |
+| `7_776_000` | `800` | `ledger.timestamp() + 7_776_000` |
+| `15_552_000` | `950` | `ledger.timestamp() + 15_552_000` |
+
+`tier_lock_secs` in `EscrowFunded` records the matched tier threshold, while
+`InvestorClaimNotBefore` records the full investor commitment duration. A
+60-day commitment can therefore emit `tier_lock_secs = 2_592_000` while storing
+`InvestorClaimNotBefore = now + 5_184_000`.
+
+Follow-on principal uses `fund()` and does not recalculate these values.
+
 ## Integration Guidance
 
 - Off-chain callers should validate amount and lock-duration inputs before submitting transactions, especially when simulating near integer limits.
 - Risk and accounting systems should use integer arithmetic for base-unit amounts and rational math for pro-rata ratios; avoid floating-point rounding when reconciling on-chain state.
 - Maturity and claim-lock checks are ledger-time checks, not wall-clock oracle checks.
+- UI and SDK code should display both the matched tier threshold and the full
+  commitment unlock timestamp when they differ.
 - Unsupported token economics remain out of scope. Fee-on-transfer, rebasing, malicious, or callback-heavy tokens are covered separately in [`escrow/src/external_calls.rs`](../escrow/src/external_calls.rs) and [`ESCROW_TOKEN_INTEGRATION_CHECKLIST.md`](ESCROW_TOKEN_INTEGRATION_CHECKLIST.md).
-


### PR DESCRIPTION
## Summary
- adds worked examples for tier-table validation, tier selection, follow-on funding discipline, and claim-lock enforcement
- expands the numeric model with basis-point and commitment-lock examples
- links the examples from the README security notes

Closes #333

## Testing
- documentation-only change
- verified raw branch content for README.md, docs/adr/ADR-005-tiered-yield.md, and docs/escrow-numeric-model.md
- verified compare contains only the three intended documentation files
