### PR TITLE
Feature/contracts 08 investor index

### DIFF
--- a/docs/escrow-data-model.md
+++ b/docs/escrow-data-model.md
@@ -55,6 +55,8 @@ with `unwrap_or(0)`.
 | `MaxUniqueInvestorsCap` | `u32` | `init` (when `max_unique_investors` arg is `Some`) | Absent means unlimited |
 | `PrimaryAttestationHash` | `BytesN<32>` | `bind_primary_attestation_hash` | Single-set; panics on second call |
 | `AttestationAppendLog` | `Vec<BytesN<32>>` | `append_attestation_digest` | Bounded by `MAX_ATTESTATION_APPEND_ENTRIES` (32) |
+| `InvestorIndex` | `Vec<Address>` | `fund_impl` (on first deposit) | Bounded vector of investor addresses who contributed |
+
 
 ### Per-address investor keys in persistent storage
 

--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -213,3 +213,17 @@ A `#[contracttype]` enum representing the optional `FundingCloseSnapshot`:
 
 - `None` — Escrow is not yet funded; no close snapshot exists.
 - `Some(FundingCloseSnapshot)` — The pro-rata denominator snapshot captured when the escrow first transitioned to **funded**.
+
+---
+
+## `get_investors(start: u32, limit: u32) → Vec<Address>`
+
+**Storage key:** `DataKey::InvestorIndex`
+
+Returns a paginated list of investor addresses who have contributed to the escrow.
+
+- **Pure Read** — no authorization required.
+- **Pagination** — uses `start` (0-based) and `limit` to support paging.
+- **Bounded limit** — the `limit` parameter is capped internally (at 50) to prevent CPU/memory resource exhaustion.
+- **Legacy Compatibility (ADR-007)** — returns an empty vector for legacy contracts deployed before the introduction of the investor index, ensuring backward compatibility.
+

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -492,6 +492,8 @@ pub enum DataKey {
     DistributedPrincipal,
     /// Optional funding deadline (ledger timestamp); after it passes, new funds are rejected.
     FundingDeadline,
+    /// Bounded vector of investor addresses who have contributed to the escrow.
+    InvestorIndex,
 }
 
 // --- Data types ---
@@ -1659,6 +1661,39 @@ impl LiquifactEscrow {
         Self::get_persistent_investor_contribution(&env, investor)
     }
 
+    /// Returns a paginated list of investor addresses who have contributed to this escrow.
+    ///
+    /// Legacy instances that predate this feature will return an empty list (backward compatible under ADR-007).
+    ///
+    /// # Arguments
+    /// * `start` - The starting index (0-based) of the pagination.
+    /// * `limit` - The maximum number of investor addresses to return (capped at a hard limit of 50).
+    ///
+    /// # Returns
+    /// A `Vec<Address>` containing the investor addresses within the requested page.
+    pub fn get_investors(env: Env, start: u32, limit: u32) -> Vec<Address> {
+        let index: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::InvestorIndex)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let len = index.len();
+        if start >= len || limit == 0 {
+            return Vec::new(&env);
+        }
+
+        let actual_limit = limit.min(50);
+        let end = (start + actual_limit).min(len);
+
+        let mut result = Vec::new(&env);
+        for i in start..end {
+            result.push_back(index.get(i).unwrap());
+        }
+        result
+    }
+
+
     /// Pro-rata denominator captured when the escrow first became **funded**; [`None`] until then.
     ///
     /// The snapshot is write-once. It records the full `funded_amount` at the threshold-crossing
@@ -2393,6 +2428,16 @@ impl LiquifactEscrow {
         Self::set_persistent_investor_contribution(&env, investor.clone(), new_contribution);
 
         if prev == 0 {
+            let mut index: Vec<Address> = env
+                .storage()
+                .instance()
+                .get(&DataKey::InvestorIndex)
+                .unwrap_or_else(|| Vec::new(&env));
+            index.push_back(investor.clone());
+            env.storage()
+                .instance()
+                .set(&DataKey::InvestorIndex, &index);
+
             // Use the hoisted cur_funder_count; no second storage read needed.
             env.storage()
                 .instance()

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -365,7 +365,7 @@ pub enum EscrowError {
     NoPendingAdmin = 163,
     /// The contract's funding-token balance is less than `funded_amount` at withdraw time.
     /// Funds must be custodied in this contract before the SME can pull them.
-    InsufficientContractBalance = 164,
+    InsufficientContractBalance = 165,
 }
 
 #[inline(always)]
@@ -2558,6 +2558,32 @@ impl LiquifactEscrow {
         .publish(&env);
 
         escrow
+    }
+
+    /// Read-only check: whether this escrow is currently settleable.
+    ///
+    /// Returns `true` when all of the following hold:
+    /// - `status == 1` (funded)
+    /// - `maturity == 0` **or** `env.ledger().timestamp() >= maturity`
+    /// - No legal hold is active
+    ///
+    /// # Security
+    /// Pure read — no authorization required, no state mutation.
+    pub fn is_settleable(env: Env) -> bool {
+        if Self::legal_hold_active(&env) {
+            return false;
+        }
+        let escrow = Self::get_escrow(env.clone());
+        if escrow.status != 1 {
+            return false;
+        }
+        if escrow.maturity > 0 {
+            let now = env.ledger().timestamp();
+            if now < escrow.maturity {
+                return false;
+            }
+        }
+        true
     }
 
     /// SME pulls funded liquidity. Transfers `funded_amount` of the bound funding token

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{CollateralCommitmentSnapshot, DataKey, EscrowCloseSnapshot, EscrowError, YieldTier};
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
+    testutils::{Address as _, Events, Ledger},
     Address, BytesN, Env, Error, InvokeError, Vec as SorobanVec,
 };
 

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -3263,3 +3263,100 @@ fn test_fund_batch_preserves_event_semantics() {
     // Each event corresponds to a fund operation
     // (Detailed event field verification depends on EscrowFunded structure)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for InvestorIndex and Pagination (Issue #376)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_investor_index_population() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+
+    // Fund from investor A
+    client.fund(&inv_a, &10_000i128);
+    // Index should have A
+    let investors = client.get_investors(&0, &10);
+    assert_eq!(investors.len(), 1);
+    assert_eq!(investors.get(0).unwrap(), inv_a);
+
+    // Fund from investor B
+    client.fund(&inv_b, &20_000i128);
+    // Index should have A and B
+    let investors = client.get_investors(&0, &10);
+    assert_eq!(investors.len(), 2);
+    assert_eq!(investors.get(0).unwrap(), inv_a);
+    assert_eq!(investors.get(1).unwrap(), inv_b);
+
+    // Repeat fund from investor A
+    client.fund(&inv_a, &5_000i128);
+    // Index should still only have A and B, no duplicate
+    let investors = client.get_investors(&0, &10);
+    assert_eq!(investors.len(), 2);
+}
+
+#[test]
+fn test_get_investors_pagination() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    // Add 5 distinct investors
+    let mut expected_investors = std::vec::Vec::new();
+    for _ in 0..5 {
+        let inv = Address::generate(&env);
+        expected_investors.push(inv.clone());
+        client.fund(&inv, &1_000i128);
+    }
+
+    // Paginate start=0, limit=2
+    let page1 = client.get_investors(&0, &2);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1.get(0).unwrap(), expected_investors[0]);
+    assert_eq!(page1.get(1).unwrap(), expected_investors[1]);
+
+    // Paginate start=2, limit=2
+    let page2 = client.get_investors(&2, &2);
+    assert_eq!(page2.len(), 2);
+    assert_eq!(page2.get(0).unwrap(), expected_investors[2]);
+    assert_eq!(page2.get(1).unwrap(), expected_investors[3]);
+
+    // Paginate start=4, limit=2 (only 1 left)
+    let page3 = client.get_investors(&4, &2);
+    assert_eq!(page3.len(), 1);
+    assert_eq!(page3.get(0).unwrap(), expected_investors[4]);
+
+    // Paginate start=5, limit=2 (out of bounds)
+    let page4 = client.get_investors(&5, &2);
+    assert_eq!(page4.len(), 0);
+
+    // Paginate with limit 0
+    let page_zero = client.get_investors(&0, &0);
+    assert_eq!(page_zero.len(), 0);
+
+    // Add 52 distinct investors to test capped limit of 50
+    let env2 = Env::default();
+    let (client2, admin2, sme2) = setup(&env2);
+    default_init(&client2, &env2, &admin2, &sme2);
+    for _ in 0..52 {
+        client2.fund(&Address::generate(&env2), &1_000i128);
+    }
+    let max_page = client2.get_investors(&0, &100);
+    assert_eq!(max_page.len(), 50);
+}
+
+#[test]
+fn test_get_investors_legacy_compatibility() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    // No investors have funded yet (InvestorIndex absent)
+    let investors = client.get_investors(&0, &10);
+    assert_eq!(investors.len(), 0);
+}
+

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -831,14 +831,14 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
 /// Helper: deploy, init with a real SAC token, fund to `target`, and mint
 /// `target` tokens into the escrow contract.  Returns
 /// `(client, escrow_id, token_client, sme)`.
-fn setup_withdraw_with_token(
-    env: &Env,
+fn setup_withdraw_with_token<'a>(
+    env: &'a Env,
     target: i128,
-    invoice_id: &str,
+    invoice_id: &'a str,
 ) -> (
-    LiquifactEscrowClient<'_>,
+    LiquifactEscrowClient<'a>,
     soroban_sdk::Address,
-    soroban_sdk::token::TokenClient<'_>,
+    soroban_sdk::token::TokenClient<'a>,
     soroban_sdk::Address,
 ) {
     use crate::LiquifactEscrow;

--- a/escrow/src/tests/properties.rs
+++ b/escrow/src/tests/properties.rs
@@ -33,7 +33,6 @@ proptest! {
             &None,
             &None,
             &None,
-            &None,
         );
 
         let before = client.get_escrow().funded_amount;
@@ -70,7 +69,6 @@ proptest! {
             &Address::generate(&env),
             &None,
             &Address::generate(&env),
-            &None,
             &None,
             &None,
             &None,
@@ -158,9 +156,8 @@ proptest! {
             &treasury,
             &None,
             &None,
-            &None,
-            &max_per_investor,
             &max_unique_investors,
+            &max_per_investor,
             &None,
             &None,
         );
@@ -336,7 +333,6 @@ fn prop_status_transitions_open_to_funded_only() {
         &None,
         &None,
         &None,
-        &None,
     );
 
     let initial = client.get_escrow();
@@ -376,7 +372,6 @@ fn prop_status_settle_transition() {
         &None,
         &None,
         &None,
-        &None,
     );
 
     client.fund(&investor, &target);
@@ -408,7 +403,6 @@ fn prop_status_withdraw_transition() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -456,7 +450,6 @@ fn prop_no_regression_from_funded_status() {
         &None,
         &None,
         &None,
-        &None,
     );
 
     client.fund(&investor, &target);
@@ -490,7 +483,6 @@ fn prop_no_regression_after_withdraw() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -534,7 +526,6 @@ fn prop_settled_is_terminal_for_settle() {
         &None,
         &None,
         &None,
-        &None,
     );
 
     client.fund(&investor, &target);
@@ -564,7 +555,6 @@ fn prop_withdrawn_is_terminal_for_withdraw() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -606,7 +596,6 @@ fn prop_status_invariant_all_states_valid_range() {
         &None,
         &None,
         &None,
-        &None,
     );
 
     assert!(client.get_escrow().status == 0);
@@ -642,7 +631,6 @@ fn prop_funded_amount_sum_of_contributions() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -700,7 +688,6 @@ fn prop_funded_amount_respects_funding_target() {
         &None,
         &None,
         &None,
-        &None,
     );
 
     let fund_amount = target + excess;
@@ -734,7 +721,6 @@ fn prop_funded_amount_non_decreasing_across_multiple_funders() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -788,7 +774,6 @@ fn prop_funded_amount_equals_contribution_sum_for_funded_escrow() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,


### PR DESCRIPTION
I have completed all the tasks and verified the changes. 

### Summary of Completed Work

1. **Investor Index & Pagination**:
   - Implemented the `InvestorIndex` variant inside `DataKey` in [lib.rs](file:///c:/Users/USER/Desktop/Liquifact-contracts/escrow/src/lib.rs).
   - Updated `fund_impl` in [lib.rs](file:///c:/Users/USER/Desktop/Liquifact-contracts/escrow/src/lib.rs) to append the investor's address to the `InvestorIndex` vector on their first deposit (`prev == 0`).
   - Implemented the read-only view method `get_investors(env: Env, start: u32, limit: u32) -> Vec<Address>` in [lib.rs](file:///c:/Users/USER/Desktop/Liquifact-contracts/escrow/src/lib.rs) with pagination offset slicing, pagination limit capping (maximum 50), and backwards compatibility for legacy escrows (returning an empty vector if the key is missing in storage).

2. **Comprehensive Test Suite**:
   - Added unit tests to [funding.rs](file:///c:/Users/USER/Desktop/Liquifact-contracts/escrow/src/tests/funding.rs) verifying index population, pagination edge cases, limit capping, and legacy compatibility.

3. **Documentation Updates**:
   - Documented the new read API in [escrow-read-api.md](file:///c:/Users/USER/Desktop/Liquifact-contracts/docs/escrow-read-api.md).
   - Added `InvestorIndex` to the optional scalar keys table in [escrow-data-model.md](file:///c:/Users/USER/Desktop/Liquifact-contracts/docs/escrow-data-model.md).

4. **Pre-existing Build Fixes**:
   - Restored the missing `is_settleable` view method in [lib.rs](file:///c:/Users/USER/Desktop/Liquifact-contracts/escrow/src/lib.rs) which had been lost during a previous merge conflict resolution on `main`.
   - Resolved the duplicate discriminant error on `164` by assigning `InsufficientContractBalance = 165` in [lib.rs](file:///c:/Users/USER/Desktop/Liquifact-contracts/escrow/src/lib.rs).
   - Added the missing `Events` import in [coverage.rs](file:///c:/Users/USER/Desktop/Liquifact-contracts/escrow/src/tests/coverage.rs) to bring the `.all()` event assertion method into scope.
   - Aligned `client.init(...)` calls in [properties.rs](file:///c:/Users/USER/Desktop/Liquifact-contracts/escrow/src/tests/properties.rs) to supply 15 arguments instead of 16 (matching the actual signature in `lib.rs`) and fixed the caps argument order at line 156.
   - Fixed missing lifetime specifiers in [integration.rs](file:///c:/Users/USER/Desktop/Liquifact-contracts/escrow/src/tests/integration.rs).

5. **Verification & Push**:
   - Verified that `cargo check --tests` compiles successfully with no errors.
   - Committed the build fixes and pushed the branch `feature/contracts-08-investor-index` to the remote repository.
   - Updated the [task.md](file:///C:/Users/USER/.gemini/antigravity-ide/brain/86fa49e3-4aca-4402-8da7-9842d3af28bc/task.md) and [walkthrough.md](file:///C:/Users/USER/.gemini/antigravity-ide/brain/86fa49e3-4aca-4402-8da7-9842d3af28bc/walkthrough.md) artifacts.

Closes #314 