### PR TITLE
fix(escrow): replace admin and allowlist panics with typed errors

### DIFF
--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -86,6 +86,7 @@ Legacy panic messages are listed only to help integrators migrate old simulation
 | 141 | `CancelFundingNotOpen` | `cancel_funding only allowed in Open state` |
 | 142 | `RefundNotCancelled` | `refund only allowed in Cancelled state` |
 | 143 | `NoContributionToRefund` | `no contribution to refund` |
+| 163 | `NoPendingAdmin` | `No pending admin` |
 
 ## Client Guidance
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -274,6 +274,9 @@ pub enum EscrowError {
     RotationNotOpen = 161,
     /// The proposed new SME address is identical to the current beneficiary.
     NewSmeSameAsCurrent = 162,
+
+    /// Attempted to accept admin role when no pending admin exists.
+    NoPendingAdmin = 163,
 }
 
 #[inline(always)]
@@ -1704,10 +1707,11 @@ impl LiquifactEscrow {
         let escrow = Self::load_escrow_require_admin(&env);
 
         let n = investors.len();
-        assert!(n > 0, "investors vector must be non-empty");
-        assert!(
+        ensure(&env, n > 0, EscrowError::InvestorBatchEmpty);
+        ensure(
+            &env,
             n <= MAX_INVESTOR_ALLOWLIST_BATCH,
-            "investors vector length exceeds MAX_INVESTOR_ALLOWLIST_BATCH"
+            EscrowError::InvestorBatchTooLarge,
         );
 
         // Iterate and perform per-address persistent storage write and event emission.
@@ -1780,22 +1784,25 @@ impl LiquifactEscrow {
     pub fn lower_max_unique_investors(env: Env, new_cap: u32) -> u32 {
         let escrow = Self::load_escrow_require_admin(&env);
 
-        assert!(escrow.status == 0, "Cap can only be lowered in Open state");
+        ensure(&env, escrow.status == 0, EscrowError::CapLowerNotOpen);
 
-        let old_cap: u32 = env
+        let old_cap: Option<u32> = env
             .storage()
             .instance()
-            .get(&DataKey::MaxUniqueInvestorsCap)
-            .unwrap_or_else(|| panic!("no investor cap configured"));
+            .get(&DataKey::MaxUniqueInvestorsCap);
+        ensure(
+            &env,
+            old_cap.is_some(),
+            EscrowError::NoInvestorCapConfigured,
+        );
+        let old_cap = old_cap.unwrap();
         let unique_count = Self::get_unique_funder_count(env.clone());
 
-        assert!(
-            new_cap < old_cap,
-            "new cap must be strictly lower than current cap"
-        );
-        assert!(
+        ensure(&env, new_cap < old_cap, EscrowError::NewCapNotLower);
+        ensure(
+            &env,
             new_cap >= unique_count,
-            "new cap cannot be below current unique funder count"
+            EscrowError::NewCapBelowCurrentFunderCount,
         );
 
         env.storage()
@@ -2474,11 +2481,9 @@ impl LiquifactEscrow {
     /// promoted into [`InvoiceEscrow::admin`] and the pending key is cleared, so admin authority
     /// changes only after both the current admin and successor have explicitly authorized.
     pub fn accept_admin(env: Env) -> InvoiceEscrow {
-        let pending: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::PendingAdmin)
-            .unwrap_or_else(|| panic!("No pending admin"));
+        let pending: Option<Address> = env.storage().instance().get(&DataKey::PendingAdmin);
+        ensure(&env, pending.is_some(), EscrowError::NoPendingAdmin);
+        let pending = pending.unwrap();
         pending.require_auth();
 
         let mut escrow = Self::get_escrow(env.clone());

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -203,7 +203,7 @@ fn test_transfer_admin_uninitialized_panics() {
 }
 
 #[test]
-#[should_panic(expected = "No pending admin")]
+#[should_panic]
 fn test_accept_admin_without_pending_panics() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -370,19 +370,7 @@ fn test_init_invoice_id_embedded_null_panics() {
     let s = soroban_sdk::String::from_bytes(&env, &bytes[..]);
 
     client.init(
-        &admin,
-        &s,
-        &sme,
-        &1000i128,
-        &500i64,
-        &0u64,
-        &t,
-        &None,
-        &tr,
-        &None,
-        &None,
-        &None,
-        &None,
+        &admin, &s, &sme, &1000i128, &500i64, &0u64, &t, &None, &tr, &None, &None, &None, &None,
         &None,
     );
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -387,7 +387,6 @@ fn settle_blocked_by_legal_hold() {
     client.settle();
 }
 
-
 #[test]
 #[should_panic]
 fn test_claim_blocked_until_commitment_ledger_time() {
@@ -1056,7 +1055,9 @@ fn test_sweep_requires_treasury_auth() {
     );
     fund_to_target(&client, &env);
     client.settle();
-    token.stellar.mint(&contract_id, &(MAX_DUST_SWEEP_AMOUNT + 1));
+    token
+        .stellar
+        .mint(&contract_id, &(MAX_DUST_SWEEP_AMOUNT + 1));
 
     client.sweep_terminal_dust(&(MAX_DUST_SWEEP_AMOUNT + 1));
 }
@@ -1516,7 +1517,10 @@ fn test_partial_settle_sme_happy_path() {
     client.partial_settle(&sme);
 
     let escrow = client.get_escrow();
-    assert_eq!(escrow.status, 1u32, "Status must be 1 (funded/settleable) after partial_settle");
+    assert_eq!(
+        escrow.status, 1u32,
+        "Status must be 1 (funded/settleable) after partial_settle"
+    );
     assert_eq!(escrow.funded_amount, TARGET / 2);
 }
 
@@ -1579,7 +1583,9 @@ fn test_partial_settle_writes_correct_snapshot() {
 
     client.partial_settle(&sme);
 
-    let snapshot = client.get_funding_close_snapshot().expect("Snapshot must exist");
+    let snapshot = client
+        .get_funding_close_snapshot()
+        .expect("Snapshot must exist");
     assert_eq!(snapshot.total_principal, amount);
     assert_eq!(snapshot.funding_target, TARGET);
 }


### PR DESCRIPTION
Closes #320

Implemented and submitted for review.

PR #361:
https://github.com/Liquifact/Liquifact-contracts/pull/361

All targeted panic-string and assert-based failures were migrated to typed EscrowError variants while preserving existing behavior.

Changes include:

* Added `NoPendingAdmin = 163`
* Replaced panic-string failures with typed `EscrowError` variants
* Replaced admin cap validation asserts with typed errors
* Replaced allowlist batch validation asserts with typed errors
* Updated tests and error documentation

Note: repository CI currently fails on upstream/main due to pre-existing test-suite issues unrelated to this change. These failures were reproduced on a clean checkout of upstream/main before submitting the PR.
