### PR TITLE
test: add dual-auth and guard tests for rotate_beneficiary

### DIFF
--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -1327,3 +1327,179 @@ fn auth_audit_sweep_terminal_dust_requires_treasury() {
     env.mock_auths(&[]);
     client.sweep_terminal_dust(&100i128);
 }
+
+// --- rotate_beneficiary tests ---
+
+#[test]
+fn test_rotate_beneficiary_success_dual_auth() {
+    use soroban_sdk::testutils::Events as _;
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_sme = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    let contract_id = client.address.clone();
+    
+    let updated = client.rotate_beneficiary(&new_sme);
+    assert_eq!(updated.sme_address, new_sme);
+    assert_eq!(client.get_escrow().sme_address, new_sme);
+    
+    assert_eq!(
+        env.events().all().events().last().unwrap().clone(),
+        crate::BeneficiaryRotated {
+            name: symbol_short!("ben_rot"),
+            invoice_id: client.get_escrow().invoice_id,
+            prior_sme: sme,
+            new_sme,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_rotate_beneficiary_only_sme_auth_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_sme = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    env.mock_auths(&[&sme]); // Only SME auth
+    client.rotate_beneficiary(&new_sme);
+}
+
+#[test]
+#[should_panic]
+fn test_rotate_beneficiary_only_admin_auth_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_sme = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    env.mock_auths(&[&admin]); // Only admin auth
+    client.rotate_beneficiary(&new_sme);
+}
+
+#[test]
+#[should_panic]
+fn test_rotate_beneficiary_no_auth_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_sme = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    env.mock_auths(&[]); // No auth
+    client.rotate_beneficiary(&new_sme);
+}
+
+#[test]
+#[should_panic]
+fn test_rotate_beneficiary_new_same_as_current_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.rotate_beneficiary(&sme);
+}
+
+#[test]
+#[should_panic]
+fn test_rotate_beneficiary_in_settled_state_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.fund(&investor, &TARGET);
+    client.settle(); // status 2
+    client.rotate_beneficiary(&new_sme);
+}
+
+#[test]
+#[should_panic]
+fn test_rotate_beneficiary_in_withdrawn_state_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.fund(&investor, &TARGET);
+    client.withdraw(); // status 3
+    client.rotate_beneficiary(&new_sme);
+}
+
+#[test]
+#[should_panic]
+fn test_rotate_beneficiary_in_cancelled_state_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.fund(&investor, &TARGET);
+    client.cancel_funding(); // status 4
+    client.rotate_beneficiary(&new_sme);
+}
+
+#[test]
+#[should_panic]
+fn test_rotate_beneficiary_with_legal_hold_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_sme = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.set_legal_hold(&true);
+    client.rotate_beneficiary(&new_sme);
+}
+
+#[test]
+fn test_rotate_beneficiary_in_funded_state_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.fund(&investor, &TARGET); // status 1
+    let updated = client.rotate_beneficiary(&new_sme);
+    assert_eq!(updated.sme_address, new_sme);
+}
+
+#[test]
+fn test_rotate_beneficiary_then_withdraw_goes_to_new_sme() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let token = install_stellar_asset_token(&env);
+    let treasury = Address::generate(&env);
+    let escrow_id = deploy_id(&env);
+    let client = LiquifactEscrowClient::new(&env, &escrow_id);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "WDTST"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    token.stellar.mint(&investor, &TARGET);
+    token.stellar.approve(&investor, &escrow_id, &TARGET);
+    client.fund(&investor, &TARGET);
+    client.rotate_beneficiary(&new_sme);
+    client.withdraw();
+    assert_eq!(token.stellar.balance(&new_sme), TARGET);
+}


### PR DESCRIPTION
test: add dual-auth and guard tests for rotate_beneficiary

This PR adds a comprehensive test suite for rotate_beneficiary covering:
- Successful rotation with dual SME/admin auth
- Failure cases with only SME, only admin, or no auth
- Guards: no-op rotation (same address), state gate (only open/funded states allowed), legal hold gate
- Event emission with correct prior/new SME addresses
- Post-rotation withdraw goes to new SME address

closes #353