### PR TITLE
fix: bound commitment lock to settlement maturity in fund_with_commitment

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -243,6 +243,10 @@ pub enum EscrowError {
     TieredSecondDeposit = 108,
     InvestorClaimTimeOverflow = 109,
     FundedAmountOverflow = 110,
+    /// Commitment lock would push `now + committed_lock_secs` past the escrow maturity.
+    /// Reject at deposit time so a settled escrow cannot hold an investor's payout
+    /// claim hostage beyond the point where principal is due.
+    CommitmentLockExceedsMaturity = 111,
 
     LegalHoldBlocksSettlement = 120,
     SettlementNotFunded = 121,
@@ -2032,6 +2036,15 @@ impl LiquifactEscrow {
                 now.checked_add(committed_lock_secs)
                     .unwrap_or_else(|| fail(&env, EscrowError::InvestorClaimTimeOverflow))
             };
+            // Bound: reject if the claim lock would expire after the escrow maturity.
+            // Only constrained when both committed_lock_secs > 0 and maturity > 0.
+            if claim_nb > 0 && escrow.maturity > 0 {
+                ensure(
+                    &env,
+                    claim_nb <= escrow.maturity,
+                    EscrowError::CommitmentLockExceedsMaturity,
+                );
+            }
             Self::set_persistent_investor_claim_not_before(&env, investor.clone(), claim_nb);
         }
 

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -8,7 +8,7 @@
 )]
 #[allow(unused_imports)]
 use super::{
-    AttestationDigestRevoked, DataKey, EscrowFunded, FundingTargetUpdated, LiquifactEscrow,
+    AttestationDigestRevoked, DataKey, EscrowError, EscrowFunded, FundingTargetUpdated, LiquifactEscrow,
     LiquifactEscrowClient, YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT,
     SCHEMA_VERSION,
 };

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -2661,3 +2661,164 @@ fn test_fund_first_deposit_sets_base_yield_and_no_claim_gate() {
         "fund() must not impose a claim gate"
     );
 }
+
+// ── CommitmentLockExceedsMaturity bound ──────────────────────────────────────
+
+// Helper: init an escrow with a specific maturity timestamp.
+fn init_with_maturity(
+    env: &Env,
+    client: &crate::LiquifactEscrowClient<'_>,
+    admin: &soroban_sdk::Address,
+    sme: &soroban_sdk::Address,
+    maturity: u64,
+) {
+    let (token, treasury) = free_addresses(env);
+    client.init(
+        admin,
+        &soroban_sdk::String::from_str(env, "LOCK1"),
+        sme,
+        &10_000i128,
+        &800i64,
+        &maturity,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+}
+
+#[test]
+fn commitment_lock_within_maturity_is_accepted() {
+    // now=1000, maturity=2000, lock=500 → claim_nb=1500 ≤ 2000  ✓
+    let env = Env::default();
+    env.mock_all_auths();
+    let mut li = env.ledger().get();
+    li.timestamp = 1000;
+    env.ledger().set(li);
+    let (client, admin, sme) = setup(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+    init_with_maturity(&env, &client, &admin, &sme, 2000);
+    let escrow = client.fund_with_commitment(&investor, &1_000i128, &500u64);
+    assert_eq!(escrow.status, 0);
+    assert_eq!(client.get_investor_claim_not_before(&investor), 1500u64);
+}
+
+#[test]
+fn commitment_lock_exactly_at_maturity_is_accepted() {
+    // now=1000, maturity=2000, lock=1000 → claim_nb=2000 == maturity  ✓ (inclusive)
+    let env = Env::default();
+    env.mock_all_auths();
+    let mut li = env.ledger().get();
+    li.timestamp = 1000;
+    env.ledger().set(li);
+    let (client, admin, sme) = setup(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+    init_with_maturity(&env, &client, &admin, &sme, 2000);
+    let escrow = client.fund_with_commitment(&investor, &1_000i128, &1000u64);
+    assert_eq!(escrow.status, 0);
+    assert_eq!(client.get_investor_claim_not_before(&investor), 2000u64);
+}
+
+#[test]
+fn commitment_lock_one_second_past_maturity_is_rejected() {
+    // now=1000, maturity=2000, lock=1001 → claim_nb=2001 > 2000  ✗
+    let env = Env::default();
+    env.mock_all_auths();
+    let mut li = env.ledger().get();
+    li.timestamp = 1000;
+    env.ledger().set(li);
+    let (client, admin, sme) = setup(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+    init_with_maturity(&env, &client, &admin, &sme, 2000);
+    assert_contract_error(
+        client.try_fund_with_commitment(&investor, &1_000i128, &1001u64),
+        EscrowError::CommitmentLockExceedsMaturity,
+    );
+}
+
+#[test]
+fn commitment_lock_far_past_maturity_is_rejected() {
+    // now=1000, maturity=2000, lock=5000 → claim_nb=6000 >> 2000  ✗
+    let env = Env::default();
+    env.mock_all_auths();
+    let mut li = env.ledger().get();
+    li.timestamp = 1000;
+    env.ledger().set(li);
+    let (client, admin, sme) = setup(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+    init_with_maturity(&env, &client, &admin, &sme, 2000);
+    assert_contract_error(
+        client.try_fund_with_commitment(&investor, &1_000i128, &5000u64),
+        EscrowError::CommitmentLockExceedsMaturity,
+    );
+}
+
+#[test]
+fn zero_lock_with_maturity_is_always_accepted() {
+    // committed_lock_secs==0 → claim_nb=0, no maturity bound applied
+    let env = Env::default();
+    env.mock_all_auths();
+    let mut li = env.ledger().get();
+    li.timestamp = 1000;
+    env.ledger().set(li);
+    let (client, admin, sme) = setup(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+    init_with_maturity(&env, &client, &admin, &sme, 2000);
+    let escrow = client.fund_with_commitment(&investor, &1_000i128, &0u64);
+    assert_eq!(escrow.status, 0);
+    assert_eq!(client.get_investor_claim_not_before(&investor), 0u64);
+}
+
+#[test]
+fn lock_with_zero_maturity_is_always_accepted() {
+    // maturity==0 means no maturity lock; any lock_secs is fine
+    let env = Env::default();
+    env.mock_all_auths();
+    let mut li = env.ledger().get();
+    li.timestamp = 1000;
+    env.ledger().set(li);
+    let (client, admin, sme) = setup(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+    // maturity = 0 → no bound applied even for a huge lock
+    let (token, treasury) = free_addresses(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "LOCK2"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64, // no maturity
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let escrow = client.fund_with_commitment(&investor, &1_000i128, &9999u64);
+    assert_eq!(escrow.status, 0);
+    assert_eq!(client.get_investor_claim_not_before(&investor), 10999u64);
+}
+
+#[test]
+fn plain_fund_with_maturity_ignores_lock_bound() {
+    // fund() (simple_fund=true) never sets a claim lock; bound is irrelevant
+    let env = Env::default();
+    env.mock_all_auths();
+    let mut li = env.ledger().get();
+    li.timestamp = 1000;
+    env.ledger().set(li);
+    let (client, admin, sme) = setup(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+    init_with_maturity(&env, &client, &admin, &sme, 2000);
+    // fund() should succeed regardless of maturity; it never imposes a lock
+    let escrow = client.fund(&investor, &1_000i128);
+    assert_eq!(escrow.status, 0);
+    assert_eq!(client.get_investor_claim_not_before(&investor), 0u64);
+}


### PR DESCRIPTION
## Summary

Closes #356. Rejects at deposit time any `fund_with_commitment` call whose `committed_lock_secs` would push `InvestorClaimNotBefore` past the escrow's `maturity`. A settled escrow (status 2) can no longer hold an investor's payout claim hostage beyond the point where principal is due.

## Changes

### `escrow/src/lib.rs`

**New error variant** (append-only, discriminant 111):
```rust
/// Commitment lock would push `now + committed_lock_secs` past the escrow maturity.
CommitmentLockExceedsMaturity = 111,
```

**Bound check** added inside the tiered branch of `fund_impl`, immediately after the existing `InvestorClaimTimeOverflow` overflow guard and before `set_persistent_investor_claim_not_before`:
```rust
if claim_nb > 0 && escrow.maturity > 0 {
    ensure(
        &env,
        claim_nb <= escrow.maturity,
        EscrowError::CommitmentLockExceedsMaturity,
    );
}
```

The guard fires only when **both** `committed_lock_secs > 0` **and** `maturity > 0`.  
- `committed_lock_secs == 0` → `claim_nb = 0`, guard skipped, no-lock semantics preserved.  
- `maturity == 0` → no maturity lock configured, guard skipped, existing behavior preserved.  
- Inclusive bound (`<=`): a lock that expires exactly at maturity is accepted.

### `escrow/src/tests/funding.rs`

Seven new tests under a dedicated section:

| Test | Scenario |
|---|---|
| `commitment_lock_within_maturity_is_accepted` | now=1000, mat=2000, lock=500 → claim_nb=1500 ✓ |
| `commitment_lock_exactly_at_maturity_is_accepted` | lock=1000 → claim_nb=2000 == maturity ✓ (inclusive) |
| `commitment_lock_one_second_past_maturity_is_rejected` | lock=1001 → claim_nb=2001 > 2000 ✗ |
| `commitment_lock_far_past_maturity_is_rejected` | lock=5000 → claim_nb=6000 >> 2000 ✗ |
| `zero_lock_with_maturity_is_always_accepted` | lock=0 → no gate, zero-lock semantics unchanged |
| `lock_with_zero_maturity_is_always_accepted` | maturity=0 → no bound, huge lock accepted |
| `plain_fund_with_maturity_ignores_lock_bound` | `fund()` never imposes a claim gate, unaffected |

### `escrow/src/tests.rs`

Added `EscrowError` to the `use super::{}` import block — this was a pre-existing omission causing the `assert_contract_error` helper in `funding.rs` to fail to compile. Fixing it is a prerequisite for the typed-error tests above.

## Security notes

- No payout can be locked beyond maturity: the check fires at deposit time before any state is written, so a rejected call leaves escrow state fully unchanged.
- Discriminant 111 is unused in the current enum and does not collide with any existing variant.
- The existing `InvestorClaimTimeOverflow = 109` overflow guard is preserved and runs first.