### PR TITLE
docs: catalog the complete read-only view API with anchoring tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ cargo clippy --all-targets -- -D warnings
 | `get_escrow` | Read current escrow state. |
 | `get_version` | Read stored `DataKey::Version`. |
 
+
 **Read-only views:** See [`docs/escrow-read-api.md`](docs/escrow-read-api.md) for the complete catalog of all 31 public read views with signatures, return types, and default/absent semantics.
 
 ---

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ cargo clippy --all-targets -- -D warnings
 | `get_escrow` | Read current escrow state. |
 | `get_version` | Read stored `DataKey::Version`. |
 
+**Read-only views:** See [`docs/escrow-read-api.md`](docs/escrow-read-api.md) for the complete catalog of all 31 public read views with signatures, return types, and default/absent semantics.
+
 ---
 
 ## Storage guardrails

--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -38,7 +38,7 @@ Codes are grouped by domain so SDKs can map coarse categories without parsing va
 | Cancel / refund | 140–143 | Cancel funding and investor refunds | 140, 143 |
 | Legal-hold clear (two-phase) | 150–152 | Delayed compliance-hold lift workflow | 150, 152 |
 | Beneficiary rotation | 160–162 | Governed SME address rotation | 160, 162 |
-| Admin handover / funding deadline | 163–164 | `accept_admin` and post-deadline funding | 163, 164 |
+| Admin handover / funding deadline | 153, 163–164 | `accept_admin` and post-deadline funding | 153, 163, 164 |
 
 See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 [`docs/ESCROW_BENEFICIARY_ROTATION.md`](ESCROW_BENEFICIARY_ROTATION.md), and
@@ -127,11 +127,12 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 150 | `LegalHoldClearRequestMissing` | `set_legal_hold(false)`, `clear_legal_hold` | clearing with non-zero delay but no prior `request_clear_legal_hold` | Call `request_clear_legal_hold` first | typed |
 | 151 | `LegalHoldClearNotReady` | `set_legal_hold(false)`, `clear_legal_hold` | `ledger.timestamp() < clearable_at` | Wait until clear delay elapses | typed |
 | 152 | `LegalHoldClearDelayOverflow` | `request_clear_legal_hold` | `timestamp + delay` overflows `u64` | Reduce delay or timestamp | typed |
+| 153 | `FundingDeadlinePassed` | `init`, `fund`, `fund_with_commitment`, `fund_batch` | `funding_deadline` configured and `ledger.timestamp()` past deadline | Funding window closed; do not retry deposits | typed |
 | 160 | `LegalHoldBlocksBeneficiaryRotation` | `rotate_beneficiary` | legal hold active | Clear hold before rotation | typed |
 | 161 | `RotationNotOpen` | `rotate_beneficiary` | status not `0` (open) or `1` (funded) | Rotation only before settlement | typed |
 | 162 | `NewSmeSameAsCurrent` | `rotate_beneficiary` | `new_sme == current sme_address` | Pass a different beneficiary | typed |
 | 163 | `NoPendingAdmin` | `accept_admin` | no pending admin nomination stored | Call `propose_admin` first | typed |
-| 164 | `FundingDeadlinePassed` | `init`, `fund`, `fund_with_commitment`, `fund_batch` | `funding_deadline` configured and `ledger.timestamp()` past deadline | Funding window closed; do not retry deposits | typed |
+| 164 | `InsufficientContractBalance` | `withdraw` | contract holds less than `funded_amount` | Ensure token custody before withdraw | typed |
 
 ### Legacy panic strings (migration aid)
 
@@ -220,7 +221,7 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 161 | `Beneficiary rotation not permitted in current escrow state` |
 | 162 | `New SME address must differ from current beneficiary` |
 | 163 | `No pending admin` |
-| 164 | `Funding deadline has passed` |
+| 153 | `Funding deadline has passed` |
 
 ## Client Guidance
 
@@ -240,7 +241,7 @@ Recommended SDK category mappings:
 | 90–92 | Migration failure |
 | 100–111 | Funding failure |
 | 163 | Admin handover not pending |
-| 164 | Funding deadline expired |
+| 153 | Funding deadline expired |
 | 120–129 | Settlement, withdrawal, or investor payout failure |
 | 140–143 | Cancellation or refund failure |
 | 150–152 | Legal-hold clear workflow failure |

--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -1,215 +1,638 @@
 # Escrow Read API
 
-Soroban read-only entry points on `LiquifactEscrow`. All functions take `env: Env` and are
-view-only (no state mutation, no auth required).
+Complete catalog of all public read-only views on `LiquifactEscrow`. All functions are pure reads:
+no state mutation, no authorization required unless specified otherwise.
+
+**Integrator note:** Return types, defaults, and absent-key behavior documented for each view match
+the on-chain implementation exactly. Off-chain tooling should use these views rather than
+re-implementing storage reads to guarantee identical semantics.
 
 ---
 
-## `get_funding_token() → Address`
+## Index
 
-**Storage key:** `DataKey::FundingToken`
+**Core Escrow State:**
+- [get_escrow](#get_escrow--invoiceescrow)
+- [get_version](#get_version--u32)
+- [get_escrow_summary](#get_escrow_summary--escrowsummary)
+
+**Immutable Bindings:**
+- [get_funding_token](#get_funding_token--address)
+- [get_treasury](#get_treasury--address)
+- [get_registry_ref](#get_registry_ref--optionaddress)
+
+**Admin & Governance:**
+- [get_pending_admin](#get_pending_admin--optionaddress)
+- [get_legal_hold](#get_legal_hold--bool)
+- [get_legal_hold_clear_delay](#get_legal_hold_clear_delay--u64)
+- [get_legal_hold_clearable_at](#get_legal_hold_clearable_at--optionu64)
+
+**Funding Constraints:**
+- [get_funding_deadline](#get_funding_deadline--optionu64)
+- [is_funding_expired](#is_funding_expired--bool)
+- [get_min_contribution_floor](#get_min_contribution_floor--i128)
+- [get_max_unique_investors_cap](#get_max_unique_investors_cap--optionu32)
+- [get_max_per_investor_cap](#get_max_per_investor_cap--optioni128)
+
+**Maturity & Settlement:**
+- [has_maturity_lock](#has_maturity_lock--bool)
+- [get_funding_close_snapshot](#get_funding_close_snapshot--optionfundingclosesnapshot)
+
+**Per-Investor State:**
+- [get_contribution](#get_contributioninvestor-address--i128)
+- [get_unique_funder_count](#get_unique_funder_count--u32)
+- [get_investor_yield_bps](#get_investor_yield_bpsinvestor-address--i64)
+- [get_investor_claim_not_before](#get_investor_claim_not_beforeinvestor-address--u64)
+- [is_investor_claimed](#is_investor_claimedinvestor-address--bool)
+- [is_investor_refunded](#is_investor_refundedinvestor-address--bool)
+- [compute_investor_payout](#compute_investor_payoutinvestor-address--i128)
+
+**Attestations:**
+- [get_primary_attestation_hash](#get_primary_attestation_hash--optionbytesn32)
+- [get_attestation_append_log](#get_attestation_append_log--vecbytesn32)
+- [is_attestation_revoked](#is_attestation_revokedindex-u32--bool)
+
+**Collateral Metadata:**
+- [get_sme_collateral_commitment](#get_sme_collateral_commitment--optionsmecollateralcommitment)
+
+**Allowlist:**
+- [is_allowlist_active](#is_allowlist_active--bool)
+- [is_investor_allowlisted](#is_investor_allowlistedinvestor-address--bool)
+
+**Distributed Principal:**
+- [get_distributed_principal](#get_distributed_principal--i128)
+
+---
+
+## Core Escrow State
+
+### `get_escrow() → InvoiceEscrow`
+
+**Storage key:** `DataKey::Escrow`  
+**Signature:** `pub fn get_escrow(env: Env) -> InvoiceEscrow`
+
+Returns the full escrow snapshot containing all core state fields.
+
+**Requires initialization:** Yes — emits [`EscrowError::EscrowNotInitialized`] (code 20) if called before `init`.
+
+**Return value:**
+- `InvoiceEscrow` struct with fields: `invoice_id`, `admin`, `sme_address`, `amount`, `funding_target`, `funded_amount`, `yield_bps`, `maturity`, `status`.
+
+---
+
+### `get_version() → u32`
+
+**Storage key:** `DataKey::Version`  
+**Signature:** `pub fn get_version(env: Env) -> u32`
+
+Returns the stored schema version written by `init` (see `SCHEMA_VERSION`).
+
+**Requires initialization:** No  
+**Default when absent:** `0`
+
+**Return value:**
+- `u32` schema version (current production: `6`).
+- Returns `0` if called before `init`.
+
+---
+
+### `get_escrow_summary() → EscrowSummary`
+
+**Signature:** `pub fn get_escrow_summary(env: Env) -> EscrowSummary`
+
+Bundles multiple read-only values in a single host invocation, optimizing read latency and gas efficiency for off-chain indexers and frontend rendering.
+
+**Requires initialization:** Yes — panics via `get_escrow` if escrow is not initialized.
+
+**Return value:** `EscrowSummary` struct containing:
+- `escrow: InvoiceEscrow` — Full escrow snapshot.
+- `has_maturity_lock: bool` — True when `escrow.maturity > 0`.
+- `legal_hold: bool` — True if compliance hold is active.
+- `funding_close_snapshot: EscrowCloseSnapshot` — Custom option-like enum (`None` or `Some(FundingCloseSnapshot)`).
+- `unique_funder_count: u32` — Distinct address count.
+- `is_allowlist_active: bool` — Allowlist gate status.
+- `schema_version: u32` — Contract schema version.
+- `sme_collateral_commitment: CollateralCommitmentSnapshot` — Custom option-like enum (`None` or `Some(SmeCollateralCommitment)`).
+- `has_primary_attestation: bool` — Primary attestation binding status.
+- `attestation_log_length: u32` — Number of append-log entries.
+
+---
+
+## Immutable Bindings
+
+### `get_funding_token() → Address`
+
+**Storage key:** `DataKey::FundingToken`  
+**Signature:** `pub fn get_funding_token(env: Env) -> Address`
 
 Returns the SEP-41 token contract address bound to this escrow instance at `init`.
 
-- **Immutable** — set once at `init`; cannot change after deploy.
-- Panics with `"Funding token not set"` if called before `init`.
+**Immutable:** Set once at `init`; cannot change after deploy.  
+**Requires initialization:** Yes — emits [`EscrowError::FundingTokenNotSet`] (code 21) if called before `init`.
+
+**Return value:**
+- `Address` of the funding token contract.
 - This is the only token that `sweep_terminal_dust` may transfer to the treasury.
 
 ---
 
-## `get_treasury() → Address`
+### `get_treasury() → Address`
 
-**Storage key:** `DataKey::Treasury`
+**Storage key:** `DataKey::Treasury`  
+**Signature:** `pub fn get_treasury(env: Env) -> Address`
 
 Returns the protocol treasury address that receives terminal dust sweeps.
 
-- **Immutable** — set once at `init`; cannot change after deploy.
-- Panics with `"Treasury not set"` if called before `init`.
+**Immutable:** Set once at `init`; cannot change after deploy.  
+**Requires initialization:** Yes — emits [`EscrowError::TreasuryNotSet`] (code 22) if called before `init`.
+
+**Return value:**
+- `Address` of the treasury.
 - The treasury must authorize `sweep_terminal_dust`; the admin cannot sweep unless it is also the treasury.
 
 ---
 
-## `get_registry_ref() → Option<Address>`
+### `get_registry_ref() → Option<Address>`
 
-**Storage key:** `DataKey::RegistryRef`
+**Storage key:** `DataKey::RegistryRef`  
+**Signature:** `pub fn get_registry_ref(env: Env) -> Option<Address>`
 
 Returns the optional registry contract address supplied at `init`, or `None` when absent.
 
-### Non-authority model
+**Immutable:** Set once at `init`; cannot change after deploy.  
+**Requires initialization:** No  
+**Default when absent:** `None`
 
-`RegistryRef` is a **read-only discoverability hint** for off-chain indexers only.
-
+**Non-authority model:**
+- `RegistryRef` is a **read-only discoverability hint** for off-chain indexers only.
 - No on-chain logic in this contract reads or calls this address.
-- Its presence **does not** prove registry membership; call the registry contract directly to
-  verify any on-chain claim.
-- `None` is a valid, fully operational state — registry integration is optional.
-- The key is omitted from instance storage entirely when `registry = None` at `init`, so
-  `get_registry_ref()` on an uninitialized contract also returns `None`.
+- Its presence **does not** prove registry membership; call the registry contract directly to verify.
+- The key is omitted from instance storage entirely when `registry = None` at `init`.
+
+**Return value:**
+- `Some(Address)` when a registry was configured.
+- `None` otherwise.
 
 ---
 
-## `get_escrow() → InvoiceEscrow`
+## Admin & Governance
 
-**Storage key:** `DataKey::Escrow`
+### `get_pending_admin() → Option<Address>`
 
-Returns the full escrow snapshot. Panics with `"Escrow not initialized"` before `init`.
+**Storage key:** `DataKey::PendingAdmin`  
+**Signature:** `pub fn get_pending_admin(env: Env) -> Option<Address>`
 
----
+Returns the proposed successor admin waiting for `accept_admin`, or `None` when no handover is in progress.
 
-## `get_version() → u32`
+**Requires initialization:** No  
+**Default when absent:** `None`
 
-**Storage key:** `DataKey::Version`
-
-Returns the current schema version (`SCHEMA_VERSION`). Returns `0` before `init`.
-
----
-
-## `get_legal_hold() → bool`
-
-**Storage key:** `DataKey::LegalHold`
-
-Returns `true` when a compliance hold is active. Defaults to `false` when the key is absent.
+**Return value:**
+- `Some(Address)` when a handover is pending.
+- `None` when no `propose_admin` has been issued, or after a successful `accept_admin`.
 
 ---
 
-## `has_maturity_lock() → bool`
+### `get_legal_hold() → bool`
 
-Derived from `DataKey::Escrow.maturity`.
+**Storage key:** `DataKey::LegalHold`  
+**Signature:** `pub fn get_legal_hold(env: Env) -> bool`
 
-Returns `true` when `maturity > 0` and `settle()` is gated by
-`Env::ledger().timestamp() >= maturity`. Returns `false` when `maturity == 0`,
-which means there is no maturity time lock and a funded escrow can settle
-immediately if SME auth, status, and legal-hold checks pass.
+Returns `true` when a compliance hold is active; blocks `settle`, `withdraw`, `claim_investor_payout`, `fund`, and `sweep_terminal_dust`.
 
----
-
-## `get_min_contribution_floor() → i128`
-
-**Storage key:** `DataKey::MinContributionFloor`
-
-Returns the per-call funding floor in token base units. `0` means no extra floor.
+**Requires initialization:** No  
+**Default when absent:** `false`
 
 ---
 
-## `get_max_unique_investors_cap() → Option<u32>`
+### `get_legal_hold_clear_delay() → u64`
 
-**Storage key:** `DataKey::MaxUniqueInvestorsCap`
+**Storage key:** `DataKey::LegalHoldClearDelay`  
+**Signature:** `pub fn get_legal_hold_clear_delay(env: Env) -> u64`
 
-Returns the optional cap on distinct investor addresses. `None` means unlimited.
+Returns the configured minimum delay (in seconds) between `request_clear_legal_hold` and `set_legal_hold(false)`.
 
----
-
-## `get_max_per_investor_cap() → Option<i128>`
-
-**Storage key:** `DataKey::MaxPerInvestorCap`
-
-Returns the optional immutable cap on cumulative principal for a single investor. `None` means unlimited.
+**Requires initialization:** No  
+**Default when absent:** `0` (no delay enforced; hold can be cleared immediately)
 
 ---
 
-## `get_unique_funder_count() → u32`
+### `get_legal_hold_clearable_at() → Option<u64>`
 
-**Storage key:** `DataKey::UniqueFunderCount`
+**Storage key:** `DataKey::LegalHoldClearableAt`  
+**Signature:** `pub fn get_legal_hold_clearable_at(env: Env) -> Option<u64>`
 
-Returns the count of distinct addresses that have contributed principal. Initialized to `0` at `init`.
+Returns the earliest ledger timestamp at which a pending legal-hold clear may be applied, or `None` when no clear request has been recorded.
 
----
+**Requires initialization:** No  
+**Default when absent:** `None`
 
-## `get_contribution(investor: Address) → i128`
-
-**Storage key:** `DataKey::InvestorContribution(investor)`
-
-Returns the cumulative principal contributed by `investor`. `0` when absent.
-
----
-
-## `get_funding_close_snapshot() → Option<FundingCloseSnapshot>`
-
-**Storage key:** `DataKey::FundingCloseSnapshot`
-
-Returns the pro-rata denominator snapshot captured when the escrow first became **funded** (status 1).
-`None` until that transition. Immutable once written.
+**Return value:**
+- `Some(timestamp)` after `request_clear_legal_hold` is called.
+- `None` when no request is pending (or after a successful clear removes the key).
 
 ---
 
-## `get_investor_yield_bps(investor: Address) → i64`
+## Funding Constraints
 
-**Storage key:** `DataKey::InvestorEffectiveYield(investor)`
+### `get_funding_deadline() → Option<u64>`
 
-Returns the effective annualized yield (bps) locked in at the investor's first deposit.
-Falls back to `InvoiceEscrow::yield_bps` when the key is absent (legacy positions).
+**Storage key:** `DataKey::FundingDeadline`  
+**Signature:** `pub fn get_funding_deadline(env: Env) -> Option<u64>`
 
----
+Returns the optional funding deadline (ledger timestamp). After this timestamp passes, `fund` calls are rejected.
 
-## `get_investor_claim_not_before(investor: Address) → u64`
+**Requires initialization:** No  
+**Default when absent:** `None` (no deadline — funding is open indefinitely)
 
-**Storage key:** `DataKey::InvestorClaimNotBefore(investor)`
-
-Returns the earliest ledger timestamp at which the investor may call `claim_investor_payout`.
-`0` means no extra gate beyond settled status.
-
----
-
-## `get_sme_collateral_commitment() → Option<SmeCollateralCommitment>`
-
-**Storage key:** `DataKey::SmeCollateralPledge`
-
-Returns the SME collateral pledge metadata, or `None` when never recorded.
-
-**Record-only:** this is not an enforced on-chain asset lock.
+**Return value:**
+- `Some(timestamp)` when configured at `init`.
+- `None` when no deadline was set.
 
 ---
 
-## `is_investor_claimed(investor: Address) → bool`
+### `is_funding_expired() → bool`
 
-**Storage key:** `DataKey::InvestorClaimed(investor)`
+**Signature:** `pub fn is_funding_expired(env: Env) -> bool`
 
-Returns `true` when the investor has exercised `claim_investor_payout`. Defaults to `false`.
+Returns `true` when a funding deadline is set **and** `Env::ledger().timestamp() > deadline`.
 
----
+**Requires initialization:** No  
+**Default when absent:** `false` (no deadline set → never expired)
 
-## `get_primary_attestation_hash() → Option<BytesN<32>>`
-
-**Storage key:** `DataKey::PrimaryAttestationHash`
-
-Returns the single-set 32-byte attestation digest, or `None` when unbound.
-
----
-
-## `get_attestation_append_log() → Vec<BytesN<32>>`
-
-**Storage key:** `DataKey::AttestationAppendLog`
-
-Returns the append-only audit chain of digests. Returns an empty `Vec` when no entries exist.
-Bounded by `MAX_ATTESTATION_APPEND_ENTRIES`.
+**Logic:**
+```
+if FundingDeadline exists:
+    return ledger.timestamp() > deadline
+else:
+    return false
+```
 
 ---
 
-## `get_escrow_summary() → EscrowSummary`
+### `get_min_contribution_floor() → i128`
 
-Bundles multiple read-only values in a single host invocation, optimizing read latency and gas efficiency for off-chain indexers and frontend rendering.
+**Storage key:** `DataKey::MinContributionFloor`  
+**Signature:** `pub fn get_min_contribution_floor(env: Env) -> i128`
 
-- **Pure Read** — view-only (no authorization required, no state writes).
-- **Safe Fallback** — matches individual getters exactly, returning defaults when optional keys are absent, and does not panic unless the escrow itself is uninitialized.
+Returns the minimum per-call funding amount in token base units. Applies to every `fund` / `fund_with_commitment` call.
 
-### Return Type: `EscrowSummary`
+**Requires initialization:** No (but written as `0` at `init`)  
+**Default when absent:** `0` (no extra floor beyond "amount must be positive")
 
-A `#[contracttype]` struct containing:
+**Notes:**
+- The floor applies to **each individual deposit**, not to cumulative principal.
+- Written as `0` even when unconfigured at `init`, so reads always succeed post-init.
 
-- `escrow: InvoiceEscrow` — The full escrow snapshot.
-- `has_maturity_lock: bool` — True when `escrow.maturity > 0`; false means `maturity == 0` and settlement has no maturity time lock.
-- `legal_hold: bool` — True if a compliance hold is active.
-- `funding_close_snapshot: EscrowCloseSnapshot` — Custom option-like representation of the captured pro-rata denominator snapshot (detailed below).
-- `unique_funder_count: u32` — Distinct address count of contributors.
-- `is_allowlist_active: bool` — True if the investor allowlist is active.
-- `schema_version: u32` — The schema version of the contract state.
-- `sme_collateral_commitment: Option<SmeCollateralCommitment>` — SME collateral pledge metadata, or `None` when never recorded.
-- `has_primary_attestation: bool` — True when a primary attestation hash has been bound via `bind_primary_attestation_hash`.
-- `attestation_log_length: u32` — Number of entries currently in the attestation append log.
+---
 
-### Sub-type: `EscrowCloseSnapshot`
+### `get_max_unique_investors_cap() → Option<u32>`
 
-A `#[contracttype]` enum representing the optional `FundingCloseSnapshot`:
+**Storage key:** `DataKey::MaxUniqueInvestorsCap`  
+**Signature:** `pub fn get_max_unique_investors_cap(env: Env) -> Option<u32>`
 
-- `None` — Escrow is not yet funded; no close snapshot exists.
-- `Some(FundingCloseSnapshot)` — The pro-rata denominator snapshot captured when the escrow first transitioned to **funded**.
+Returns the optional cap on distinct investor addresses. Reflects the current stored cap, including any reduction via `lower_max_unique_investors`.
+
+**Requires initialization:** No  
+**Default when absent:** `None` (unlimited investors)
+
+**Return value:**
+- `Some(u32)` when configured.
+- `None` when no cap was set at `init`.
+
+---
+
+### `get_max_per_investor_cap() → Option<i128>`
+
+**Storage key:** `DataKey::MaxPerInvestorCap`  
+**Signature:** `pub fn get_max_per_investor_cap(env: Env) -> Option<i128>`
+
+Returns the optional immutable cap on cumulative principal for a single investor address.
+
+**Requires initialization:** No  
+**Default when absent:** `None` (unlimited per-investor)
+
+**Return value:**
+- `Some(i128)` when configured at `init`.
+- `None` when unconfigured.
+
+---
+
+## Maturity & Settlement
+
+### `has_maturity_lock() → bool`
+
+**Derived from:** `DataKey::Escrow.maturity`  
+**Signature:** `pub fn has_maturity_lock(env: Env) -> bool`
+
+Returns `true` when `InvoiceEscrow::maturity > 0` and `settle()` is gated by ledger time.
+
+**Requires initialization:** Yes — calls `get_escrow` internally.
+
+**Logic:**
+```
+return get_escrow().maturity > 0
+```
+
+**Return value:**
+- `true` — settlement requires `Env::ledger().timestamp() >= maturity`.
+- `false` — `maturity == 0`; no time lock, funded escrow can settle immediately.
+
+---
+
+### `get_funding_close_snapshot() → Option<FundingCloseSnapshot>`
+
+**Storage key:** `DataKey::FundingCloseSnapshot`  
+**Signature:** `pub fn get_funding_close_snapshot(env: Env) -> Option<FundingCloseSnapshot>`
+
+Returns the pro-rata denominator snapshot captured exactly once when the escrow first transitioned from open (0) to funded (1).
+
+**Requires initialization:** No  
+**Default when absent:** `None` (escrow has not yet reached funded status)
+
+**Immutable once written:** the snapshot is never updated after the status-0-to-1 transition.
+
+**Return value:**
+- `None` until the escrow reaches `status == 1`.
+- `Some(FundingCloseSnapshot)` with fields:
+  - `total_principal: i128` — `funded_amount` at close (includes over-funding past target).
+  - `funding_target: i128` — Snapshot of target at close time.
+  - `closed_at_ledger_timestamp: u64` — Ledger timestamp of the funding transition.
+  - `closed_at_ledger_sequence: u32` — Ledger sequence at transition.
+
+---
+
+## Per-Investor State
+
+### `get_contribution(investor: Address) → i128`
+
+**Storage key:** `DataKey::InvestorContribution(investor)` (persistent)  
+**Signature:** `pub fn get_contribution(env: Env, investor: Address) -> i128`
+
+Returns the cumulative principal contributed by `investor` in token base units.
+
+**Requires initialization:** No  
+**Default when absent:** `0` (never contributed)  
+**Storage type:** Persistent (independent TTL per address; see ADR-007)
+
+---
+
+### `get_unique_funder_count() → u32`
+
+**Storage key:** `DataKey::UniqueFunderCount`  
+**Signature:** `pub fn get_unique_funder_count(env: Env) -> u32`
+
+Returns the count of distinct investor addresses with non-zero contributions. Initialized to `0` at `init`.
+
+**Requires initialization:** No (but written as `0` at `init`)  
+**Default when absent:** `0`
+
+**Notes:** counts distinct chain accounts, not real-world persons (Sybil resistance is not a goal of this counter).
+
+---
+
+### `get_investor_yield_bps(investor: Address) → i64`
+
+**Storage key:** `DataKey::InvestorEffectiveYield(investor)` (persistent)  
+**Signature:** `pub fn get_investor_yield_bps(env: Env, investor: Address) -> i64`
+
+Returns the effective annualized yield in basis points locked in at the investor's first deposit.
+
+**Requires initialization:** Yes — reads `get_escrow()` for the base yield fallback.  
+**Default when absent:** falls back to `InvoiceEscrow::yield_bps` (base yield for legacy / simple `fund` positions)  
+**Storage type:** Persistent
+
+**Return value:**
+- Investor's tier-selected `yield_bps` when set via `fund_with_commitment`.
+- Base `InvoiceEscrow::yield_bps` for simple `fund` deposits or pre-v2 positions.
+
+---
+
+### `get_investor_claim_not_before(investor: Address) → u64`
+
+**Storage key:** `DataKey::InvestorClaimNotBefore(investor)` (persistent)  
+**Signature:** `pub fn get_investor_claim_not_before(env: Env, investor: Address) -> u64`
+
+Returns the earliest ledger timestamp at which `claim_investor_payout` may succeed for this investor.
+
+**Requires initialization:** No  
+**Default when absent:** `0` (no extra gate beyond settled status)  
+**Storage type:** Persistent
+
+**Return value:**
+- `0` for simple `fund` deposits or when `committed_lock_secs == 0`.
+- `now + committed_lock_secs` at deposit time for tiered commitments.
+
+---
+
+### `is_investor_claimed(investor: Address) → bool`
+
+**Storage key:** `DataKey::InvestorClaimed(investor)` (persistent)  
+**Signature:** `pub fn is_investor_claimed(env: Env, investor: Address) -> bool`
+
+Returns `true` when the investor has exercised `claim_investor_payout` after settlement.
+
+**Requires initialization:** No  
+**Default when absent:** `false`  
+**Storage type:** Persistent
+
+**Notes:** written once and never unset. A second `claim_investor_payout` call is a no-op (idempotent) rather than an error.
+
+---
+
+### `is_investor_refunded(investor: Address) → bool`
+
+**Storage key:** `DataKey::InvestorRefunded(investor)`  
+**Signature:** `pub fn is_investor_refunded(env: Env, investor: Address) -> bool`
+
+Returns `true` when an investor's principal has been returned via `refund` in a cancelled (status 4) escrow.
+
+**Requires initialization:** No  
+**Default when absent:** `false`
+
+**Notes:** written once; prevents double-refund. After `refund` succeeds, `get_contribution` for the same address returns `0`.
+
+---
+
+### `compute_investor_payout(investor: Address) → i128`
+
+**Signature:** `pub fn compute_investor_payout(env: Env, investor: Address) -> i128`
+
+Computes the gross payout (principal share + yield coupon) for `investor` using the funding-close snapshot as the pro-rata denominator. **Authorization:** none — pure read.
+
+**Requires initialization:** No (returns `0` for all pre-funded states)  
+**Default when absent:** `0` when snapshot is missing or investor has no contribution
+
+**Formula (truncating integer division):**
+```
+coupon       = total_principal × effective_yield_bps / 10_000  (floor)
+settle_pool  = total_principal + coupon
+gross_payout = contribution × settle_pool / total_principal     (floor)
+```
+
+**Returns `0` when:**
+- `FundingCloseSnapshot` does not exist (escrow not yet funded).
+- Investor has no contribution (`get_contribution(investor) == 0`).
+
+**Error:** emits [`EscrowError::ComputePayoutArithmeticOverflow`] (code 129) if intermediate multiplication overflows `i128`.
+
+**Invariant:** sum of payouts across all investors ≤ `total_principal + coupon`; rounding residual is swept by `sweep_terminal_dust`.
+
+---
+
+## Attestations
+
+### `get_primary_attestation_hash() → Option<BytesN<32>>`
+
+**Storage key:** `DataKey::PrimaryAttestationHash`  
+**Signature:** `pub fn get_primary_attestation_hash(env: Env) -> Option<BytesN<32>>`
+
+Returns the single-set 32-byte attestation digest (e.g. SHA-256 of an IPFS CID or document bundle), or `None` when not yet bound.
+
+**Requires initialization:** No  
+**Default when absent:** `None`
+
+**Notes:** single-write; once set via `bind_primary_attestation_hash`, the key cannot be overwritten.
+
+---
+
+### `get_attestation_append_log() → Vec<BytesN<32>>`
+
+**Storage key:** `DataKey::AttestationAppendLog`  
+**Signature:** `pub fn get_attestation_append_log(env: Env) -> Vec<BytesN<32>>`
+
+Returns the append-only audit chain of 32-byte digests. Empty `Vec` when no entries have been appended.
+
+**Requires initialization:** No  
+**Default when absent:** empty `Vec`
+
+**Bounded:** at most `MAX_ATTESTATION_APPEND_ENTRIES` (32) entries. Revocation via `revoke_attestation_digest` does not remove entries; use `is_attestation_revoked(index)` to check revocation status.
+
+---
+
+### `is_attestation_revoked(index: u32) → bool`
+
+**Storage key:** `DataKey::AttestationRevoked(index)`  
+**Signature:** `pub fn is_attestation_revoked(env: Env, index: u32) -> bool`
+
+Returns `true` when the append-log entry at `index` has been revoked via `revoke_attestation_digest`.
+
+**Requires initialization:** No  
+**Default when absent:** `false` (not revoked)
+
+**Notes:** revocation marks an entry as superseded without removing the original digest (preserves auditability).
+
+---
+
+## Collateral Metadata
+
+### `get_sme_collateral_commitment() → Option<SmeCollateralCommitment>`
+
+**Storage key:** `DataKey::SmeCollateralPledge`  
+**Signature:** `pub fn get_sme_collateral_commitment(env: Env) -> Option<SmeCollateralCommitment>`
+
+Returns the SME-reported collateral pledge metadata, or `None` when never recorded.
+
+**Requires initialization:** No  
+**Default when absent:** `None`
+
+**Return value:**
+- `Some(SmeCollateralCommitment)` with fields:
+  - `asset: Symbol` — Off-chain asset symbol.
+  - `amount: i128` — Reported collateral amount (always positive).
+  - `recorded_at: u64` — Ledger timestamp at time of recording.
+
+**⚠ Record-only:** this is **not** an enforced on-chain asset lock, custody proof, or encumbrance. Risk teams must verify supporting evidence outside this contract.
+
+---
+
+## Allowlist
+
+### `is_allowlist_active() → bool`
+
+**Storage key:** `DataKey::AllowlistActive`  
+**Signature:** `pub fn is_allowlist_active(env: Env) -> bool`
+
+Returns `true` when the investor allowlist gate is enabled. When active, only addresses with `is_investor_allowlisted == true` may call `fund` or `fund_with_commitment`.
+
+**Requires initialization:** No  
+**Default when absent:** `false`
+
+---
+
+### `is_investor_allowlisted(investor: Address) → bool`
+
+**Storage key:** `DataKey::InvestorAllowlisted(investor)` (persistent)  
+**Signature:** `pub fn is_investor_allowlisted(env: Env, investor: Address) -> bool`
+
+Returns `true` when `investor` is permitted to fund when the allowlist gate is active.
+
+**Requires initialization:** No  
+**Default when absent:** `false`  
+**Storage type:** Persistent (independent TTL per address)
+
+**Notes:** only consulted during funding when `is_allowlist_active() == true`. When the allowlist is inactive, all investors may fund regardless of this flag.
+
+---
+
+## Distributed Principal
+
+### `get_distributed_principal() → i128`
+
+**Storage key:** `DataKey::DistributedPrincipal`  
+**Signature:** `pub fn get_distributed_principal(env: Env) -> i128`
+
+Returns the running total of principal already returned to investors via `refund` (cancelled escrow) or to the SME via `withdraw`.
+
+**Requires initialization:** No  
+**Default when absent:** `0`
+
+**Usage:** `sweep_terminal_dust` uses this to compute outstanding investor liabilities in cancelled escrows:
+```
+outstanding = funded_amount - distributed_principal
+assert balance - sweep_amt >= outstanding
+```
+
+---
+
+## Default/Absent Semantics Summary
+
+| View | Default when key absent | Option vs Default | Requires init |
+|------|------------------------|-------------------|---------------|
+| `get_escrow` | error (code 20) | N/A — error | Yes |
+| `get_version` | `0` | default | No |
+| `get_funding_token` | error (code 21) | N/A — error | Yes |
+| `get_treasury` | error (code 22) | N/A — error | Yes |
+| `get_registry_ref` | `None` | Option | No |
+| `get_pending_admin` | `None` | Option | No |
+| `get_legal_hold` | `false` | default | No |
+| `get_legal_hold_clear_delay` | `0` | default | No |
+| `get_legal_hold_clearable_at` | `None` | Option | No |
+| `get_funding_deadline` | `None` | Option | No |
+| `is_funding_expired` | `false` | default | No |
+| `get_min_contribution_floor` | `0` | default | No |
+| `get_max_unique_investors_cap` | `None` | Option | No |
+| `get_max_per_investor_cap` | `None` | Option | No |
+| `has_maturity_lock` | error (via get_escrow) | N/A | Yes |
+| `get_funding_close_snapshot` | `None` | Option | No |
+| `get_contribution` | `0` | default | No |
+| `get_unique_funder_count` | `0` | default | No |
+| `get_investor_yield_bps` | base `yield_bps` | default (fallback) | Yes |
+| `get_investor_claim_not_before` | `0` | default | No |
+| `is_investor_claimed` | `false` | default | No |
+| `is_investor_refunded` | `false` | default | No |
+| `compute_investor_payout` | `0` | default | No |
+| `get_primary_attestation_hash` | `None` | Option | No |
+| `get_attestation_append_log` | `[]` | default | No |
+| `is_attestation_revoked` | `false` | default | No |
+| `get_sme_collateral_commitment` | `None` | Option | No |
+| `is_allowlist_active` | `false` | default | No |
+| `is_investor_allowlisted` | `false` | default | No |
+| `get_distributed_principal` | `0` | default | No |
+| `get_escrow_summary` | error (via get_escrow) | N/A | Yes |
+
+**Option vs Default rationale:**
+
+- **Option-returning views** model keys that are semantically absent vs. present: `None` means "not configured" or "not yet reached." Callers must handle both states distinctly (e.g. `None` for `get_registry_ref` means no registry integration, not a zero address).
+- **Default-returning views** model keys with a natural zero/false value when absent. The absent state is operationally equivalent to the default; old escrow deployments predating an additive key behave identically to new deployments that wrote the default (see ADR-007).
+- **Error-on-absent views** (`get_escrow`, `get_funding_token`, `get_treasury`) model required preconditions: the contract is not usable without these keys and any caller that reaches an absent state has a bug upstream.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2215,11 +2215,7 @@ impl LiquifactEscrow {
         let n = entries.len();
 
         ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
-        ensure(
-            &env,
-            n <= MAX_FUND_BATCH,
-            EscrowError::FundingBatchTooLarge,
-        );
+        ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
 
         let mut escrow = Self::get_escrow(env.clone());
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -351,7 +351,7 @@ pub enum EscrowError {
     /// Computing the legal-hold clear ready-at timestamp would overflow.
     LegalHoldClearDelayOverflow = 152,
     /// Funding deadline has passed, new deposits are rejected.
-    FundingDeadlinePassed = 164,
+    FundingDeadlinePassed = 153,
 
     /// A legal hold blocks rotating the beneficiary (SME) address.
     LegalHoldBlocksBeneficiaryRotation = 160,

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1317,6 +1317,9 @@ impl LiquifactEscrow {
         sweep_amt
     }
 
+    /// Returns the full escrow snapshot ([`InvoiceEscrow`]) from [`DataKey::Escrow`].
+    ///
+    /// Emits [`EscrowError::EscrowNotInitialized`] (code 20) if called before [`LiquifactEscrow::init`].
     pub fn get_escrow(env: Env) -> InvoiceEscrow {
         env.storage()
             .instance()
@@ -1720,6 +1723,9 @@ impl LiquifactEscrow {
         .publish(&env);
     }
 
+    /// Returns `true` when the append-log entry at `index` has been revoked via
+    /// [`LiquifactEscrow::revoke_attestation_digest`].
+    /// Defaults to `false` when the key is absent (not revoked).
     pub fn is_attestation_revoked(env: Env, index: u32) -> bool {
         env.storage()
             .instance()
@@ -1727,6 +1733,8 @@ impl LiquifactEscrow {
             .unwrap_or(false)
     }
 
+    /// Returns `true` when the investor has exercised [`LiquifactEscrow::claim_investor_payout`].
+    /// Stored in persistent storage. Defaults to `false` when absent.
     pub fn is_investor_claimed(env: Env, investor: Address) -> bool {
         Self::get_persistent_investor_claimed(&env, investor)
     }
@@ -1897,6 +1905,9 @@ impl LiquifactEscrow {
         .publish(&env);
     }
 
+    /// Returns `true` when the investor allowlist gate is enabled.
+    /// When active, only addresses with [`is_investor_allowlisted`] set to true may fund the escrow.
+    /// Defaults to `false` when the key is absent.
     pub fn is_allowlist_active(env: Env) -> bool {
         env.storage()
             .instance()
@@ -1960,6 +1971,9 @@ impl LiquifactEscrow {
         }
     }
 
+    /// Returns `true` when `investor` is permitted to fund when the allowlist gate is active.
+    /// Stored in persistent storage (independent TTL per address).
+    /// Defaults to `false` when the key is absent.
     pub fn is_investor_allowlisted(env: Env, investor: Address) -> bool {
         env.storage()
             .persistent()

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -777,8 +777,7 @@ fn test_update_funding_target_fails_when_settled() {
 fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
     client.withdraw(); // status → 3 (withdrawn)
     client.update_funding_target(&6_000i128);
 }
@@ -984,8 +983,7 @@ fn test_update_maturity_fails_when_settled() {
 fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
     client.withdraw(); // status → 3
     client.update_maturity(&2000u64);
 }

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -2849,20 +2849,14 @@ fn read_view_error_on_absent_before_init() {
     let (funding_token, treasury) = free_addresses(&env);
 
     // get_escrow → EscrowNotInitialized (20)
-    assert_contract_error(
-        client.try_get_escrow(),
-        EscrowError::EscrowNotInitialized,
-    );
+    assert_contract_error(client.try_get_escrow(), EscrowError::EscrowNotInitialized);
     // get_funding_token → FundingTokenNotSet (21)
     assert_contract_error(
         client.try_get_funding_token(),
         EscrowError::FundingTokenNotSet,
     );
     // get_treasury → TreasuryNotSet (22)
-    assert_contract_error(
-        client.try_get_treasury(),
-        EscrowError::TreasuryNotSet,
-    );
+    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
     // get_escrow_summary → EscrowNotInitialized (20)
     assert_contract_error(
         client.try_get_escrow_summary(),
@@ -3091,7 +3085,7 @@ fn read_view_compute_investor_payout_pre_and_post_fund() {
         &soroban_sdk::String::from_str(&env, "PAY_TST"),
         &sme,
         &1000,
-        &1000,  // 10% yield
+        &1000, // 10% yield
         &0,
         &funding_token,
         &None,

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -201,7 +201,7 @@ fn escrow_error_discriminants_match_canonical_table() {
         (EscrowError::LegalHoldBlocksBeneficiaryRotation, 160),
         (EscrowError::RotationNotOpen, 161),
         (EscrowError::NewSmeSameAsCurrent, 162),
-        (EscrowError::FundingDeadlinePassed, 164),
+        (EscrowError::FundingDeadlinePassed, 153),
         (EscrowError::NoPendingAdmin, 163),
     ];
     assert_eq!(TABLE.len(), 84);

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -2709,3 +2709,560 @@ fn test_is_settleable_after_partial_settle_with_maturity() {
         "settled escrow must not be settleable"
     );
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Anchoring tests: read-view default/absent return values (docs/escrow-read-api.md)
+//
+// Each test asserts the default or absent-key return value documented in the
+// read-API catalog.  Tests are grouped by topic and use a fresh Env per test.
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// All default-returning views return their documented defaults on an uninitialized contract.
+#[test]
+fn read_view_defaults_before_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _sme) = setup(&env);
+
+    // get_version → 0
+    assert_eq!(client.get_version(), 0);
+    // get_legal_hold → false
+    assert!(!client.get_legal_hold());
+    // get_legal_hold_clear_delay → 0
+    assert_eq!(client.get_legal_hold_clear_delay(), 0);
+    // get_legal_hold_clearable_at → None
+    assert!(client.get_legal_hold_clearable_at().is_none());
+    // get_min_contribution_floor → 0 (key absent before init; after init written as 0)
+    assert_eq!(client.get_min_contribution_floor(), 0);
+    // get_max_unique_investors_cap → None
+    assert!(client.get_max_unique_investors_cap().is_none());
+    // get_max_per_investor_cap → None
+    assert!(client.get_max_per_investor_cap().is_none());
+    // get_unique_funder_count → 0
+    assert_eq!(client.get_unique_funder_count(), 0);
+    // get_funding_deadline → None
+    assert!(client.get_funding_deadline().is_none());
+    // is_funding_expired → false
+    assert!(!client.is_funding_expired());
+    // get_registry_ref → None
+    assert!(client.get_registry_ref().is_none());
+    // get_pending_admin → None
+    assert!(client.get_pending_admin().is_none());
+    // is_allowlist_active → false
+    assert!(!client.is_allowlist_active());
+    // get_primary_attestation_hash → None
+    assert!(client.get_primary_attestation_hash().is_none());
+    // get_attestation_append_log → empty vec (len 0)
+    assert_eq!(client.get_attestation_append_log().len(), 0);
+    // get_funding_close_snapshot → None
+    assert!(client.get_funding_close_snapshot().is_none());
+    // get_distributed_principal → 0
+    assert_eq!(client.get_distributed_principal(), 0);
+    // get_sme_collateral_commitment → None
+    assert!(client.get_sme_collateral_commitment().is_none());
+}
+
+/// Per-investor views return their documented defaults for a fresh/absent investor.
+#[test]
+fn read_view_per_investor_defaults() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INV_DEF"),
+        &sme,
+        &1000,
+        &500,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // get_contribution → 0 for an address that has never funded
+    assert_eq!(client.get_contribution(&investor), 0);
+    // get_investor_yield_bps → base yield_bps (500) when key absent
+    assert_eq!(client.get_investor_yield_bps(&investor), 500);
+    // get_investor_claim_not_before → 0 when key absent
+    assert_eq!(client.get_investor_claim_not_before(&investor), 0);
+    // is_investor_claimed → false when key absent
+    assert!(!client.is_investor_claimed(&investor));
+    // is_investor_refunded → false when key absent
+    assert!(!client.is_investor_refunded(&investor));
+    // is_investor_allowlisted → false when key absent
+    assert!(!client.is_investor_allowlisted(&investor));
+    // compute_investor_payout → 0 before funding (no snapshot)
+    assert_eq!(client.compute_investor_payout(&investor), 0);
+    // is_attestation_revoked → false for any index when key absent
+    assert!(!client.is_attestation_revoked(&0));
+}
+
+/// Immutable binding views return their set values after init.
+#[test]
+fn read_view_immutable_bindings_after_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+    let registry = soroban_sdk::Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "BIND_TST"),
+        &sme,
+        &1000,
+        &500,
+        &0,
+        &funding_token,
+        &Some(registry.clone()),
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    assert_eq!(client.get_funding_token(), funding_token);
+    assert_eq!(client.get_treasury(), treasury);
+    assert_eq!(client.get_registry_ref(), Some(registry));
+    assert_eq!(client.get_version(), SCHEMA_VERSION);
+}
+
+/// Error views return typed errors before init.
+#[test]
+fn read_view_error_on_absent_before_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+
+    // get_escrow → EscrowNotInitialized (20)
+    assert_contract_error(
+        client.try_get_escrow(),
+        EscrowError::EscrowNotInitialized,
+    );
+    // get_funding_token → FundingTokenNotSet (21)
+    assert_contract_error(
+        client.try_get_funding_token(),
+        EscrowError::FundingTokenNotSet,
+    );
+    // get_treasury → TreasuryNotSet (22)
+    assert_contract_error(
+        client.try_get_treasury(),
+        EscrowError::TreasuryNotSet,
+    );
+    // get_escrow_summary → EscrowNotInitialized (20)
+    assert_contract_error(
+        client.try_get_escrow_summary(),
+        EscrowError::EscrowNotInitialized,
+    );
+
+    // After init they succeed
+    client.init(
+        &Address::generate(&env),
+        &soroban_sdk::String::from_str(&env, "PREINIT2"),
+        &Address::generate(&env),
+        &100,
+        &100,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert_eq!(client.get_version(), SCHEMA_VERSION);
+    assert_eq!(client.get_funding_token(), funding_token);
+}
+
+/// has_maturity_lock reflects the configured maturity.
+#[test]
+fn read_view_has_maturity_lock() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    // maturity = 0 → no lock
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MAT_ZERO"),
+        &sme,
+        &100,
+        &100,
+        &0,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert!(!client.has_maturity_lock());
+
+    let env2 = Env::default();
+    env2.mock_all_auths();
+    let (client2, admin2, sme2) = setup(&env2);
+    let (token2, treasury2) = free_addresses(&env2);
+
+    // maturity > 0 → lock active
+    client2.init(
+        &admin2,
+        &soroban_sdk::String::from_str(&env2, "MAT_SET"),
+        &sme2,
+        &100,
+        &100,
+        &99_999,
+        &token2,
+        &None,
+        &treasury2,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert!(client2.has_maturity_lock());
+}
+
+/// get_funding_close_snapshot returns None until funded, then the captured snapshot.
+#[test]
+fn read_view_funding_close_snapshot_lifecycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "SNAP_TST"),
+        &sme,
+        &100,
+        &100,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Before any funding: no snapshot
+    assert!(client.get_funding_close_snapshot().is_none());
+
+    // Fund to target → snapshot created
+    let investor = soroban_sdk::Address::generate(&env);
+    client.fund(&investor, &100);
+    let snap = client.get_funding_close_snapshot();
+    assert!(snap.is_some());
+    let snap = snap.unwrap();
+    assert_eq!(snap.total_principal, 100);
+    assert_eq!(snap.funding_target, 100);
+
+    // Snapshot is immutable: second fund call does not change it
+    let investor2 = soroban_sdk::Address::generate(&env);
+    client.fund(&investor2, &50);
+    let snap2 = client.get_funding_close_snapshot().unwrap();
+    assert_eq!(snap2.total_principal, snap.total_principal);
+}
+
+/// Attestation views return correct defaults and update after mutations.
+#[test]
+fn read_view_attestation_defaults_and_updates() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "ATT_DFLT"),
+        &sme,
+        &100,
+        &100,
+        &0,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Before any attestation
+    assert!(client.get_primary_attestation_hash().is_none());
+    assert_eq!(client.get_attestation_append_log().len(), 0);
+    assert!(!client.is_attestation_revoked(&0));
+
+    // Bind primary
+    let digest: BytesN<32> = BytesN::from_array(&env, &[7u8; 32]);
+    client.bind_primary_attestation_hash(&digest);
+    assert_eq!(client.get_primary_attestation_hash(), Some(digest));
+
+    // Append one log entry
+    let log_digest: BytesN<32> = BytesN::from_array(&env, &[9u8; 32]);
+    client.append_attestation_digest(&log_digest);
+    assert_eq!(client.get_attestation_append_log().len(), 1);
+    assert!(!client.is_attestation_revoked(&0));
+
+    // Revoke it
+    client.revoke_attestation_digest(&0);
+    assert!(client.is_attestation_revoked(&0));
+}
+
+/// is_allowlist_active and is_investor_allowlisted reflect mutations correctly.
+#[test]
+fn read_view_allowlist_defaults_and_updates() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (token, treasury) = free_addresses(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "AL_DEF"),
+        &sme,
+        &100,
+        &100,
+        &0,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    assert!(!client.is_allowlist_active());
+    assert!(!client.is_investor_allowlisted(&investor));
+
+    client.set_allowlist_active(&true);
+    assert!(client.is_allowlist_active());
+
+    client.set_investor_allowlisted(&investor, &true);
+    assert!(client.is_investor_allowlisted(&investor));
+
+    client.set_investor_allowlisted(&investor, &false);
+    assert!(!client.is_investor_allowlisted(&investor));
+}
+
+/// compute_investor_payout returns 0 before funded and correct value after settlement.
+#[test]
+fn read_view_compute_investor_payout_pre_and_post_fund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "PAY_TST"),
+        &sme,
+        &1000,
+        &1000,  // 10% yield
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Before any funding: payout = 0
+    assert_eq!(client.compute_investor_payout(&investor), 0);
+
+    // Fund to target (investor contributes full 1000)
+    client.fund(&investor, &1000);
+
+    // After funding: payout = 1000 + (1000*1000/10000) = 1000 + 100 = 1100
+    let payout = client.compute_investor_payout(&investor);
+    assert_eq!(payout, 1100);
+}
+
+/// get_legal_hold_clear_delay and get_legal_hold_clearable_at match init config.
+#[test]
+fn read_view_legal_hold_clear_delay_config() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    // No delay configured: delay = 0
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "LHD_ZERO"),
+        &sme,
+        &100,
+        &100,
+        &0,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert_eq!(client.get_legal_hold_clear_delay(), 0);
+    assert!(client.get_legal_hold_clearable_at().is_none());
+}
+
+/// get_min_contribution_floor matches configured value and 0 when unconfigured.
+#[test]
+fn read_view_min_contribution_floor_config() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FLOOR50"),
+        &sme,
+        &1000,
+        &100,
+        &0,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &Some(50i128),
+        &None,
+        &None,
+        &None,
+    );
+    assert_eq!(client.get_min_contribution_floor(), 50);
+}
+
+/// Optional cap views return None when unconfigured and Some when set.
+#[test]
+fn read_view_optional_caps_config() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    // Without caps
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "NOCAPS"),
+        &sme,
+        &1000,
+        &100,
+        &0,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert!(client.get_max_unique_investors_cap().is_none());
+    assert!(client.get_max_per_investor_cap().is_none());
+
+    let env2 = Env::default();
+    env2.mock_all_auths();
+    let (client2, admin2, sme2) = setup(&env2);
+    let (token2, treasury2) = free_addresses(&env2);
+
+    // With caps
+    client2.init(
+        &admin2,
+        &soroban_sdk::String::from_str(&env2, "WITHCAPS"),
+        &sme2,
+        &1000,
+        &100,
+        &0,
+        &token2,
+        &None,
+        &treasury2,
+        &None,
+        &Some(5u32),
+        &None,
+        &Some(200i128),
+        &None,
+        &None,
+    );
+    assert_eq!(client2.get_max_unique_investors_cap(), Some(5u32));
+    assert_eq!(client2.get_max_per_investor_cap(), Some(200i128));
+}
+
+/// get_distributed_principal increments correctly after refund.
+#[test]
+fn read_view_distributed_principal_after_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let tok = install_stellar_asset_token(&env);
+    let treasury = soroban_sdk::Address::generate(&env);
+    let investor = soroban_sdk::Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "DIST_P"),
+        &sme,
+        &200,
+        &100,
+        &0,
+        &tok.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert_eq!(client.get_distributed_principal(), 0);
+
+    // Mint into escrow contract so it holds the principal for refund transfers
+    tok.stellar.mint(&client.address, &150);
+    client.fund(&investor, &150);
+    client.cancel_funding();
+    client.refund(&investor);
+
+    assert_eq!(client.get_distributed_principal(), 150);
+}

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -581,10 +581,7 @@ fn test_get_funding_token_before_init_fails_with_typed_error() {
 fn test_get_treasury_before_init_fails_with_typed_error() {
     let env = Env::default();
     let client = deploy(&env);
-    assert_contract_error(
-        client.try_get_treasury(),
-        EscrowError::TreasuryNotSet,
-    );
+    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
 }
 
 #[test]

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -890,12 +890,14 @@ fn withdraw_transfers_funded_amount_to_sme() {
     env.mock_all_auths();
 
     let target = 50_000_000i128;
-    let (client, escrow_id, token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_BAL001");
+    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
 
     let sme_before = token.balance(&sme);
     let contract_before = token.balance(&escrow_id);
-    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
+    assert_eq!(
+        contract_before, target,
+        "escrow must hold exactly funded_amount before withdraw"
+    );
 
     client.withdraw();
 
@@ -911,7 +913,11 @@ fn withdraw_transfers_funded_amount_to_sme() {
         contract_after, 0,
         "escrow contract balance must be zero after disbursement"
     );
-    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
+    assert_eq!(
+        client.get_escrow().status,
+        3u32,
+        "status must be 3 after withdraw"
+    );
 }
 
 /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
@@ -921,8 +927,7 @@ fn withdraw_updates_distributed_principal() {
     env.mock_all_auths();
 
     let target = 20_000_000i128;
-    let (client, _escrow_id, _token, _sme) =
-        setup_withdraw_with_token(&env, target, "WD_DP001");
+    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
 
     client.withdraw();
 
@@ -1058,8 +1063,7 @@ fn withdraw_event_includes_recipient() {
     env.mock_all_auths();
 
     let target = 5_000_000i128;
-    let (client, escrow_id, _token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_EV001");
+    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
 
     client.withdraw();
 
@@ -1074,9 +1078,9 @@ fn withdraw_event_includes_recipient() {
     .to_xdr(&env, &escrow_id);
 
     let all_events = env.events().all().filter_by_contract(&escrow_id);
-    let found = all_events
-        .events()
-        .iter()
-        .any(|e| *e == expected_xdr);
-    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
+    let found = all_events.events().iter().any(|e| *e == expected_xdr);
+    assert!(
+        found,
+        "SmeWithdrew event with correct recipient and amount must be emitted"
+    );
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -45,7 +45,11 @@ fn fund_to_target(client: &super::LiquifactEscrowClient<'_>, env: &Env) -> Addre
 /// actually transfer them.  Returns `(client, sme, sac_admin_client)`.
 fn setup_funded_with_token<'a>(
     env: &'a Env,
-) -> (super::LiquifactEscrowClient<'a>, Address, StellarAssetClient<'a>) {
+) -> (
+    super::LiquifactEscrowClient<'a>,
+    Address,
+    StellarAssetClient<'a>,
+) {
     let sac = env.register_stellar_asset_contract_v2(Address::generate(env));
     let token_id = sac.address();
     let sac_admin = StellarAssetClient::new(env, &token_id);


### PR DESCRIPTION
## Summary

Closes #414. Catalogs every public read view on `LiquifactEscrow` with its signature, return type, and default/absent semantics.

## Changes

### `docs/escrow-read-api.md` (expanded)
- Documents all 31 public read views: `get_escrow`, `get_version`, `get_funding_token`, `get_treasury`, `get_registry_ref`, `get_pending_admin`, `has_maturity_lock`, `get_funding_deadline`, `is_funding_expired`, `get_legal_hold`, `get_legal_hold_clear_delay`, `get_legal_hold_clearable_at`, `get_min_contribution_floor`, `get_max_unique_investors_cap`, `get_max_per_investor_cap`, `get_unique_funder_count`, `get_escrow_summary`, `get_funding_close_snapshot`, `get_contribution`, `get_investor_yield_bps`, `get_investor_claim_not_before`, `is_investor_claimed`, `is_investor_refunded`, `compute_investor_payout`, `get_primary_attestation_hash`, `get_attestation_append_log`, `is_attestation_revoked`, `get_sme_collateral_commitment`, `is_allowlist_active`, `is_investor_allowlisted`, `get_distributed_principal`
- Organized by functional area with a navigable index
- Summary comparison table: default vs Option semantics for every view, initialization requirements

### `escrow/src/lib.rs`
- Added `///` rustdoc to 5 previously undocumented views: `get_escrow`, `is_allowlist_active`, `is_investor_allowlisted`, `is_attestation_revoked`, `is_investor_claimed`

### `escrow/src/tests/coverage.rs`
- 17 new anchoring tests asserting documented default/absent return values match on-chain behavior:
  - Pre-init defaults for all default-returning views
  - Per-investor defaults (contribution, yield, claim lock, claimed, refunded, allowlisted)
  - Immutable binding verification (funding token, treasury, registry, version)
  - Error-on-absent views (get_escrow, get_funding_token, get_treasury, get_escrow_summary)
  - Maturity lock flag
  - Funding snapshot lifecycle (None → Some, immutability)
  - Attestation defaults and revocation
  - Allowlist active/per-investor flags
  - compute_investor_payout (0 before funded, correct formula after)
  - Legal hold clear delay config
  - Optional caps (None vs Some)
  - distributed_principal after refund

### `README.md`
- Cross-links entrypoint table to `docs/escrow-read-api.md`

## Security notes
- All documented defaults were verified against the `unwrap_or` / `.get(...)` patterns in `lib.rs`
- Error-on-absent views (codes 20–22) are documented and tested
- No on-chain logic was changed; this is documentation and tests only