### PR TITLE
refactor: centralize funding-token and treasury storage reads behind …

### DIFF
--- a/docs/escrow-data-model.md
+++ b/docs/escrow-data-model.md
@@ -202,6 +202,24 @@ test plan.
 
 ---
 
+## Private typed accessors
+
+Two private helpers centralise storage reads for immutable addresses, ensuring consistent
+error codes across all entrypoints:
+
+| Accessor | Key read | Error on absence |
+|----------|----------|-----------------|
+| `funding_token_or_fail(&env)` | `DataKey::FundingToken` | [`EscrowError::FundingTokenNotSet`] (code 21) |
+| `treasury_or_fail(&env)` | `DataKey::Treasury` | [`EscrowError::TreasuryNotSet`] (code 22) |
+
+Both are defined as `fn(&Env) -> Address` inside `impl LiquifactEscrow` (not public
+entrypoints). They panic with the typed error listed above when called before `init`.
+The public getters `get_funding_token` and `get_treasury` delegate to them; internal
+callers (`sweep_terminal_dust`, `refund`) also use them instead of inlining the
+`.get().unwrap_or_else(|| fail(...))` pattern.
+
+---
+
 ## Security notes
 
 - **Token economics:** `external_calls::transfer_funding_token_with_balance_checks` asserts exact

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -846,6 +846,24 @@ impl LiquifactEscrow {
             .unwrap_or(false)
     }
 
+    /// Read the immutable funding token address, failing with [`EscrowError::FundingTokenNotSet`]
+    /// when the escrow has not been initialized.
+    fn funding_token_or_fail(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::FundingToken)
+            .unwrap_or_else(|| fail(env, EscrowError::FundingTokenNotSet))
+    }
+
+    /// Read the immutable treasury address, failing with [`EscrowError::TreasuryNotSet`]
+    /// when the escrow has not been initialized.
+    fn treasury_or_fail(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Treasury)
+            .unwrap_or_else(|| fail(env, EscrowError::TreasuryNotSet))
+    }
+
     fn validate_yield_tiers_table(env: &Env, tiers: &Option<Vec<YieldTier>>, base_yield: i64) {
         let Some(tiers) = tiers else {
             return;
@@ -1062,10 +1080,7 @@ impl LiquifactEscrow {
     /// **Immutable:** set once at init; cannot change after deploy. Emits
     /// [`EscrowError::FundingTokenNotSet`] if called before init.
     pub fn get_funding_token(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get(&DataKey::FundingToken)
-            .unwrap_or_else(|| fail(&env, EscrowError::FundingTokenNotSet))
+        Self::funding_token_or_fail(&env)
     }
 
     /// Returns the protocol treasury address bound at [`LiquifactEscrow::init`] ([`DataKey::Treasury`]).
@@ -1074,10 +1089,7 @@ impl LiquifactEscrow {
     /// recipient of [`LiquifactEscrow::sweep_terminal_dust`]. Emits
     /// [`EscrowError::TreasuryNotSet`] if called before init.
     pub fn get_treasury(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get(&DataKey::Treasury)
-            .unwrap_or_else(|| fail(&env, EscrowError::TreasuryNotSet))
+        Self::treasury_or_fail(&env)
     }
 
     /// Returns the optional off-chain registry hint stored at [`DataKey::RegistryRef`], or [`None`]
@@ -1162,18 +1174,10 @@ impl LiquifactEscrow {
             EscrowError::DustSweepNotTerminal,
         );
 
-        let treasury: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Treasury)
-            .unwrap_or_else(|| fail(&env, EscrowError::TreasuryNotSet));
+        let treasury = Self::treasury_or_fail(&env);
         treasury.require_auth();
 
-        let token_addr = env
-            .storage()
-            .instance()
-            .get(&DataKey::FundingToken)
-            .unwrap_or_else(|| fail(&env, EscrowError::FundingTokenNotSet));
+        let token_addr = Self::funding_token_or_fail(&env);
         let this = env.current_contract_address();
 
         let token = TokenClient::new(&env, &token_addr);
@@ -2800,11 +2804,7 @@ impl LiquifactEscrow {
             &prev_distributed.saturating_add(amount),
         );
 
-        let token_addr: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::FundingToken)
-            .unwrap_or_else(|| fail(&env, EscrowError::FundingTokenNotSet));
+        let token_addr = Self::funding_token_or_fail(&env);
         let this = env.current_contract_address();
 
         external_calls::transfer_funding_token_with_balance_checks(

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -16,8 +16,28 @@ use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events, Ledger as _},
     token::{StellarAssetClient, TokenClient},
-    Address, Env, Event, String, Val, Vec as SorobanVec,
+    Address, Env, Error, Event, InvokeError, String, Val, Vec as SorobanVec,
 };
+use std::fmt::Debug;
+
+pub(crate) fn assert_contract_error<T, E>(
+    result: Result<Result<T, E>, Result<Error, InvokeError>>,
+    expected: EscrowError,
+) where
+    T: Debug,
+    E: Debug,
+{
+    let expected_code = expected as u32;
+    match result {
+        Err(Ok(error)) => {
+            assert_eq!(error, Error::from_contract_error(expected_code));
+        }
+        Err(Err(InvokeError::Contract(code))) => {
+            assert_eq!(code, expected_code);
+        }
+        other => panic!("expected ContractError({expected_code}), got {other:?}"),
+    }
+}
 
 // Focused test tree for escrow behavior. Shared helpers live here so feature
 // modules stay assertion-focused and each test still owns a fresh Env.

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -2,28 +2,10 @@ use super::{free_addresses, setup};
 use crate::{CollateralCommitmentSnapshot, DataKey, EscrowCloseSnapshot, EscrowError, YieldTier};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    Address, Env, Error, InvokeError, Vec as SorobanVec,
+    Address, Env, Vec as SorobanVec,
 };
-use std::fmt::Debug;
 
-fn assert_contract_error<T, E>(
-    result: Result<Result<T, E>, Result<Error, InvokeError>>,
-    expected: EscrowError,
-) where
-    T: Debug,
-    E: Debug,
-{
-    let expected_code = expected as u32;
-    match result {
-        Err(Ok(error)) => {
-            assert_eq!(error, Error::from_contract_error(expected_code));
-        }
-        Err(Err(InvokeError::Contract(code))) => {
-            assert_eq!(code, expected_code);
-        }
-        other => panic!("expected ContractError({expected_code}), got {other:?}"),
-    }
-}
+pub(crate) use super::assert_contract_error;
 
 #[test]
 fn typed_error_codes_cover_init_and_state_guards() {

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -567,19 +567,73 @@ fn test_init_min_contribution_equal_to_amount_accepted() {
 }
 
 #[test]
-#[should_panic]
-fn test_get_funding_token_before_init_panics() {
+fn test_get_funding_token_before_init_fails_with_typed_error() {
     let env = Env::default();
     let client = deploy(&env);
-    client.get_funding_token();
+    assert_contract_error(
+        client.try_get_funding_token(),
+        EscrowError::FundingTokenNotSet,
+    );
 }
 
 #[test]
-#[should_panic]
-fn test_get_treasury_before_init_panics() {
+fn test_get_treasury_before_init_fails_with_typed_error() {
     let env = Env::default();
     let client = deploy(&env);
-    client.get_treasury();
+    assert_contract_error(
+        client.try_get_treasury(),
+        EscrowError::TreasuryNotSet,
+    );
+}
+
+#[test]
+fn test_get_funding_token_after_init_succeeds() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let (token, treasury) = free_addresses(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FT001"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &1000u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert_eq!(client.get_funding_token(), token);
+}
+
+#[test]
+fn test_get_treasury_after_init_succeeds() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let (token, treasury) = free_addresses(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TR001"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &1000u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert_eq!(client.get_treasury(), treasury);
 }
 
 #[test]


### PR DESCRIPTION
closes #336 

# refactor: centralize funding-token and treasury storage reads behind typed accessors

## Summary

Replaces every inline `env.storage().instance().get(&DataKey::FundingToken).unwrap_or_else(|| fail(…))` and the equivalent Treasury pattern with dedicated private accessors, eliminating three copies of the same `unwrap_or_else` chain and ensuring consistent error codes as more entrypoints move funds on-chain.

## Changes

### New private accessors (`escrow/src/lib.rs`)

| Accessor | Key read | Error on absence |
|---|---|---|
| `funding_token_or_fail(env: &Env) -> Address` | `DataKey::FundingToken` | `FundingTokenNotSet` (code 21) |
| `treasury_or_fail(env: &Env) -> Address` | `DataKey::Treasury` | `TreasuryNotSet` (code 22) |

Both are `fn(&Env)` inside `impl LiquifactEscrow` (not public entrypoints), with NatSpec `///` doc comments.

### Call-site replacements

- **`get_funding_token`** — body replaced with `Self::funding_token_or_fail(&env)`
- **`get_treasury`** — body replaced with `Self::treasury_or_fail(&env)`
- **`sweep_terminal_dust`** — both the Treasury and FundingToken inline reads replaced
- **`refund`** — the FundingToken inline read replaced

No other storage keys, control flow, or error codes were touched.

### Tests (`escrow/src/tests/init.rs`)

- **Pre-init typed-error assertions**: `test_get_funding_token_before_init_fails_with_typed_error` and `test_get_treasury_before_init_fails_with_typed_error` now use `try_get_funding_token`/`try_get_treasury` + `assert_contract_error` to verify the exact error code, replacing bare `#[should_panic]` tests.
- **Post-init success assertions**: `test_get_funding_token_after_init_succeeds` and `test_get_treasury_after_init_succeeds` verify the accessors return the bound address after `init`.

### Shared test utility (`escrow/src/tests.rs`)

Moved `assert_contract_error` from `coverage.rs` into the parent `tests` module so all feature test modules can reuse it.

### Documentation (`docs/escrow-data-model.md`)

Added a "Private typed accessors" section documenting both helpers, their error codes, and their callers, so future contributors reach for these instead of inlining storage reads.

## Security

- **Identical error codes**: `FundingTokenNotSet = 21`, `TreasuryNotSet = 22` — unchanged.
- **Identical panic semantics**: `unwrap_or_else(|| fail(…))` → same call via accessor; the panic is identical.
- **Immutability preserved**: Both accessors are read-only; they never write storage.

## Testing

All existing `sweep_terminal_dust`, `refund`, and getter tests continue to exercise the accessor paths:

| Test path | Coverage |
|---|---|
| Pre-init `get_funding_token` → `FundingTokenNotSet` | `test_get_funding_token_before_init_fails_with_typed_error` |
| Pre-init `get_treasury` → `TreasuryNotSet` | `test_get_treasury_before_init_fails_with_typed_error` |
| Post-init `get_funding_token` returns token | `test_get_funding_token_after_init_succeeds` |
| Post-init `get_treasury` returns treasury | `test_get_treasury_after_init_succeeds` |
| `sweep_terminal_dust` reads treasury + token | `test_sweep_terminal_dust_happy_path` (coverage.rs) |
| `refund` reads funding token | `test_refund_returns_principal_to_investor` (funding.rs) |

## Notes

- Closes #336 
- No schema version bump — storage layout is unchanged.
- `cargo fmt --all -- --check`, `cargo build`, and `cargo test` pass.
