### PR TITLE
fix: extend per-investor persistent TTL at write time in fund and claim flows (#321)

### DIFF
--- a/docs/adr/ADR-007-storage-key-evolution.md
+++ b/docs/adr/ADR-007-storage-key-evolution.md
@@ -63,7 +63,7 @@ independent TTL and the contract instance entry does not grow with investor card
 - `DataKey::InvestorClaimed(Address)`
 
 Read/write semantics are unchanged: absent keys still default to `0`, base `yield_bps`, `0`, and
-`false` respectively. See `docs/escrow-gas-storage-notes.md` for TTL extension via
+`false` respectively. Per-investor persistent keys have their TTL extended at write time using `PERSISTENT_TTL_MIN_EXTENSION_LEDGERS`. See `docs/escrow-gas-storage-notes.md` for additional TTL extension via
 [`LiquifactEscrow::bump_ttl`](../../escrow/src/lib.rs).
 
 **Migration:** relocating storage type is not enumerable on-chain (no iteration over instance keys

--- a/docs/escrow-gas-storage-notes.md
+++ b/docs/escrow-gas-storage-notes.md
@@ -58,6 +58,10 @@ If instance storage expires and is not extended, `AllowlistActive` returns `fals
 `unwrap_or`), silently disabling the allowlist gate even if persistent allowlist entries remain.
 Operators must extend instance storage TTL together with persistent storage TTL.
 
+### Write-time TTL extension for persistent keys
+
+Per-investor persistent keys (`InvestorContribution`, `InvestorEffectiveYield`, `InvestorClaimNotBefore`, `InvestorClaimed`) are automatically extended at write time inside the fund and claim flows using the `PERSISTENT_TTL_MIN_EXTENSION_LEDGERS` horizon. This provides defense-in-depth against silent expiry of live positions prior to settlement.
+
 ### Permissionless TTL extension
 
 The contract includes a permissionless `bump_ttl` entrypoint that extends TTLs for:

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1611,9 +1611,13 @@ impl LiquifactEscrow {
     }
 
     fn set_persistent_investor_contribution(env: &Env, investor: Address, amount: i128) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::InvestorContribution(investor), &amount);
+        let key = DataKey::InvestorContribution(investor);
+        env.storage().persistent().set(&key, &amount);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+        );
     }
 
     fn get_persistent_investor_effective_yield(env: &Env, investor: Address) -> Option<i64> {
@@ -1623,9 +1627,13 @@ impl LiquifactEscrow {
     }
 
     fn set_persistent_investor_effective_yield(env: &Env, investor: Address, value: i64) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::InvestorEffectiveYield(investor), &value);
+        let key = DataKey::InvestorEffectiveYield(investor);
+        env.storage().persistent().set(&key, &value);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+        );
     }
 
     fn get_persistent_investor_claim_not_before(env: &Env, investor: Address) -> u64 {
@@ -1636,9 +1644,13 @@ impl LiquifactEscrow {
     }
 
     fn set_persistent_investor_claim_not_before(env: &Env, investor: Address, value: u64) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::InvestorClaimNotBefore(investor), &value);
+        let key = DataKey::InvestorClaimNotBefore(investor);
+        env.storage().persistent().set(&key, &value);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+        );
     }
 
     fn get_persistent_investor_claimed(env: &Env, investor: Address) -> bool {
@@ -1649,9 +1661,13 @@ impl LiquifactEscrow {
     }
 
     fn set_persistent_investor_claimed(env: &Env, investor: Address, value: bool) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::InvestorClaimed(investor), &value);
+        let key = DataKey::InvestorClaimed(investor);
+        env.storage().persistent().set(&key, &value);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+            PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+        );
     }
 
     /// Public API: contribution recorded for `investor` (persistent storage).
@@ -2201,11 +2217,7 @@ impl LiquifactEscrow {
         let n = entries.len();
 
         ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
-        ensure(
-            &env,
-            n <= MAX_FUND_BATCH,
-            EscrowError::FundingBatchTooLarge,
-        );
+        ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
 
         let mut escrow = Self::get_escrow(env.clone());
 

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -777,8 +777,7 @@ fn test_update_funding_target_fails_when_settled() {
 fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
     client.withdraw(); // status → 3 (withdrawn)
     client.update_funding_target(&6_000i128);
 }
@@ -984,8 +983,7 @@ fn test_update_maturity_fails_when_settled() {
 fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
     client.withdraw(); // status → 3
     client.update_maturity(&2000u64);
 }

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -581,10 +581,7 @@ fn test_get_funding_token_before_init_fails_with_typed_error() {
 fn test_get_treasury_before_init_fails_with_typed_error() {
     let env = Env::default();
     let client = deploy(&env);
-    assert_contract_error(
-        client.try_get_treasury(),
-        EscrowError::TreasuryNotSet,
-    );
+    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
 }
 
 #[test]

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -890,12 +890,14 @@ fn withdraw_transfers_funded_amount_to_sme() {
     env.mock_all_auths();
 
     let target = 50_000_000i128;
-    let (client, escrow_id, token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_BAL001");
+    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
 
     let sme_before = token.balance(&sme);
     let contract_before = token.balance(&escrow_id);
-    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
+    assert_eq!(
+        contract_before, target,
+        "escrow must hold exactly funded_amount before withdraw"
+    );
 
     client.withdraw();
 
@@ -911,7 +913,11 @@ fn withdraw_transfers_funded_amount_to_sme() {
         contract_after, 0,
         "escrow contract balance must be zero after disbursement"
     );
-    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
+    assert_eq!(
+        client.get_escrow().status,
+        3u32,
+        "status must be 3 after withdraw"
+    );
 }
 
 /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
@@ -921,8 +927,7 @@ fn withdraw_updates_distributed_principal() {
     env.mock_all_auths();
 
     let target = 20_000_000i128;
-    let (client, _escrow_id, _token, _sme) =
-        setup_withdraw_with_token(&env, target, "WD_DP001");
+    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
 
     client.withdraw();
 
@@ -1058,8 +1063,7 @@ fn withdraw_event_includes_recipient() {
     env.mock_all_auths();
 
     let target = 5_000_000i128;
-    let (client, escrow_id, _token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_EV001");
+    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
 
     client.withdraw();
 
@@ -1074,9 +1078,9 @@ fn withdraw_event_includes_recipient() {
     .to_xdr(&env, &escrow_id);
 
     let all_events = env.events().all().filter_by_contract(&escrow_id);
-    let found = all_events
-        .events()
-        .iter()
-        .any(|e| *e == expected_xdr);
-    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
+    let found = all_events.events().iter().any(|e| *e == expected_xdr);
+    assert!(
+        found,
+        "SmeWithdrew event with correct recipient and amount must be emitted"
+    );
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -45,7 +45,11 @@ fn fund_to_target(client: &super::LiquifactEscrowClient<'_>, env: &Env) -> Addre
 /// actually transfer them.  Returns `(client, sme, sac_admin_client)`.
 fn setup_funded_with_token<'a>(
     env: &'a Env,
-) -> (super::LiquifactEscrowClient<'a>, Address, StellarAssetClient<'a>) {
+) -> (
+    super::LiquifactEscrowClient<'a>,
+    Address,
+    StellarAssetClient<'a>,
+) {
     let sac = env.register_stellar_asset_contract_v2(Address::generate(env));
     let token_id = sac.address();
     let sac_admin = StellarAssetClient::new(env, &token_id);


### PR DESCRIPTION
## Description
This PR hardens per-investor persistent entries against TTL expiry by extending their TTL at write time. Previously, `fund_impl` and `claim_investor_payout` wrote per-investor persistent keys but relied entirely on the permissionless `bump_ttl` entrypoint to keep them alive. This update extends the TTL inside the funding and claim paths using the existing `PERSISTENT_TTL_MIN_EXTENSION_LEDGERS` horizon.

## Changes
- Modified per-investor setters in `escrow/src/lib.rs` (`set_persistent_investor_contribution`, `set_persistent_investor_effective_yield`, `set_persistent_investor_claim_not_before`, `set_persistent_investor_claimed`) to call `env.storage().persistent().extend_ttl(...)` using the `PERSISTENT_TTL_MIN_EXTENSION_LEDGERS` constant immediately after writing.
- Formatted the codebase using `cargo fmt`.
- Updated `docs/escrow-gas-storage-notes.md` to reflect the new write-time TTL extension for persistent keys.
- Updated `docs/adr/ADR-007-storage-key-evolution.md` to mention write-time extension for per-investor keys.

## Security Notes
- No TTLs are shortened (`extend_ttl` is monotonic).
- The permissionless `bump_ttl` entrypoint is kept intact, providing defense-in-depth.
- Live positions in long-dated escrows are now protected from premature archival without requiring external crons or manual bumps.

Closes #321
