### PR TITLE
feat: persist settlement timestamp and expose get_settled_at

### DIFF
--- a/ci_logs.txt
+++ b/ci_logs.txt
@@ -1,0 +1,529 @@
+﻿2026-06-25T09:33:54.6890637Z Current runner version: '2.335.1'
+2026-06-25T09:33:54.6914411Z ##[group]Runner Image Provisioner
+2026-06-25T09:33:54.6915323Z Hosted Compute Agent
+2026-06-25T09:33:54.6915983Z Version: 20260611.554
+2026-06-25T09:33:54.6916634Z Commit: 5e0782fdc9014723d3be820dd114dd31555c2bd1
+2026-06-25T09:33:54.6917342Z Build Date: 2026-06-11T21:40:46Z
+2026-06-25T09:33:54.6918094Z Worker ID: {f06ce407-a32c-45c0-a4d7-173dc9a0efa0}
+2026-06-25T09:33:54.6918849Z Azure Region: westcentralus
+2026-06-25T09:33:54.6919483Z ##[endgroup]
+2026-06-25T09:33:54.6920984Z ##[group]Operating System
+2026-06-25T09:33:54.6921850Z Ubuntu
+2026-06-25T09:33:54.6922454Z 24.04.4
+2026-06-25T09:33:54.6922984Z LTS
+2026-06-25T09:33:54.6923533Z ##[endgroup]
+2026-06-25T09:33:54.6924089Z ##[group]Runner Image
+2026-06-25T09:33:54.6924680Z Image: ubuntu-24.04
+2026-06-25T09:33:54.6925285Z Version: 20260622.220.1
+2026-06-25T09:33:54.6926554Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260622.220/images/ubuntu/Ubuntu2404-Readme.md
+2026-06-25T09:33:54.6928112Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260622.220
+2026-06-25T09:33:54.6929062Z ##[endgroup]
+2026-06-25T09:33:54.6930301Z ##[group]GITHUB_TOKEN Permissions
+2026-06-25T09:33:54.6932403Z Contents: read
+2026-06-25T09:33:54.6933086Z Metadata: read
+2026-06-25T09:33:54.6933655Z Packages: read
+2026-06-25T09:33:54.6934203Z ##[endgroup]
+2026-06-25T09:33:54.6936274Z Secret source: None
+2026-06-25T09:33:54.6936993Z Prepare workflow directory
+2026-06-25T09:33:54.7264719Z Prepare all required actions
+2026-06-25T09:33:54.7302699Z Getting action download info
+2026-06-25T09:33:55.1079906Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2026-06-25T09:33:55.1872377Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+2026-06-25T09:33:55.4064326Z Download action repository 'Swatinem/rust-cache@v2' (SHA:e18b497796c12c097a38f9edb9d0641fb99eee32)
+2026-06-25T09:33:56.3967851Z Download action repository 'taiki-e/install-action@cargo-llvm-cov' (SHA:901c6c5742b8b5bab0a7cf0bf63286ad5e3120f3)
+2026-06-25T09:33:57.3531796Z Complete job name: fmt-build-test
+2026-06-25T09:33:57.4273351Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-06-25T09:33:57.4282460Z ##[group]Run actions/checkout@v4
+2026-06-25T09:33:57.4283484Z with:
+2026-06-25T09:33:57.4284078Z   repository: Liquifact/Liquifact-contracts
+2026-06-25T09:33:57.4288087Z   token: ***
+2026-06-25T09:33:57.4288442Z   ssh-strict: true
+2026-06-25T09:33:57.4288786Z   ssh-user: git
+2026-06-25T09:33:57.4289147Z   persist-credentials: true
+2026-06-25T09:33:57.4289705Z   clean: true
+2026-06-25T09:33:57.4290312Z   sparse-checkout-cone-mode: true
+2026-06-25T09:33:57.4290860Z   fetch-depth: 1
+2026-06-25T09:33:57.4291415Z   fetch-tags: false
+2026-06-25T09:33:57.4291797Z   show-progress: true
+2026-06-25T09:33:57.4292162Z   lfs: false
+2026-06-25T09:33:57.4292520Z   submodules: false
+2026-06-25T09:33:57.4292874Z   set-safe-directory: true
+2026-06-25T09:33:57.4293625Z ##[endgroup]
+2026-06-25T09:33:57.5336504Z Syncing repository: Liquifact/Liquifact-contracts
+2026-06-25T09:33:57.5338058Z ##[group]Getting Git version info
+2026-06-25T09:33:57.5338704Z Working directory is '/home/runner/work/Liquifact-contracts/Liquifact-contracts'
+2026-06-25T09:33:57.5339854Z [command]/usr/bin/git version
+2026-06-25T09:33:57.5382067Z git version 2.54.0
+2026-06-25T09:33:57.5434367Z ##[endgroup]
+2026-06-25T09:33:57.5447750Z Temporarily overriding HOME='/home/runner/work/_temp/4d2cb77e-ac2c-445c-9a68-d5f7387d1015' before making global git config changes
+2026-06-25T09:33:57.5449055Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-25T09:33:57.5453719Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:33:57.5495496Z Deleting the contents of '/home/runner/work/Liquifact-contracts/Liquifact-contracts'
+2026-06-25T09:33:57.5499496Z ##[group]Initializing the repository
+2026-06-25T09:33:57.5504170Z [command]/usr/bin/git init /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:33:57.5636703Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-06-25T09:33:57.5638041Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-06-25T09:33:57.5638855Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-06-25T09:33:57.5639482Z hint: call:
+2026-06-25T09:33:57.5639826Z hint:
+2026-06-25T09:33:57.5640268Z hint: 	git config --global init.defaultBranch <name>
+2026-06-25T09:33:57.5640965Z hint:
+2026-06-25T09:33:57.5642070Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-06-25T09:33:57.5643473Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-06-25T09:33:57.5644634Z hint:
+2026-06-25T09:33:57.5645400Z hint: 	git branch -m <name>
+2026-06-25T09:33:57.5646157Z hint:
+2026-06-25T09:33:57.5647137Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-06-25T09:33:57.5648852Z Initialized empty Git repository in /home/runner/work/Liquifact-contracts/Liquifact-contracts/.git/
+2026-06-25T09:33:57.5654679Z [command]/usr/bin/git remote add origin https://github.com/Liquifact/Liquifact-contracts
+2026-06-25T09:33:57.5694335Z ##[endgroup]
+2026-06-25T09:33:57.5694961Z ##[group]Disabling automatic garbage collection
+2026-06-25T09:33:57.5699275Z [command]/usr/bin/git config --local gc.auto 0
+2026-06-25T09:33:57.5726107Z ##[endgroup]
+2026-06-25T09:33:57.5726682Z ##[group]Setting up auth
+2026-06-25T09:33:57.5734013Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-25T09:33:57.5765643Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-25T09:33:57.6077267Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-06-25T09:33:57.6107487Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-06-25T09:33:57.6320826Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-06-25T09:33:57.6350895Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-06-25T09:33:57.6565628Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-06-25T09:33:57.6632274Z ##[endgroup]
+2026-06-25T09:33:57.6633806Z ##[group]Fetching the repository
+2026-06-25T09:33:57.6636031Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +40c0d2d52927ae9dc3ec04815413e6ee324cc084:refs/remotes/pull/427/merge
+2026-06-25T09:33:58.5493742Z From https://github.com/Liquifact/Liquifact-contracts
+2026-06-25T09:33:58.5495063Z  * [new ref]         40c0d2d52927ae9dc3ec04815413e6ee324cc084 -> pull/427/merge
+2026-06-25T09:33:58.5542771Z ##[endgroup]
+2026-06-25T09:33:58.5543460Z ##[group]Determining the checkout info
+2026-06-25T09:33:58.5544938Z ##[endgroup]
+2026-06-25T09:33:58.5550742Z [command]/usr/bin/git sparse-checkout disable
+2026-06-25T09:33:58.5594242Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-06-25T09:33:58.5621554Z ##[group]Checking out the ref
+2026-06-25T09:33:58.5625325Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/427/merge
+2026-06-25T09:33:58.6022707Z Note: switching to 'refs/remotes/pull/427/merge'.
+2026-06-25T09:33:58.6023793Z 
+2026-06-25T09:33:58.6024913Z You are in 'detached HEAD' state. You can look around, make experimental
+2026-06-25T09:33:58.6026186Z changes and commit them, and you can discard any commits you make in this
+2026-06-25T09:33:58.6028118Z state without impacting any branches by switching back to a branch.
+2026-06-25T09:33:58.6028866Z 
+2026-06-25T09:33:58.6029468Z If you want to create a new branch to retain commits you create, you may
+2026-06-25T09:33:58.6030359Z do so (now or later) by using -c with the switch command. Example:
+2026-06-25T09:33:58.6030917Z 
+2026-06-25T09:33:58.6031397Z   git switch -c <new-branch-name>
+2026-06-25T09:33:58.6031773Z 
+2026-06-25T09:33:58.6031990Z Or undo this operation with:
+2026-06-25T09:33:58.6033452Z 
+2026-06-25T09:33:58.6033671Z   git switch -
+2026-06-25T09:33:58.6033949Z 
+2026-06-25T09:33:58.6034936Z Turn off this advice by setting config variable advice.detachedHead to false
+2026-06-25T09:33:58.6035576Z 
+2026-06-25T09:33:58.6036321Z HEAD is now at 40c0d2d Merge 0d34f9ce066a273deb547ace0217d9f11c5af21f into f3c49bc43a4afd486efc2e2beb59bd144adb5029
+2026-06-25T09:33:58.6039029Z ##[endgroup]
+2026-06-25T09:33:58.6071740Z [command]/usr/bin/git log -1 --format=%H
+2026-06-25T09:33:58.6095464Z 40c0d2d52927ae9dc3ec04815413e6ee324cc084
+2026-06-25T09:33:58.6436258Z ##[group]Run dtolnay/rust-toolchain@stable
+2026-06-25T09:33:58.6436595Z with:
+2026-06-25T09:33:58.6436853Z   components: rustfmt, clippy, llvm-tools-preview
+2026-06-25T09:33:58.6437176Z   toolchain: stable
+2026-06-25T09:33:58.6437395Z ##[endgroup]
+2026-06-25T09:33:58.6559105Z ##[group]Run : parse toolchain version
+2026-06-25T09:33:58.6559481Z [36;1m: parse toolchain version[0m
+2026-06-25T09:33:58.6559781Z [36;1mif [[ -z $toolchain ]]; then[0m
+2026-06-25T09:33:58.6560323Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+2026-06-25T09:33:58.6560924Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+2026-06-25T09:33:58.6561438Z [36;1m  exit 1[0m
+2026-06-25T09:33:58.6561818Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+2026-06-25T09:33:58.6562249Z [36;1m  if [[ Linux == macOS ]]; then[0m
+2026-06-25T09:33:58.6562828Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:33:58.6563350Z [36;1m  else[0m
+2026-06-25T09:33:58.6563760Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:33:58.6564223Z [36;1m  fi[0m
+2026-06-25T09:33:58.6564538Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+2026-06-25T09:33:58.6565078Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:33:58.6565551Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+2026-06-25T09:33:58.6566086Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:33:58.6566595Z [36;1melse[0m
+2026-06-25T09:33:58.6566858Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:33:58.6567161Z [36;1mfi[0m
+2026-06-25T09:33:58.6716478Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:33:58.6716883Z env:
+2026-06-25T09:33:58.6717105Z   toolchain: stable
+2026-06-25T09:33:58.6717349Z ##[endgroup]
+2026-06-25T09:33:58.6860094Z ##[group]Run : construct rustup command line
+2026-06-25T09:33:58.6860442Z [36;1m: construct rustup command line[0m
+2026-06-25T09:33:58.6860922Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:33:58.6861962Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:33:58.6862467Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:33:58.6889958Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:33:58.6890316Z env:
+2026-06-25T09:33:58.6890507Z   targets: 
+2026-06-25T09:33:58.6890755Z   components: rustfmt, clippy, llvm-tools-preview
+2026-06-25T09:33:58.6891499Z ##[endgroup]
+2026-06-25T09:33:58.6975854Z ##[group]Run : set $CARGO_HOME
+2026-06-25T09:33:58.6976131Z [36;1m: set $CARGO_HOME[0m
+2026-06-25T09:33:58.6976461Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+2026-06-25T09:33:58.7003721Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:33:58.7004157Z ##[endgroup]
+2026-06-25T09:33:58.7087110Z ##[group]Run : install rustup if needed
+2026-06-25T09:33:58.7087430Z [36;1m: install rustup if needed[0m
+2026-06-25T09:33:58.7087738Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+2026-06-25T09:33:58.7088520Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+2026-06-25T09:33:58.7089300Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+2026-06-25T09:33:58.7089596Z [36;1mfi[0m
+2026-06-25T09:33:58.7116872Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:33:58.7117229Z env:
+2026-06-25T09:33:58.7117618Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:33:58.7117894Z ##[endgroup]
+2026-06-25T09:33:58.7202329Z ##[group]Run rustup toolchain install stable --component rustfmt --component clippy --component llvm-tools-preview --profile minimal --no-self-update
+2026-06-25T09:33:58.7203403Z [36;1mrustup toolchain install stable --component rustfmt --component clippy --component llvm-tools-preview --profile minimal --no-self-update[0m
+2026-06-25T09:33:58.7230463Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:33:58.7230814Z env:
+2026-06-25T09:33:58.7231157Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:33:58.7231625Z   RUSTUP_PERMIT_COPY_RENAME: 1
+2026-06-25T09:33:58.7231882Z ##[endgroup]
+2026-06-25T09:33:58.9483951Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+2026-06-25T09:33:59.2421638Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T09:33:59.2741704Z info: component clippy is up to date
+2026-06-25T09:33:59.2742536Z info: component rustfmt is up to date
+2026-06-25T09:33:59.2752351Z info: downloading component llvm-tools
+2026-06-25T09:34:02.3177952Z 
+2026-06-25T09:34:02.3287989Z   stable-x86_64-unknown-linux-gnu updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.96.0 (ac68faa20 2026-05-25))
+2026-06-25T09:34:02.3289427Z 
+2026-06-25T09:34:02.3422384Z ##[group]Run rustup default stable
+2026-06-25T09:34:02.3422714Z [36;1mrustup default stable[0m
+2026-06-25T09:34:02.3461235Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:34:02.3461671Z env:
+2026-06-25T09:34:02.3461893Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:34:02.3462178Z ##[endgroup]
+2026-06-25T09:34:02.3560963Z info: using existing install for stable-x86_64-unknown-linux-gnu
+2026-06-25T09:34:02.3567671Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+2026-06-25T09:34:02.3568021Z 
+2026-06-25T09:34:02.3644161Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T09:34:02.3644843Z 
+2026-06-25T09:34:02.3678327Z ##[group]Run : create cachekey
+2026-06-25T09:34:02.3678655Z [36;1m: create cachekey[0m
+2026-06-25T09:34:02.3679187Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+2026-06-25T09:34:02.3679869Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+2026-06-25T09:34:02.3680423Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:34:02.3709279Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:34:02.3709647Z env:
+2026-06-25T09:34:02.3709864Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:34:02.3710132Z ##[endgroup]
+2026-06-25T09:34:02.4859588Z ##[group]Run : disable incremental compilation
+2026-06-25T09:34:02.4859983Z [36;1m: disable incremental compilation[0m
+2026-06-25T09:34:02.4860324Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+2026-06-25T09:34:02.4860696Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+2026-06-25T09:34:02.4861004Z [36;1mfi[0m
+2026-06-25T09:34:02.4891899Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:34:02.4892311Z env:
+2026-06-25T09:34:02.4892557Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:34:02.4892841Z ##[endgroup]
+2026-06-25T09:34:02.4960707Z ##[group]Run : enable colors in Cargo output
+2026-06-25T09:34:02.4961361Z [36;1m: enable colors in Cargo output[0m
+2026-06-25T09:34:02.4961751Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+2026-06-25T09:34:02.4962109Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+2026-06-25T09:34:02.4962428Z [36;1mfi[0m
+2026-06-25T09:34:02.4989276Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:34:02.4989657Z env:
+2026-06-25T09:34:02.4989864Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:34:02.4990134Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:34:02.4990359Z ##[endgroup]
+2026-06-25T09:34:02.5057823Z ##[group]Run : enable Cargo sparse registry
+2026-06-25T09:34:02.5058314Z [36;1m: enable Cargo sparse registry[0m
+2026-06-25T09:34:02.5058700Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+2026-06-25T09:34:02.5059446Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+2026-06-25T09:34:02.5060200Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+2026-06-25T09:34:02.5060789Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-06-25T09:34:02.5061537Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+2026-06-25T09:34:02.5062050Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+2026-06-25T09:34:02.5062635Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-06-25T09:34:02.5063196Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+2026-06-25T09:34:02.5063558Z [36;1m  fi[0m
+2026-06-25T09:34:02.5063761Z [36;1mfi[0m
+2026-06-25T09:34:02.5090662Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:34:02.5091185Z env:
+2026-06-25T09:34:02.5091403Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:34:02.5091689Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:34:02.5091922Z   CARGO_TERM_COLOR: always
+2026-06-25T09:34:02.5092170Z ##[endgroup]
+2026-06-25T09:34:02.5427125Z ##[group]Run : work around spurious network errors in curl 8.0
+2026-06-25T09:34:02.5427574Z [36;1m: work around spurious network errors in curl 8.0[0m
+2026-06-25T09:34:02.5428163Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+2026-06-25T09:34:02.5428817Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+2026-06-25T09:34:02.5429289Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+2026-06-25T09:34:02.5429617Z [36;1mfi[0m
+2026-06-25T09:34:02.5460379Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:34:02.5460736Z env:
+2026-06-25T09:34:02.5460946Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:34:02.5461866Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:34:02.5462110Z   CARGO_TERM_COLOR: always
+2026-06-25T09:34:02.5462370Z ##[endgroup]
+2026-06-25T09:34:02.5684406Z ##[group]Run rustc +stable --version --verbose
+2026-06-25T09:34:02.5685050Z [36;1mrustc +stable --version --verbose[0m
+2026-06-25T09:34:02.5728300Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:34:02.5728924Z env:
+2026-06-25T09:34:02.5729268Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:34:02.5729753Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:34:02.5730170Z   CARGO_TERM_COLOR: always
+2026-06-25T09:34:02.5730811Z ##[endgroup]
+2026-06-25T09:34:02.5915146Z rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T09:34:02.5916095Z binary: rustc
+2026-06-25T09:34:02.5917109Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T09:34:02.5918081Z commit-date: 2026-05-25
+2026-06-25T09:34:02.5918995Z host: x86_64-unknown-linux-gnu
+2026-06-25T09:34:02.5919819Z release: 1.96.0
+2026-06-25T09:34:02.5920242Z LLVM version: 22.1.2
+2026-06-25T09:34:02.6044588Z ##[group]Run Swatinem/rust-cache@v2
+2026-06-25T09:34:02.6044908Z with:
+2026-06-25T09:34:02.6045113Z   prefix-key: v0-rust
+2026-06-25T09:34:02.6045353Z   add-job-id-key: true
+2026-06-25T09:34:02.6045599Z   add-rust-environment-hash-key: true
+2026-06-25T09:34:02.6045885Z   cache-targets: true
+2026-06-25T09:34:02.6046111Z   cache-all-crates: false
+2026-06-25T09:34:02.6046358Z   cache-workspace-crates: false
+2026-06-25T09:34:02.6046606Z   save-if: true
+2026-06-25T09:34:02.6046815Z   cache-provider: github
+2026-06-25T09:34:02.6047044Z   cache-bin: true
+2026-06-25T09:34:02.6047348Z   lookup-only: false
+2026-06-25T09:34:02.6047761Z   cmd-format: {0}
+2026-06-25T09:34:02.6048053Z env:
+2026-06-25T09:34:02.6048380Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:34:02.6048823Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:34:02.6049122Z   CARGO_TERM_COLOR: always
+2026-06-25T09:34:02.6049505Z ##[endgroup]
+2026-06-25T09:34:02.8852027Z (node:2441) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+2026-06-25T09:34:02.8853459Z (Use `node --trace-deprecation ...` to show where the warning was created)
+2026-06-25T09:34:04.8741036Z ##[group]Cache Configuration
+2026-06-25T09:34:04.8742197Z Cache Provider:
+2026-06-25T09:34:04.8742892Z     github
+2026-06-25T09:34:04.8743464Z Workspaces:
+2026-06-25T09:34:04.8744183Z     /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:34:04.8745019Z Cache Paths:
+2026-06-25T09:34:04.8745634Z     /home/runner/.cargo/bin
+2026-06-25T09:34:04.8746318Z     /home/runner/.cargo/.crates.toml
+2026-06-25T09:34:04.8747008Z     /home/runner/.cargo/.crates2.json
+2026-06-25T09:34:04.8747696Z     /home/runner/.cargo/registry
+2026-06-25T09:34:04.8748378Z     /home/runner/.cargo/git
+2026-06-25T09:34:04.8749243Z     /home/runner/work/Liquifact-contracts/Liquifact-contracts/target
+2026-06-25T09:34:04.8750204Z Restore Key:
+2026-06-25T09:34:04.8750859Z     v0-rust-fmt-build-test-Linux-x64-4107bf91
+2026-06-25T09:34:04.8751997Z Cache Key:
+2026-06-25T09:34:04.8752682Z     v0-rust-fmt-build-test-Linux-x64-4107bf91-e1b782ec
+2026-06-25T09:34:04.8753491Z .. Prefix:
+2026-06-25T09:34:04.8754024Z   - v0-rust-fmt-build-test-Linux-x64
+2026-06-25T09:34:04.8754638Z .. Environment considered:
+2026-06-25T09:34:04.8755161Z   - Rust Versions:
+2026-06-25T09:34:04.8755943Z     - 1.96.0 x86_64-unknown-linux-gnu ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T09:34:04.8757150Z     - 1.96.0 x86_64-unknown-linux-gnu ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T09:34:04.8758307Z   - CARGO_HOME
+2026-06-25T09:34:04.8758896Z   - CARGO_INCREMENTAL
+2026-06-25T09:34:04.8759494Z   - CARGO_TERM_COLOR
+2026-06-25T09:34:04.8760293Z .. Lockfiles considered:
+2026-06-25T09:34:04.8761466Z   - /home/runner/work/Liquifact-contracts/Liquifact-contracts/Cargo.lock
+2026-06-25T09:34:04.8762976Z   - /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/Cargo.toml
+2026-06-25T09:34:04.8764372Z ##[endgroup]
+2026-06-25T09:34:04.8764871Z 
+2026-06-25T09:34:04.8765242Z ... Restoring cache ...
+2026-06-25T09:34:05.0794067Z No cache found.
+2026-06-25T09:34:05.0909565Z ##[group]Run cargo fmt -p liquifact_escrow -- --check
+2026-06-25T09:34:05.0910004Z [36;1mcargo fmt -p liquifact_escrow -- --check[0m
+2026-06-25T09:34:05.0943411Z shell: /usr/bin/bash -e {0}
+2026-06-25T09:34:05.0943670Z env:
+2026-06-25T09:34:05.0943880Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:34:05.0944156Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:34:05.0944390Z   CARGO_TERM_COLOR: always
+2026-06-25T09:34:05.0944624Z   CACHE_ON_FAILURE: false
+2026-06-25T09:34:05.0945026Z ##[endgroup]
+2026-06-25T09:34:07.2407402Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/lib.rs:2220:
+2026-06-25T09:34:07.2408472Z          let n = entries.len();
+2026-06-25T09:34:07.2408972Z  
+2026-06-25T09:34:07.2414269Z          ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
+2026-06-25T09:34:07.2414716Z -        ensure(
+2026-06-25T09:34:07.2414981Z -            &env,
+2026-06-25T09:34:07.2415249Z -            n <= MAX_FUND_BATCH,
+2026-06-25T09:34:07.2415667Z -            EscrowError::FundingBatchTooLarge,
+2026-06-25T09:34:07.2416037Z -        );
+2026-06-25T09:34:07.2416422Z +        ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
+2026-06-25T09:34:07.2416896Z  
+2026-06-25T09:34:07.2417181Z          let mut escrow = Self::get_escrow(env.clone());
+2026-06-25T09:34:07.2417561Z  
+2026-06-25T09:34:07.2534946Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:777:
+2026-06-25T09:34:07.2536100Z  fn test_update_funding_target_fails_when_withdrawn() {
+2026-06-25T09:34:07.2536787Z      let env = Env::default();
+2026-06-25T09:34:07.2537273Z      env.mock_all_auths();
+2026-06-25T09:34:07.2537748Z -    let (client, _escrow_id, _sme) =
+2026-06-25T09:34:07.2538395Z -        init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+2026-06-25T09:34:07.2539178Z +    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+2026-06-25T09:34:07.2539999Z      client.withdraw(); // status → 3 (withdrawn)
+2026-06-25T09:34:07.2540446Z      client.update_funding_target(&6_000i128);
+2026-06-25T09:34:07.2540818Z  }
+2026-06-25T09:34:07.2541529Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:984:
+2026-06-25T09:34:07.2542216Z  fn test_update_maturity_fails_when_withdrawn() {
+2026-06-25T09:34:07.2542619Z      let env = Env::default();
+2026-06-25T09:34:07.2542927Z      env.mock_all_auths();
+2026-06-25T09:34:07.2543231Z -    let (client, _escrow_id, _sme) =
+2026-06-25T09:34:07.2543664Z -        init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+2026-06-25T09:34:07.2544286Z +    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+2026-06-25T09:34:07.2544896Z      client.withdraw(); // status → 3
+2026-06-25T09:34:07.2545247Z      client.update_maturity(&2000u64);
+2026-06-25T09:34:07.2545569Z  }
+2026-06-25T09:34:07.3072104Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:581:
+2026-06-25T09:34:07.3073481Z  fn test_get_treasury_before_init_fails_with_typed_error() {
+2026-06-25T09:34:07.3074279Z      let env = Env::default();
+2026-06-25T09:34:07.3074832Z      let client = deploy(&env);
+2026-06-25T09:34:07.3075392Z -    assert_contract_error(
+2026-06-25T09:34:07.3075941Z -        client.try_get_treasury(),
+2026-06-25T09:34:07.3076575Z -        EscrowError::TreasuryNotSet,
+2026-06-25T09:34:07.3076975Z -    );
+2026-06-25T09:34:07.3077487Z +    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
+2026-06-25T09:34:07.3078127Z  }
+2026-06-25T09:34:07.3078378Z  
+2026-06-25T09:34:07.3078623Z  #[test]
+2026-06-25T09:34:07.3121905Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:890:
+2026-06-25T09:34:07.3123118Z      env.mock_all_auths();
+2026-06-25T09:34:07.3123586Z  
+2026-06-25T09:34:07.3123961Z      let target = 50_000_000i128;
+2026-06-25T09:34:07.3124520Z -    let (client, escrow_id, token, sme) =
+2026-06-25T09:34:07.3125660Z -        setup_withdraw_with_token(&env, target, "WD_BAL001");
+2026-06-25T09:34:07.3126719Z +    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
+2026-06-25T09:34:07.3127631Z  
+2026-06-25T09:34:07.3128039Z      let sme_before = token.balance(&sme);
+2026-06-25T09:34:07.3128738Z      let contract_before = token.balance(&escrow_id);
+2026-06-25T09:34:07.3129465Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:898:
+2026-06-25T09:34:07.3130581Z -    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
+2026-06-25T09:34:07.3131398Z +    assert_eq!(
+2026-06-25T09:34:07.3131680Z +        contract_before, target,
+2026-06-25T09:34:07.3132094Z +        "escrow must hold exactly funded_amount before withdraw"
+2026-06-25T09:34:07.3132526Z +    );
+2026-06-25T09:34:07.3132782Z  
+2026-06-25T09:34:07.3133079Z      client.withdraw();
+2026-06-25T09:34:07.3133366Z  
+2026-06-25T09:34:07.3133919Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:911:
+2026-06-25T09:34:07.3134594Z          contract_after, 0,
+2026-06-25T09:34:07.3134989Z          "escrow contract balance must be zero after disbursement"
+2026-06-25T09:34:07.3135414Z      );
+2026-06-25T09:34:07.3135826Z -    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
+2026-06-25T09:34:07.3136354Z +    assert_eq!(
+2026-06-25T09:34:07.3136618Z +        client.get_escrow().status,
+2026-06-25T09:34:07.3136947Z +        3u32,
+2026-06-25T09:34:07.3137212Z +        "status must be 3 after withdraw"
+2026-06-25T09:34:07.3137544Z +    );
+2026-06-25T09:34:07.3137759Z  }
+2026-06-25T09:34:07.3137970Z  
+2026-06-25T09:34:07.3138319Z  /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
+2026-06-25T09:34:07.3139102Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:921:
+2026-06-25T09:34:07.3139766Z      env.mock_all_auths();
+2026-06-25T09:34:07.3140050Z  
+2026-06-25T09:34:07.3140271Z      let target = 20_000_000i128;
+2026-06-25T09:34:07.3140614Z -    let (client, _escrow_id, _token, _sme) =
+2026-06-25T09:34:07.3141168Z -        setup_withdraw_with_token(&env, target, "WD_DP001");
+2026-06-25T09:34:07.3141805Z +    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
+2026-06-25T09:34:07.3142364Z  
+2026-06-25T09:34:07.3142591Z      client.withdraw();
+2026-06-25T09:34:07.3142860Z  
+2026-06-25T09:34:07.3143419Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:1058:
+2026-06-25T09:34:07.3144035Z      env.mock_all_auths();
+2026-06-25T09:34:07.3144254Z  
+2026-06-25T09:34:07.3144436Z      let target = 5_000_000i128;
+2026-06-25T09:34:07.3144697Z -    let (client, escrow_id, _token, sme) =
+2026-06-25T09:34:07.3145032Z -        setup_withdraw_with_token(&env, target, "WD_EV001");
+2026-06-25T09:34:07.3145510Z +    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
+2026-06-25T09:34:07.3145942Z  
+2026-06-25T09:34:07.3146123Z      client.withdraw();
+2026-06-25T09:34:07.3146338Z  
+2026-06-25T09:34:07.3146746Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:1074:
+2026-06-25T09:34:07.3147245Z      .to_xdr(&env, &escrow_id);
+2026-06-25T09:34:07.3147473Z  
+2026-06-25T09:34:07.3147745Z      let all_events = env.events().all().filter_by_contract(&escrow_id);
+2026-06-25T09:34:07.3148111Z -    let found = all_events
+2026-06-25T09:34:07.3148346Z -        .events()
+2026-06-25T09:34:07.3148543Z -        .iter()
+2026-06-25T09:34:07.3148754Z -        .any(|e| *e == expected_xdr);
+2026-06-25T09:34:07.3149181Z -    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
+2026-06-25T09:34:07.3149695Z +    let found = all_events.events().iter().any(|e| *e == expected_xdr);
+2026-06-25T09:34:07.3150032Z +    assert!(
+2026-06-25T09:34:07.3150216Z +        found,
+2026-06-25T09:34:07.3150698Z +        "SmeWithdrew event with correct recipient and amount must be emitted"
+2026-06-25T09:34:07.3151199Z +    );
+2026-06-25T09:34:07.3151372Z  }
+2026-06-25T09:34:07.3151537Z  
+2026-06-25T09:34:07.3842537Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/settlement.rs:45:
+2026-06-25T09:34:07.3843406Z  /// actually transfer them.  Returns `(client, sme, sac_admin_client)`.
+2026-06-25T09:34:07.3843925Z  fn setup_funded_with_token<'a>(
+2026-06-25T09:34:07.3844560Z      env: &'a Env,
+2026-06-25T09:34:07.3844992Z -) -> (super::LiquifactEscrowClient<'a>, Address, StellarAssetClient<'a>) {
+2026-06-25T09:34:07.3845477Z +) -> (
+2026-06-25T09:34:07.3845722Z +    super::LiquifactEscrowClient<'a>,
+2026-06-25T09:34:07.3846039Z +    Address,
+2026-06-25T09:34:07.3846282Z +    StellarAssetClient<'a>,
+2026-06-25T09:34:07.3846566Z +) {
+2026-06-25T09:34:07.3846922Z      let sac = env.register_stellar_asset_contract_v2(Address::generate(env));
+2026-06-25T09:34:07.3847402Z      let token_id = sac.address();
+2026-06-25T09:34:07.3847777Z      let sac_admin = StellarAssetClient::new(env, &token_id);
+2026-06-25T09:34:07.3848460Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/settlement.rs:1673:
+2026-06-25T09:34:07.3849105Z      default_init(&client, &env, &admin, &sme);
+2026-06-25T09:34:07.3849439Z  
+2026-06-25T09:34:07.3849850Z      // Not yet funded — should be None.
+2026-06-25T09:34:07.3850350Z -    assert!(client.get_settled_at().is_none(), "settled_at must be None before settle");
+2026-06-25T09:34:07.3850854Z +    assert!(
+2026-06-25T09:34:07.3851448Z +        client.get_settled_at().is_none(),
+2026-06-25T09:34:07.3851921Z +        "settled_at must be None before settle"
+2026-06-25T09:34:07.3852254Z +    );
+2026-06-25T09:34:07.3852460Z  
+2026-06-25T09:34:07.3852773Z      // Fund to target (status 1) — still None.
+2026-06-25T09:34:07.3853124Z      fund_to_target(&client, &env);
+2026-06-25T09:34:07.3853729Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/settlement.rs:1680:
+2026-06-25T09:34:07.3854583Z -    assert!(client.get_settled_at().is_none(), "settled_at must be None after funding, before settle");
+2026-06-25T09:34:07.3855144Z +    assert!(
+2026-06-25T09:34:07.3855393Z +        client.get_settled_at().is_none(),
+2026-06-25T09:34:07.3855788Z +        "settled_at must be None after funding, before settle"
+2026-06-25T09:34:07.3856164Z +    );
+2026-06-25T09:34:07.3856367Z  }
+2026-06-25T09:34:07.3856569Z  
+2026-06-25T09:34:07.3856954Z  /// `get_settled_at` returns `Some(timestamp)` equal to the ledger time at `settle()`.
+2026-06-25T09:34:07.3857743Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/settlement.rs:1693:
+2026-06-25T09:34:07.3858417Z      env.ledger().with_mut(|l| l.timestamp = settle_ts);
+2026-06-25T09:34:07.3858785Z      client.settle();
+2026-06-25T09:34:07.3859032Z  
+2026-06-25T09:34:07.3859422Z -    let stored = client.get_settled_at().expect("settled_at must be Some after settle");
+2026-06-25T09:34:07.3860150Z -    assert_eq!(stored, settle_ts, "settled_at must equal the ledger timestamp at settle()");
+2026-06-25T09:34:07.3860680Z +    let stored = client
+2026-06-25T09:34:07.3860946Z +        .get_settled_at()
+2026-06-25T09:34:07.3861533Z +        .expect("settled_at must be Some after settle");
+2026-06-25T09:34:07.3861911Z +    assert_eq!(
+2026-06-25T09:34:07.3862150Z +        stored, settle_ts,
+2026-06-25T09:34:07.3862504Z +        "settled_at must equal the ledger timestamp at settle()"
+2026-06-25T09:34:07.3862895Z +    );
+2026-06-25T09:34:07.3863095Z  }
+2026-06-25T09:34:07.3863291Z  
+2026-06-25T09:34:07.3863839Z  /// `get_settled_at` value is stable — subsequent reads return the same timestamp.
+2026-06-25T09:34:07.3864668Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/settlement.rs:1712:
+2026-06-25T09:34:07.3865249Z  
+2026-06-25T09:34:07.3865515Z      // Advance ledger — stored value must not change.
+2026-06-25T09:34:07.3866052Z      env.ledger().with_mut(|l| l.timestamp = settle_ts + 10_000);
+2026-06-25T09:34:07.3866513Z -    let stored = client.get_settled_at().expect("settled_at must remain Some");
+2026-06-25T09:34:07.3867085Z -    assert_eq!(stored, settle_ts, "settled_at must not change after additional ledger advancement");
+2026-06-25T09:34:07.3867558Z +    let stored = client
+2026-06-25T09:34:07.3867790Z +        .get_settled_at()
+2026-06-25T09:34:07.3868046Z +        .expect("settled_at must remain Some");
+2026-06-25T09:34:07.3868461Z +    assert_eq!(
+2026-06-25T09:34:07.3868663Z +        stored, settle_ts,
+2026-06-25T09:34:07.3868985Z +        "settled_at must not change after additional ledger advancement"
+2026-06-25T09:34:07.3869338Z +    );
+2026-06-25T09:34:07.3869514Z  }
+2026-06-25T09:34:07.3869691Z  
+2026-06-25T09:34:07.3869998Z  /// `settle()` with maturity = 0 (no time-lock) still records the correct timestamp.
+2026-06-25T09:34:07.4190387Z ##[error]Process completed with exit code 1.
+2026-06-25T09:34:07.4327811Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-06-25T09:34:07.4329158Z Post job cleanup.
+2026-06-25T09:34:07.5130832Z [command]/usr/bin/git version
+2026-06-25T09:34:07.5167112Z git version 2.54.0
+2026-06-25T09:34:07.5235679Z Temporarily overriding HOME='/home/runner/work/_temp/5b843660-ae31-40a1-80e0-af8a1d943a7e' before making global git config changes
+2026-06-25T09:34:07.5236672Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-25T09:34:07.5241242Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:34:07.5276012Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-25T09:34:07.5307623Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-25T09:34:07.5528679Z fatal: No url found for submodule path 'Liquifact-contracts' in .gitmodules
+2026-06-25T09:34:07.5566068Z ##[warning]The process '/usr/bin/git' failed with exit code 128
+2026-06-25T09:34:07.5670698Z Cleaning up orphan processes
+2026-06-25T09:34:07.5947926Z ##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/ci_logs2.txt
+++ b/ci_logs2.txt
@@ -1,0 +1,656 @@
+﻿2026-06-25T09:50:12.5860702Z Current runner version: '2.335.1'
+2026-06-25T09:50:12.5884990Z ##[group]Runner Image Provisioner
+2026-06-25T09:50:12.5885908Z Hosted Compute Agent
+2026-06-25T09:50:12.5886540Z Version: 20260611.554
+2026-06-25T09:50:12.5887203Z Commit: 5e0782fdc9014723d3be820dd114dd31555c2bd1
+2026-06-25T09:50:12.5887945Z Build Date: 2026-06-11T21:40:46Z
+2026-06-25T09:50:12.5888637Z Worker ID: {b681863c-cf16-4b43-a607-da7351f42aca}
+2026-06-25T09:50:12.5889397Z Azure Region: northcentralus
+2026-06-25T09:50:12.5890042Z ##[endgroup]
+2026-06-25T09:50:12.5891448Z ##[group]Operating System
+2026-06-25T09:50:12.5892464Z Ubuntu
+2026-06-25T09:50:12.5892989Z 24.04.4
+2026-06-25T09:50:12.5893584Z LTS
+2026-06-25T09:50:12.5894133Z ##[endgroup]
+2026-06-25T09:50:12.5894769Z ##[group]Runner Image
+2026-06-25T09:50:12.5895421Z Image: ubuntu-24.04
+2026-06-25T09:50:12.5895990Z Version: 20260615.205.1
+2026-06-25T09:50:12.5897299Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260615.205/images/ubuntu/Ubuntu2404-Readme.md
+2026-06-25T09:50:12.5898804Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260615.205
+2026-06-25T09:50:12.5899858Z ##[endgroup]
+2026-06-25T09:50:12.5901002Z ##[group]GITHUB_TOKEN Permissions
+2026-06-25T09:50:12.5903356Z Contents: read
+2026-06-25T09:50:12.5903964Z Metadata: read
+2026-06-25T09:50:12.5904590Z Packages: read
+2026-06-25T09:50:12.5905165Z ##[endgroup]
+2026-06-25T09:50:12.5907153Z Secret source: None
+2026-06-25T09:50:12.5907991Z Prepare workflow directory
+2026-06-25T09:50:12.6358715Z Prepare all required actions
+2026-06-25T09:50:12.6413579Z Getting action download info
+2026-06-25T09:50:12.9159384Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2026-06-25T09:50:12.9899541Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+2026-06-25T09:50:13.1395834Z Download action repository 'Swatinem/rust-cache@v2' (SHA:e18b497796c12c097a38f9edb9d0641fb99eee32)
+2026-06-25T09:50:13.6128764Z Download action repository 'taiki-e/install-action@cargo-llvm-cov' (SHA:901c6c5742b8b5bab0a7cf0bf63286ad5e3120f3)
+2026-06-25T09:50:14.1084457Z Complete job name: fmt-build-test
+2026-06-25T09:50:14.1873628Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-06-25T09:50:14.1883479Z ##[group]Run actions/checkout@v4
+2026-06-25T09:50:14.1884283Z with:
+2026-06-25T09:50:14.1884768Z   repository: Liquifact/Liquifact-contracts
+2026-06-25T09:50:14.1889860Z   token: ***
+2026-06-25T09:50:14.1890308Z   ssh-strict: true
+2026-06-25T09:50:14.1890767Z   ssh-user: git
+2026-06-25T09:50:14.1891257Z   persist-credentials: true
+2026-06-25T09:50:14.1891991Z   clean: true
+2026-06-25T09:50:14.1892467Z   sparse-checkout-cone-mode: true
+2026-06-25T09:50:14.1893052Z   fetch-depth: 1
+2026-06-25T09:50:14.1893515Z   fetch-tags: false
+2026-06-25T09:50:14.1893990Z   show-progress: true
+2026-06-25T09:50:14.1894469Z   lfs: false
+2026-06-25T09:50:14.1894925Z   submodules: false
+2026-06-25T09:50:14.1895411Z   set-safe-directory: true
+2026-06-25T09:50:14.1896183Z ##[endgroup]
+2026-06-25T09:50:14.2903508Z Syncing repository: Liquifact/Liquifact-contracts
+2026-06-25T09:50:14.2905430Z ##[group]Getting Git version info
+2026-06-25T09:50:14.2906457Z Working directory is '/home/runner/work/Liquifact-contracts/Liquifact-contracts'
+2026-06-25T09:50:14.2907857Z [command]/usr/bin/git version
+2026-06-25T09:50:14.2958723Z git version 2.54.0
+2026-06-25T09:50:14.2978495Z ##[endgroup]
+2026-06-25T09:50:14.2992505Z Temporarily overriding HOME='/home/runner/work/_temp/b023f174-3e98-4a42-8f37-00397fc74f7f' before making global git config changes
+2026-06-25T09:50:14.2994315Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-25T09:50:14.2997762Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:50:14.3043084Z Deleting the contents of '/home/runner/work/Liquifact-contracts/Liquifact-contracts'
+2026-06-25T09:50:14.3047486Z ##[group]Initializing the repository
+2026-06-25T09:50:14.3052054Z [command]/usr/bin/git init /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:50:14.3161519Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-06-25T09:50:14.3163583Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-06-25T09:50:14.3164793Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-06-25T09:50:14.3165884Z hint: call:
+2026-06-25T09:50:14.3166402Z hint:
+2026-06-25T09:50:14.3167274Z hint: 	git config --global init.defaultBranch <name>
+2026-06-25T09:50:14.3168415Z hint:
+2026-06-25T09:50:14.3169137Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-06-25T09:50:14.3170337Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-06-25T09:50:14.3171273Z hint:
+2026-06-25T09:50:14.3172030Z hint: 	git branch -m <name>
+2026-06-25T09:50:14.3172740Z hint:
+2026-06-25T09:50:14.3173635Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-06-25T09:50:14.3175105Z Initialized empty Git repository in /home/runner/work/Liquifact-contracts/Liquifact-contracts/.git/
+2026-06-25T09:50:14.3177948Z [command]/usr/bin/git remote add origin https://github.com/Liquifact/Liquifact-contracts
+2026-06-25T09:50:14.3248950Z ##[endgroup]
+2026-06-25T09:50:14.3250041Z ##[group]Disabling automatic garbage collection
+2026-06-25T09:50:14.3253574Z [command]/usr/bin/git config --local gc.auto 0
+2026-06-25T09:50:14.3285616Z ##[endgroup]
+2026-06-25T09:50:14.3286420Z ##[group]Setting up auth
+2026-06-25T09:50:14.3292314Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-25T09:50:14.3324215Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-25T09:50:14.3644774Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-06-25T09:50:14.3675492Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-06-25T09:50:14.3887373Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-06-25T09:50:14.3916375Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-06-25T09:50:14.4126242Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-06-25T09:50:14.4157801Z ##[endgroup]
+2026-06-25T09:50:14.4158633Z ##[group]Fetching the repository
+2026-06-25T09:50:14.4167414Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +33b0fe8e31ad0681158724777d06338f1022e9f5:refs/remotes/pull/427/merge
+2026-06-25T09:50:14.8429736Z From https://github.com/Liquifact/Liquifact-contracts
+2026-06-25T09:50:14.8431567Z  * [new ref]         33b0fe8e31ad0681158724777d06338f1022e9f5 -> pull/427/merge
+2026-06-25T09:50:14.8464801Z ##[endgroup]
+2026-06-25T09:50:14.8466663Z ##[group]Determining the checkout info
+2026-06-25T09:50:14.8468393Z ##[endgroup]
+2026-06-25T09:50:14.8472276Z [command]/usr/bin/git sparse-checkout disable
+2026-06-25T09:50:14.8514627Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-06-25T09:50:14.8548845Z ##[group]Checking out the ref
+2026-06-25T09:50:14.8551397Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/427/merge
+2026-06-25T09:50:14.8931295Z Note: switching to 'refs/remotes/pull/427/merge'.
+2026-06-25T09:50:14.8933593Z 
+2026-06-25T09:50:14.8935012Z You are in 'detached HEAD' state. You can look around, make experimental
+2026-06-25T09:50:14.8937816Z changes and commit them, and you can discard any commits you make in this
+2026-06-25T09:50:14.8940754Z state without impacting any branches by switching back to a branch.
+2026-06-25T09:50:14.8942609Z 
+2026-06-25T09:50:14.8943670Z If you want to create a new branch to retain commits you create, you may
+2026-06-25T09:50:14.8945960Z do so (now or later) by using -c with the switch command. Example:
+2026-06-25T09:50:14.8947320Z 
+2026-06-25T09:50:14.8948037Z   git switch -c <new-branch-name>
+2026-06-25T09:50:14.8948949Z 
+2026-06-25T09:50:14.8949499Z Or undo this operation with:
+2026-06-25T09:50:14.8950323Z 
+2026-06-25T09:50:14.8950833Z   git switch -
+2026-06-25T09:50:14.8951490Z 
+2026-06-25T09:50:14.8952826Z Turn off this advice by setting config variable advice.detachedHead to false
+2026-06-25T09:50:14.8954348Z 
+2026-06-25T09:50:14.8956474Z HEAD is now at 33b0fe8 Merge d8f0d7e4c10369ada2b0181552630269ceada035 into f3c49bc43a4afd486efc2e2beb59bd144adb5029
+2026-06-25T09:50:14.8962075Z ##[endgroup]
+2026-06-25T09:50:14.8977802Z [command]/usr/bin/git log -1 --format=%H
+2026-06-25T09:50:14.8999400Z 33b0fe8e31ad0681158724777d06338f1022e9f5
+2026-06-25T09:50:14.9586790Z ##[group]Run dtolnay/rust-toolchain@stable
+2026-06-25T09:50:14.9588069Z with:
+2026-06-25T09:50:14.9589088Z   components: rustfmt, clippy, llvm-tools-preview
+2026-06-25T09:50:14.9590401Z   toolchain: stable
+2026-06-25T09:50:14.9591321Z ##[endgroup]
+2026-06-25T09:50:14.9754079Z ##[group]Run : parse toolchain version
+2026-06-25T09:50:14.9755369Z [36;1m: parse toolchain version[0m
+2026-06-25T09:50:14.9756517Z [36;1mif [[ -z $toolchain ]]; then[0m
+2026-06-25T09:50:14.9758498Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+2026-06-25T09:50:14.9760632Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+2026-06-25T09:50:14.9762063Z [36;1m  exit 1[0m
+2026-06-25T09:50:14.9763442Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+2026-06-25T09:50:14.9765089Z [36;1m  if [[ Linux == macOS ]]; then[0m
+2026-06-25T09:50:14.9767160Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:50:14.9769173Z [36;1m  else[0m
+2026-06-25T09:50:14.9770794Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:50:14.9772766Z [36;1m  fi[0m
+2026-06-25T09:50:14.9773988Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+2026-06-25T09:50:14.9776072Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:50:14.9777886Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+2026-06-25T09:50:14.9779943Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:50:14.9782026Z [36;1melse[0m
+2026-06-25T09:50:14.9783063Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:50:14.9784322Z [36;1mfi[0m
+2026-06-25T09:50:14.9946580Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:14.9947954Z env:
+2026-06-25T09:50:14.9948782Z   toolchain: stable
+2026-06-25T09:50:14.9949694Z ##[endgroup]
+2026-06-25T09:50:15.0128169Z ##[group]Run : construct rustup command line
+2026-06-25T09:50:15.0129451Z [36;1m: construct rustup command line[0m
+2026-06-25T09:50:15.0131192Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:50:15.0133884Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:50:15.0135823Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:50:15.0165484Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:15.0166853Z env:
+2026-06-25T09:50:15.0167651Z   targets: 
+2026-06-25T09:50:15.0168620Z   components: rustfmt, clippy, llvm-tools-preview
+2026-06-25T09:50:15.0169837Z ##[endgroup]
+2026-06-25T09:50:15.0289139Z ##[group]Run : set $CARGO_HOME
+2026-06-25T09:50:15.0290204Z [36;1m: set $CARGO_HOME[0m
+2026-06-25T09:50:15.0291516Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+2026-06-25T09:50:15.0321349Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:15.0323028Z ##[endgroup]
+2026-06-25T09:50:15.0500509Z ##[group]Run : install rustup if needed
+2026-06-25T09:50:15.0501926Z [36;1m: install rustup if needed[0m
+2026-06-25T09:50:15.0503167Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+2026-06-25T09:50:15.0505962Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+2026-06-25T09:50:15.0508709Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+2026-06-25T09:50:15.0509898Z [36;1mfi[0m
+2026-06-25T09:50:15.0539584Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:15.0540920Z env:
+2026-06-25T09:50:15.0542168Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:15.0543249Z ##[endgroup]
+2026-06-25T09:50:15.0668967Z ##[group]Run rustup toolchain install stable --component rustfmt --component clippy --component llvm-tools-preview --profile minimal --no-self-update
+2026-06-25T09:50:15.0672844Z [36;1mrustup toolchain install stable --component rustfmt --component clippy --component llvm-tools-preview --profile minimal --no-self-update[0m
+2026-06-25T09:50:15.0703413Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:15.0704689Z env:
+2026-06-25T09:50:15.0705507Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:15.0706547Z   RUSTUP_PERMIT_COPY_RENAME: 1
+2026-06-25T09:50:15.0707529Z ##[endgroup]
+2026-06-25T09:50:15.6669114Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+2026-06-25T09:50:15.8817554Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T09:50:15.8974561Z info: component clippy is up to date
+2026-06-25T09:50:15.8975815Z info: component rustfmt is up to date
+2026-06-25T09:50:15.8982806Z info: downloading component llvm-tools
+2026-06-25T09:50:18.3992956Z 
+2026-06-25T09:50:18.4073792Z   stable-x86_64-unknown-linux-gnu updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.96.0 (ac68faa20 2026-05-25))
+2026-06-25T09:50:18.4074736Z 
+2026-06-25T09:50:18.4195164Z ##[group]Run rustup default stable
+2026-06-25T09:50:18.4195512Z [36;1mrustup default stable[0m
+2026-06-25T09:50:18.4228387Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:18.4228778Z env:
+2026-06-25T09:50:18.4229023Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:18.4229359Z ##[endgroup]
+2026-06-25T09:50:18.4332740Z info: using existing install for stable-x86_64-unknown-linux-gnu
+2026-06-25T09:50:18.4339433Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+2026-06-25T09:50:18.4339802Z 
+2026-06-25T09:50:18.4418841Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T09:50:18.4419396Z 
+2026-06-25T09:50:18.4464685Z ##[group]Run : create cachekey
+2026-06-25T09:50:18.4465054Z [36;1m: create cachekey[0m
+2026-06-25T09:50:18.4465622Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+2026-06-25T09:50:18.4466349Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+2026-06-25T09:50:18.4466894Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:50:18.4499528Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:18.4499932Z env:
+2026-06-25T09:50:18.4500180Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:18.4500481Z ##[endgroup]
+2026-06-25T09:50:18.5085317Z ##[group]Run : disable incremental compilation
+2026-06-25T09:50:18.5085730Z [36;1m: disable incremental compilation[0m
+2026-06-25T09:50:18.5086104Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+2026-06-25T09:50:18.5086518Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+2026-06-25T09:50:18.5086853Z [36;1mfi[0m
+2026-06-25T09:50:18.5119700Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:18.5120130Z env:
+2026-06-25T09:50:18.5120389Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:18.5120698Z ##[endgroup]
+2026-06-25T09:50:18.5201308Z ##[group]Run : enable colors in Cargo output
+2026-06-25T09:50:18.5201925Z [36;1m: enable colors in Cargo output[0m
+2026-06-25T09:50:18.5202401Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+2026-06-25T09:50:18.5202797Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+2026-06-25T09:50:18.5203149Z [36;1mfi[0m
+2026-06-25T09:50:18.5233443Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:18.5233853Z env:
+2026-06-25T09:50:18.5234099Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:18.5234407Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:50:18.5234669Z ##[endgroup]
+2026-06-25T09:50:18.5316550Z ##[group]Run : enable Cargo sparse registry
+2026-06-25T09:50:18.5317090Z [36;1m: enable Cargo sparse registry[0m
+2026-06-25T09:50:18.5317521Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+2026-06-25T09:50:18.5318296Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+2026-06-25T09:50:18.5319073Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+2026-06-25T09:50:18.5319688Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-06-25T09:50:18.5320272Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+2026-06-25T09:50:18.5320816Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+2026-06-25T09:50:18.5321427Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-06-25T09:50:18.5322273Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+2026-06-25T09:50:18.5322672Z [36;1m  fi[0m
+2026-06-25T09:50:18.5322914Z [36;1mfi[0m
+2026-06-25T09:50:18.5353355Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:18.5353747Z env:
+2026-06-25T09:50:18.5353991Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:18.5354307Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:50:18.5354573Z   CARGO_TERM_COLOR: always
+2026-06-25T09:50:18.5354865Z ##[endgroup]
+2026-06-25T09:50:18.5705525Z ##[group]Run : work around spurious network errors in curl 8.0
+2026-06-25T09:50:18.5706027Z [36;1m: work around spurious network errors in curl 8.0[0m
+2026-06-25T09:50:18.5706829Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+2026-06-25T09:50:18.5707546Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+2026-06-25T09:50:18.5708052Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+2026-06-25T09:50:18.5708409Z [36;1mfi[0m
+2026-06-25T09:50:18.5742619Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:18.5743018Z env:
+2026-06-25T09:50:18.5743281Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:18.5743592Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:50:18.5743861Z   CARGO_TERM_COLOR: always
+2026-06-25T09:50:18.5744135Z ##[endgroup]
+2026-06-25T09:50:18.5963552Z ##[group]Run rustc +stable --version --verbose
+2026-06-25T09:50:18.5963967Z [36;1mrustc +stable --version --verbose[0m
+2026-06-25T09:50:18.5996493Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:50:18.5996892Z env:
+2026-06-25T09:50:18.5997142Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:18.5997447Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:50:18.5997720Z   CARGO_TERM_COLOR: always
+2026-06-25T09:50:18.5998168Z ##[endgroup]
+2026-06-25T09:50:18.6164719Z rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T09:50:18.6165687Z binary: rustc
+2026-06-25T09:50:18.6166324Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T09:50:18.6167009Z commit-date: 2026-05-25
+2026-06-25T09:50:18.6167544Z host: x86_64-unknown-linux-gnu
+2026-06-25T09:50:18.6168137Z release: 1.96.0
+2026-06-25T09:50:18.6168623Z LLVM version: 22.1.2
+2026-06-25T09:50:18.6317584Z ##[group]Run Swatinem/rust-cache@v2
+2026-06-25T09:50:18.6318157Z with:
+2026-06-25T09:50:18.6318541Z   prefix-key: v0-rust
+2026-06-25T09:50:18.6318950Z   add-job-id-key: true
+2026-06-25T09:50:18.6319390Z   add-rust-environment-hash-key: true
+2026-06-25T09:50:18.6319788Z   cache-targets: true
+2026-06-25T09:50:18.6320235Z   cache-all-crates: false
+2026-06-25T09:50:18.6320613Z   cache-workspace-crates: false
+2026-06-25T09:50:18.6321027Z   save-if: true
+2026-06-25T09:50:18.6321384Z   cache-provider: github
+2026-06-25T09:50:18.6321955Z   cache-bin: true
+2026-06-25T09:50:18.6322396Z   lookup-only: false
+2026-06-25T09:50:18.6322776Z   cmd-format: {0}
+2026-06-25T09:50:18.6323096Z env:
+2026-06-25T09:50:18.6323488Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:18.6323881Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:50:18.6324267Z   CARGO_TERM_COLOR: always
+2026-06-25T09:50:18.6324675Z ##[endgroup]
+2026-06-25T09:50:18.9015607Z (node:2438) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+2026-06-25T09:50:18.9016478Z (Use `node --trace-deprecation ...` to show where the warning was created)
+2026-06-25T09:50:19.8658862Z ##[group]Cache Configuration
+2026-06-25T09:50:19.8659360Z Cache Provider:
+2026-06-25T09:50:19.8659704Z     github
+2026-06-25T09:50:19.8660021Z Workspaces:
+2026-06-25T09:50:19.8660464Z     /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:50:19.8661033Z Cache Paths:
+2026-06-25T09:50:19.8661386Z     /home/runner/.cargo/bin
+2026-06-25T09:50:19.8662074Z     /home/runner/.cargo/.crates.toml
+2026-06-25T09:50:19.8662453Z     /home/runner/.cargo/.crates2.json
+2026-06-25T09:50:19.8662728Z     /home/runner/.cargo/registry
+2026-06-25T09:50:19.8662975Z     /home/runner/.cargo/git
+2026-06-25T09:50:19.8663318Z     /home/runner/work/Liquifact-contracts/Liquifact-contracts/target
+2026-06-25T09:50:19.8663833Z Restore Key:
+2026-06-25T09:50:19.8664079Z     v0-rust-fmt-build-test-Linux-x64-4107bf91
+2026-06-25T09:50:19.8664391Z Cache Key:
+2026-06-25T09:50:19.8664638Z     v0-rust-fmt-build-test-Linux-x64-4107bf91-e1b782ec
+2026-06-25T09:50:19.8664946Z .. Prefix:
+2026-06-25T09:50:19.8665158Z   - v0-rust-fmt-build-test-Linux-x64
+2026-06-25T09:50:19.8665426Z .. Environment considered:
+2026-06-25T09:50:19.8665650Z   - Rust Versions:
+2026-06-25T09:50:19.8666011Z     - 1.96.0 x86_64-unknown-linux-gnu ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T09:50:19.8666510Z     - 1.96.0 x86_64-unknown-linux-gnu ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T09:50:19.8667084Z   - CARGO_HOME
+2026-06-25T09:50:19.8667295Z   - CARGO_INCREMENTAL
+2026-06-25T09:50:19.8667515Z   - CARGO_TERM_COLOR
+2026-06-25T09:50:19.8667734Z .. Lockfiles considered:
+2026-06-25T09:50:19.8668064Z   - /home/runner/work/Liquifact-contracts/Liquifact-contracts/Cargo.lock
+2026-06-25T09:50:19.8668554Z   - /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/Cargo.toml
+2026-06-25T09:50:19.8669127Z ##[endgroup]
+2026-06-25T09:50:19.8669250Z 
+2026-06-25T09:50:19.8669348Z ... Restoring cache ...
+2026-06-25T09:50:19.9593796Z No cache found.
+2026-06-25T09:50:19.9703406Z ##[group]Run cargo fmt -p liquifact_escrow -- --check
+2026-06-25T09:50:19.9703828Z [36;1mcargo fmt -p liquifact_escrow -- --check[0m
+2026-06-25T09:50:19.9735443Z shell: /usr/bin/bash -e {0}
+2026-06-25T09:50:19.9735688Z env:
+2026-06-25T09:50:19.9735891Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:19.9736152Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:50:19.9736371Z   CARGO_TERM_COLOR: always
+2026-06-25T09:50:19.9736599Z   CACHE_ON_FAILURE: false
+2026-06-25T09:50:19.9736992Z ##[endgroup]
+2026-06-25T09:50:20.8777400Z ##[group]Run cargo clippy -p liquifact_escrow -- -D warnings
+2026-06-25T09:50:20.8778167Z [36;1mcargo clippy -p liquifact_escrow -- -D warnings[0m
+2026-06-25T09:50:20.8814161Z shell: /usr/bin/bash -e {0}
+2026-06-25T09:50:20.8814416Z env:
+2026-06-25T09:50:20.8814619Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:50:20.8814886Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:50:20.8815103Z   CARGO_TERM_COLOR: always
+2026-06-25T09:50:20.8815329Z   CACHE_ON_FAILURE: false
+2026-06-25T09:50:20.8815548Z ##[endgroup]
+2026-06-25T09:50:21.2936071Z [1m[92m    Updating[0m crates.io index
+2026-06-25T09:50:21.8493781Z [1m[92m Downloading[0m crates ...
+2026-06-25T09:50:21.9211489Z [1m[92m  Downloaded[0m curve25519-dalek-derive v0.1.1
+2026-06-25T09:50:21.9364014Z [1m[92m  Downloaded[0m ark-bn254 v0.4.0
+2026-06-25T09:50:21.9385487Z [1m[92m  Downloaded[0m schemars v0.8.22
+2026-06-25T09:50:21.9631056Z [1m[92m  Downloaded[0m ark-ec v0.4.2
+2026-06-25T09:50:21.9690773Z [1m[92m  Downloaded[0m sec1 v0.7.3
+2026-06-25T09:50:21.9720405Z [1m[92m  Downloaded[0m dtor-proc-macro v0.0.6
+2026-06-25T09:50:21.9734160Z [1m[92m  Downloaded[0m zeroize_derive v1.4.3
+2026-06-25T09:50:21.9749783Z [1m[92m  Downloaded[0m visibility v0.1.1
+2026-06-25T09:50:21.9769333Z [1m[92m  Downloaded[0m signature v2.2.0
+2026-06-25T09:50:21.9789392Z [1m[92m  Downloaded[0m powerfmt v0.2.0
+2026-06-25T09:50:21.9806866Z [1m[92m  Downloaded[0m stable_deref_trait v1.2.1
+2026-06-25T09:50:21.9821032Z [1m[92m  Downloaded[0m rfc6979 v0.4.0
+2026-06-25T09:50:21.9837693Z [1m[92m  Downloaded[0m soroban-builtin-sdk-macros v25.0.1
+2026-06-25T09:50:21.9851688Z [1m[92m  Downloaded[0m wasmi_arena v0.4.1
+2026-06-25T09:50:21.9866900Z [1m[92m  Downloaded[0m sha2 v0.10.9
+2026-06-25T09:50:21.9898839Z [1m[92m  Downloaded[0m zmij v1.0.21
+2026-06-25T09:50:21.9922233Z [1m[92m  Downloaded[0m time-macros v0.2.27
+2026-06-25T09:50:22.0073810Z [1m[92m  Downloaded[0m static_assertions v1.1.0
+2026-06-25T09:50:22.0094698Z [1m[92m  Downloaded[0m stellar-strkey v0.0.16
+2026-06-25T09:50:22.0132709Z [1m[92m  Downloaded[0m zeroize v1.8.2
+2026-06-25T09:50:22.0151953Z [1m[92m  Downloaded[0m soroban-sdk-macros v25.3.0
+2026-06-25T09:50:22.0179832Z [1m[92m  Downloaded[0m serde_derive v1.0.228
+2026-06-25T09:50:22.0216742Z [1m[92m  Downloaded[0m unicode-ident v1.0.24
+2026-06-25T09:50:22.0251001Z [1m[92m  Downloaded[0m typenum v1.19.0
+2026-06-25T09:50:22.0285324Z [1m[92m  Downloaded[0m ark-poly v0.4.2
+2026-06-25T09:50:22.0319326Z [1m[92m  Downloaded[0m soroban-env-common v25.0.1
+2026-06-25T09:50:22.0351851Z [1m[92m  Downloaded[0m serde_with v3.12.0
+2026-06-25T09:50:22.0439490Z [1m[92m  Downloaded[0m proc-macro2 v1.0.106
+2026-06-25T09:50:22.0475134Z [1m[92m  Downloaded[0m hmac v0.12.1
+2026-06-25T09:50:22.0502290Z [1m[92m  Downloaded[0m indexmap v1.9.3
+2026-06-25T09:50:22.0621954Z [1m[92m  Downloaded[0m serde_core v1.0.228
+2026-06-25T09:50:22.0657511Z [1m[92m  Downloaded[0m wasmparser-nostd v0.100.2
+2026-06-25T09:50:22.0710202Z [1m[92m  Downloaded[0m soroban-wasmi v0.31.1-soroban.20.0.1
+2026-06-25T09:50:22.0780716Z [1m[92m  Downloaded[0m prettyplease v0.2.37
+2026-06-25T09:50:22.0821429Z [1m[92m  Downloaded[0m wasmparser v0.116.1
+2026-06-25T09:50:22.0880805Z [1m[92m  Downloaded[0m time v0.3.47
+2026-06-25T09:50:22.1016648Z [1m[92m  Downloaded[0m syn v1.0.109
+2026-06-25T09:50:22.1117573Z [1m[92m  Downloaded[0m itertools v0.10.5
+2026-06-25T09:50:22.1183936Z [1m[92m  Downloaded[0m zerocopy v0.8.42
+2026-06-25T09:50:22.1353923Z [1m[92m  Downloaded[0m hashbrown v0.16.1
+2026-06-25T09:50:22.1408292Z [1m[92m  Downloaded[0m hashbrown v0.13.2
+2026-06-25T09:50:22.1449465Z [1m[92m  Downloaded[0m syn v2.0.117
+2026-06-25T09:50:22.1555323Z [1m[92m  Downloaded[0m libm v0.2.16
+2026-06-25T09:50:22.1666664Z [1m[92m  Downloaded[0m hashbrown v0.12.3
+2026-06-25T09:50:22.1706977Z [1m[92m  Downloaded[0m chrono v0.4.44
+2026-06-25T09:50:22.1776446Z [1m[92m  Downloaded[0m ed25519-dalek v2.2.0
+2026-06-25T09:50:22.1809008Z [1m[92m  Downloaded[0m k256 v0.13.4
+2026-06-25T09:50:22.1848117Z [1m[92m  Downloaded[0m ark-bls12-381 v0.4.0
+2026-06-25T09:50:22.1883638Z [1m[92m  Downloaded[0m indexmap v2.13.0
+2026-06-25T09:50:22.1926618Z [1m[92m  Downloaded[0m curve25519-dalek v4.1.3
+2026-06-25T09:50:22.2013165Z [1m[92m  Downloaded[0m serde v1.0.228
+2026-06-25T09:50:22.2048465Z [1m[92m  Downloaded[0m rand v0.8.5
+2026-06-25T09:50:22.2083194Z [1m[92m  Downloaded[0m num-bigint v0.4.6
+2026-06-25T09:50:22.2130749Z [1m[92m  Downloaded[0m der v0.7.10
+2026-06-25T09:50:22.2184820Z [1m[92m  Downloaded[0m crypto-bigint v0.5.5
+2026-06-25T09:50:22.2257874Z [1m[92m  Downloaded[0m memchr v2.8.0
+2026-06-25T09:50:22.2351012Z [1m[92m  Downloaded[0m soroban-env-host v25.0.1
+2026-06-25T09:50:22.2582458Z [1m[92m  Downloaded[0m base64 v0.22.1
+2026-06-25T09:50:22.2620751Z [1m[92m  Downloaded[0m ark-ff v0.4.2
+2026-06-25T09:50:22.2660435Z [1m[92m  Downloaded[0m soroban-sdk v25.2.0
+2026-06-25T09:50:22.2718669Z [1m[92m  Downloaded[0m darling_core v0.20.11
+2026-06-25T09:50:22.2770155Z [1m[92m  Downloaded[0m serde_json v1.0.149
+2026-06-25T09:50:22.2842970Z [1m[92m  Downloaded[0m num-traits v0.2.19
+2026-06-25T09:50:22.2869465Z [1m[92m  Downloaded[0m heapless v0.8.0
+2026-06-25T09:50:22.2907835Z [1m[92m  Downloaded[0m elliptic-curve v0.13.8
+2026-06-25T09:50:22.2945702Z [1m[92m  Downloaded[0m p256 v0.13.2
+2026-06-25T09:50:22.2979218Z [1m[92m  Downloaded[0m getrandom v0.2.17
+2026-06-25T09:50:22.3008593Z [1m[92m  Downloaded[0m ethnum v1.5.2
+2026-06-25T09:50:22.3051175Z [1m[92m  Downloaded[0m derivative v2.2.0
+2026-06-25T09:50:22.3130724Z [1m[92m  Downloaded[0m data-encoding v2.10.0
+2026-06-25T09:50:22.3141508Z [1m[92m  Downloaded[0m darling v0.20.11
+2026-06-25T09:50:22.3190687Z [1m[92m  Downloaded[0m once_cell v1.21.4
+2026-06-25T09:50:22.3216757Z [1m[92m  Downloaded[0m iana-time-zone v0.1.65
+2026-06-25T09:50:22.3245050Z [1m[92m  Downloaded[0m group v0.13.0
+2026-06-25T09:50:22.3261151Z [1m[92m  Downloaded[0m const-oid v0.9.6
+2026-06-25T09:50:22.3280249Z [1m[92m  Downloaded[0m sha3 v0.10.8
+2026-06-25T09:50:22.3323655Z [1m[92m  Downloaded[0m byteorder v1.5.0
+2026-06-25T09:50:22.3339528Z [1m[92m  Downloaded[0m semver v1.0.27
+2026-06-25T09:50:22.3363848Z [1m[92m  Downloaded[0m libc v0.2.183
+2026-06-25T09:50:22.3753701Z [1m[92m  Downloaded[0m quote v1.0.45
+2026-06-25T09:50:22.3780115Z [1m[92m  Downloaded[0m primeorder v0.13.6
+2026-06-25T09:50:22.3793084Z [1m[92m  Downloaded[0m ecdsa v0.16.9
+2026-06-25T09:50:22.3809656Z [1m[92m  Downloaded[0m deranged v0.5.8
+2026-06-25T09:50:22.3823772Z [1m[92m  Downloaded[0m autocfg v1.5.0
+2026-06-25T09:50:22.3842768Z [1m[92m  Downloaded[0m spin v0.9.8
+2026-06-25T09:50:22.3865803Z [1m[92m  Downloaded[0m smallvec v1.15.1
+2026-06-25T09:50:22.3886645Z [1m[92m  Downloaded[0m rand_core v0.6.4
+2026-06-25T09:50:22.3899964Z [1m[92m  Downloaded[0m ppv-lite86 v0.2.21
+2026-06-25T09:50:22.3913314Z [1m[92m  Downloaded[0m pkcs8 v0.10.2
+2026-06-25T09:50:22.3941082Z [1m[92m  Downloaded[0m paste v1.0.15
+2026-06-25T09:50:22.3972275Z [1m[92m  Downloaded[0m generic-array v0.14.9
+2026-06-25T09:50:22.3986633Z [1m[92m  Downloaded[0m ff v0.13.1
+2026-06-25T09:50:22.4001669Z [1m[92m  Downloaded[0m stellar-strkey v0.0.13
+2026-06-25T09:50:22.4028154Z [1m[92m  Downloaded[0m num-integer v0.1.46
+2026-06-25T09:50:22.4043902Z [1m[92m  Downloaded[0m spki v0.7.3
+2026-06-25T09:50:22.4061486Z [1m[92m  Downloaded[0m soroban-ledger-snapshot v25.3.0
+2026-06-25T09:50:22.4072337Z [1m[92m  Downloaded[0m either v1.15.0
+2026-06-25T09:50:22.4086750Z [1m[92m  Downloaded[0m ed25519 v2.2.3
+2026-06-25T09:50:22.4104157Z [1m[92m  Downloaded[0m dtor v0.1.1
+2026-06-25T09:50:22.4114513Z [1m[92m  Downloaded[0m digest v0.10.7
+2026-06-25T09:50:22.4132279Z [1m[92m  Downloaded[0m base64ct v1.8.3
+2026-06-25T09:50:22.4157632Z [1m[92m  Downloaded[0m ark-std v0.4.0
+2026-06-25T09:50:22.4210554Z [1m[92m  Downloaded[0m ark-ff-asm v0.4.2
+2026-06-25T09:50:22.4220518Z [1m[92m  Downloaded[0m thiserror-impl v1.0.69
+2026-06-25T09:50:22.4234034Z [1m[92m  Downloaded[0m thiserror v1.0.69
+2026-06-25T09:50:22.4289500Z [1m[92m  Downloaded[0m serde_with_macros v3.12.0
+2026-06-25T09:50:22.4306787Z [1m[92m  Downloaded[0m hex-literal v0.4.1
+2026-06-25T09:50:22.4316656Z [1m[92m  Downloaded[0m hash32 v0.3.1
+2026-06-25T09:50:22.4331040Z [1m[92m  Downloaded[0m wasmi_core v0.13.0
+2026-06-25T09:50:22.4343610Z [1m[92m  Downloaded[0m soroban-env-macros v25.0.1
+2026-06-25T09:50:22.4354256Z [1m[92m  Downloaded[0m heck v0.5.0
+2026-06-25T09:50:22.4366866Z [1m[92m  Downloaded[0m cfg_eval v0.1.2
+2026-06-25T09:50:22.4383208Z [1m[92m  Downloaded[0m cfg-if v1.0.4
+2026-06-25T09:50:22.4396894Z [1m[92m  Downloaded[0m soroban-spec-rust v25.3.0
+2026-06-25T09:50:22.4406017Z [1m[92m  Downloaded[0m downcast-rs v1.2.1
+2026-06-25T09:50:22.4419223Z [1m[92m  Downloaded[0m derive_arbitrary v1.3.2
+2026-06-25T09:50:22.4428493Z [1m[92m  Downloaded[0m keccak v0.1.6
+2026-06-25T09:50:22.4440049Z [1m[92m  Downloaded[0m block-buffer v0.10.4
+2026-06-25T09:50:22.4450615Z [1m[92m  Downloaded[0m base16ct v0.2.0
+2026-06-25T09:50:22.4464154Z [1m[92m  Downloaded[0m rand_chacha v0.3.1
+2026-06-25T09:50:22.4475105Z [1m[92m  Downloaded[0m num-derive v0.4.2
+2026-06-25T09:50:22.4492603Z [1m[92m  Downloaded[0m indexmap-nostd v0.4.0
+2026-06-25T09:50:22.4505876Z [1m[92m  Downloaded[0m rustc_version v0.4.1
+2026-06-25T09:50:22.4519429Z [1m[92m  Downloaded[0m fnv v1.0.7
+2026-06-25T09:50:22.4527606Z [1m[92m  Downloaded[0m ark-serialize-derive v0.4.2
+2026-06-25T09:50:22.4536599Z [1m[92m  Downloaded[0m bytes-lit v0.0.5
+2026-06-25T09:50:22.4550258Z [1m[92m  Downloaded[0m macro-string v0.1.4
+2026-06-25T09:50:22.4569319Z [1m[92m  Downloaded[0m ark-ff-macros v0.4.2
+2026-06-25T09:50:22.4583457Z [1m[92m  Downloaded[0m strsim v0.11.1
+2026-06-25T09:50:22.4596319Z [1m[92m  Downloaded[0m soroban-spec v25.3.0
+2026-06-25T09:50:22.4605674Z [1m[92m  Downloaded[0m num-conv v0.2.0
+2026-06-25T09:50:22.4614407Z [1m[92m  Downloaded[0m itoa v1.0.17
+2026-06-25T09:50:22.4628548Z [1m[92m  Downloaded[0m hex v0.4.3
+2026-06-25T09:50:22.4644277Z [1m[92m  Downloaded[0m version_check v0.9.5
+2026-06-25T09:50:22.4656746Z [1m[92m  Downloaded[0m time-core v0.1.8
+2026-06-25T09:50:22.4667534Z [1m[92m  Downloaded[0m subtle v2.6.1
+2026-06-25T09:50:22.4679075Z [1m[92m  Downloaded[0m ctor v0.5.0
+2026-06-25T09:50:22.4689929Z [1m[92m  Downloaded[0m crypto-common v0.1.6
+2026-06-25T09:50:22.4698887Z [1m[92m  Downloaded[0m cpufeatures v0.2.17
+2026-06-25T09:50:22.4713270Z [1m[92m  Downloaded[0m escape-bytes v0.1.1
+2026-06-25T09:50:22.4727962Z [1m[92m  Downloaded[0m equivalent v1.0.2
+2026-06-25T09:50:22.4737783Z [1m[92m  Downloaded[0m dyn-clone v1.0.20
+2026-06-25T09:50:22.4754319Z [1m[92m  Downloaded[0m darling_macro v0.20.11
+2026-06-25T09:50:22.4761572Z [1m[92m  Downloaded[0m ctor-proc-macro v0.0.6
+2026-06-25T09:50:22.4769319Z [1m[92m  Downloaded[0m crate-git-revision v0.0.6
+2026-06-25T09:50:22.4781966Z [1m[92m  Downloaded[0m ark-serialize v0.4.2
+2026-06-25T09:50:22.4792743Z [1m[92m  Downloaded[0m ahash v0.8.12
+2026-06-25T09:50:22.4816389Z [1m[92m  Downloaded[0m ident_case v1.0.1
+2026-06-25T09:50:22.4825032Z [1m[92m  Downloaded[0m arbitrary v1.3.2
+2026-06-25T09:50:22.4844387Z [1m[92m  Downloaded[0m stellar-xdr v25.0.0
+2026-06-25T09:50:22.6508433Z [1m[92m   Compiling[0m proc-macro2 v1.0.106
+2026-06-25T09:50:22.6549183Z [1m[92m   Compiling[0m unicode-ident v1.0.24
+2026-06-25T09:50:22.6563955Z [1m[92m   Compiling[0m quote v1.0.45
+2026-06-25T09:50:22.6602520Z [1m[92m   Compiling[0m version_check v0.9.5
+2026-06-25T09:50:24.8328367Z [1m[92m   Compiling[0m typenum v1.19.0
+2026-06-25T09:50:24.8912681Z [1m[92m   Compiling[0m serde_core v1.0.228
+2026-06-25T09:50:26.1503274Z [1m[92m   Compiling[0m zmij v1.0.21
+2026-06-25T09:50:26.1683409Z [1m[92m   Compiling[0m serde v1.0.228
+2026-06-25T09:50:26.2926982Z [1m[92m   Compiling[0m serde_json v1.0.149
+2026-06-25T09:50:26.3697804Z [1m[92m   Compiling[0m memchr v2.8.0
+2026-06-25T09:50:26.9632878Z [1m[92m   Compiling[0m itoa v1.0.17
+2026-06-25T09:50:27.0479674Z [1m[92m   Compiling[0m syn v2.0.117
+2026-06-25T09:50:27.0532788Z [1m[92m   Compiling[0m generic-array v0.14.9
+2026-06-25T09:50:27.0793202Z [1m[92m    Checking[0m cfg-if v1.0.4
+2026-06-25T09:50:27.1922955Z [1m[92m    Checking[0m subtle v2.6.1
+2026-06-25T09:50:27.2803406Z [1m[92m    Checking[0m const-oid v0.9.6
+2026-06-25T09:50:27.3653436Z [1m[92m   Compiling[0m libc v0.2.183
+2026-06-25T09:50:27.6253694Z [1m[92m   Compiling[0m autocfg v1.5.0
+2026-06-25T09:50:28.0133744Z [1m[92m   Compiling[0m num-traits v0.2.19
+2026-06-25T09:50:28.1143188Z [1m[92m   Compiling[0m zerocopy v0.8.42
+2026-06-25T09:50:28.7693559Z [1m[92m    Checking[0m getrandom v0.2.17
+2026-06-25T09:50:28.8583680Z [1m[92m    Checking[0m rand_core v0.6.4
+2026-06-25T09:50:29.4483479Z [1m[92m   Compiling[0m syn v1.0.109
+2026-06-25T09:50:29.6413050Z [1m[92m   Compiling[0m fnv v1.0.7
+2026-06-25T09:50:29.6763205Z [1m[92m   Compiling[0m strsim v0.11.1
+2026-06-25T09:50:29.8933357Z [1m[92m   Compiling[0m ident_case v1.0.1
+2026-06-25T09:50:30.4813506Z [1m[92m   Compiling[0m darling_core v0.20.11
+2026-06-25T09:50:30.6813177Z [1m[92m   Compiling[0m semver v1.0.27
+2026-06-25T09:50:31.8563390Z [1m[92m   Compiling[0m serde_derive v1.0.228
+2026-06-25T09:50:32.5183656Z [1m[92m   Compiling[0m zeroize_derive v1.4.3
+2026-06-25T09:50:32.9413576Z [1m[92m   Compiling[0m darling_macro v0.20.11
+2026-06-25T09:50:32.9903181Z [1m[92m    Checking[0m zeroize v1.8.2
+2026-06-25T09:50:33.1723383Z [1m[92m   Compiling[0m schemars v0.8.22
+2026-06-25T09:50:33.2833040Z [1m[92m   Compiling[0m paste v1.0.15
+2026-06-25T09:50:33.4494319Z [1m[92m   Compiling[0m darling v0.20.11
+2026-06-25T09:50:33.4903463Z [1m[92m    Checking[0m ppv-lite86 v0.2.21
+2026-06-25T09:50:33.5893896Z [1m[92m    Checking[0m crypto-common v0.1.6
+2026-06-25T09:50:33.6452947Z [1m[92m    Checking[0m block-buffer v0.10.4
+2026-06-25T09:50:33.7219845Z [1m[92m    Checking[0m digest v0.10.7
+2026-06-25T09:50:33.9153547Z [1m[92m   Compiling[0m dyn-clone v1.0.20
+2026-06-25T09:50:33.9873228Z [1m[92m    Checking[0m rand_chacha v0.3.1
+2026-06-25T09:50:34.0613659Z [1m[92m   Compiling[0m serde_with_macros v3.12.0
+2026-06-25T09:50:34.4803620Z [1m[92m   Compiling[0m cfg_eval v0.1.2
+2026-06-25T09:50:34.6813168Z [1m[92m   Compiling[0m num-integer v0.1.46
+2026-06-25T09:50:34.9344501Z [1m[92m   Compiling[0m cpufeatures v0.2.17
+2026-06-25T09:50:34.9623344Z [1m[92m   Compiling[0m data-encoding v2.10.0
+2026-06-25T09:50:35.1113778Z [1m[92m   Compiling[0m sha2 v0.10.9
+2026-06-25T09:50:35.4513513Z [1m[92m   Compiling[0m crate-git-revision v0.0.6
+2026-06-25T09:50:35.4778985Z [1m[92m   Compiling[0m hex v0.4.3
+2026-06-25T09:50:35.6163667Z [1m[92m   Compiling[0m num-bigint v0.4.6
+2026-06-25T09:50:35.6234541Z [1m[92m   Compiling[0m stellar-strkey v0.0.13
+2026-06-25T09:50:35.6850792Z [1m[92m   Compiling[0m stellar-xdr v25.0.0
+2026-06-25T09:50:35.7893256Z [1m[92m    Checking[0m rand v0.8.5
+2026-06-25T09:50:36.1513002Z [1m[92m   Compiling[0m ahash v0.8.12
+2026-06-25T09:50:36.2913637Z [1m[92m   Compiling[0m ethnum v1.5.2
+2026-06-25T09:50:36.3173384Z [1m[92m   Compiling[0m escape-bytes v0.1.1
+2026-06-25T09:50:36.4043040Z [1m[92m    Checking[0m ark-std v0.4.0
+2026-06-25T09:50:36.5095228Z [1m[92m   Compiling[0m serde_with v3.12.0
+2026-06-25T09:50:37.0356940Z [1m[92m   Compiling[0m ark-serialize-derive v0.4.2
+2026-06-25T09:50:37.0745634Z [1m[92m    Checking[0m der v0.7.10
+2026-06-25T09:50:37.3733278Z [1m[92m   Compiling[0m rustc_version v0.4.1
+2026-06-25T09:50:37.6030130Z [1m[92m    Checking[0m ff v0.13.1
+2026-06-25T09:50:37.6081420Z [1m[92m    Checking[0m either v1.15.0
+2026-06-25T09:50:37.7343190Z [1m[92m    Checking[0m once_cell v1.21.4
+2026-06-25T09:50:37.8128844Z [1m[92m    Checking[0m base16ct v0.2.0
+2026-06-25T09:50:37.8343986Z [1m[92m   Compiling[0m itertools v0.10.5
+2026-06-25T09:50:37.8516971Z [1m[92m    Checking[0m ark-serialize v0.4.2
+2026-06-25T09:50:37.8723055Z [1m[92m    Checking[0m sec1 v0.7.3
+2026-06-25T09:50:38.0783137Z [1m[92m    Checking[0m group v0.13.0
+2026-06-25T09:50:38.1384692Z [1m[92m   Compiling[0m ark-ff-macros v0.4.2
+2026-06-25T09:50:38.8643768Z [1m[92m   Compiling[0m derivative v2.2.0
+2026-06-25T09:50:38.9253031Z [1m[92m   Compiling[0m ark-ff-asm v0.4.2
+2026-06-25T09:50:38.9853889Z [1m[92m    Checking[0m signature v2.2.0
+2026-06-25T09:50:39.0483657Z [1m[92m    Checking[0m crypto-bigint v0.5.5
+2026-06-25T09:50:39.3233108Z [1m[92m   Compiling[0m libm v0.2.16
+2026-06-25T09:50:39.5102808Z [1m[92m    Checking[0m hashbrown v0.13.2
+2026-06-25T09:50:39.9123722Z [1m[92m    Checking[0m hmac v0.12.1
+2026-06-25T09:50:39.9883644Z [1m[92m   Compiling[0m hashbrown v0.16.1
+2026-06-25T09:50:40.0993159Z [1m[92m    Checking[0m elliptic-curve v0.13.8
+2026-06-25T09:50:40.3413503Z [1m[92m   Compiling[0m thiserror v1.0.69
+2026-06-25T09:50:40.5283608Z [1m[92m   Compiling[0m equivalent v1.0.2
+2026-06-25T09:50:40.5514085Z [1m[92m    Checking[0m ark-ff v0.4.2
+2026-06-25T09:50:40.5653050Z [1m[92m   Compiling[0m indexmap v2.13.0
+2026-06-25T09:50:40.7893259Z [1m[92m    Checking[0m rfc6979 v0.4.0
+2026-06-25T09:50:41.2193521Z [1m[92m   Compiling[0m curve25519-dalek v4.1.3
+2026-06-25T09:50:41.4663712Z [1m[92m   Compiling[0m thiserror-impl v1.0.69
+2026-06-25T09:50:41.7073556Z [1m[92m   Compiling[0m num-derive v0.4.2
+2026-06-25T09:50:42.4495413Z [1m[92m    Checking[0m indexmap-nostd v0.4.0
+2026-06-25T09:50:42.4903128Z [1m[92m   Compiling[0m prettyplease v0.2.37
+2026-06-25T09:50:42.8003351Z [1m[92m    Checking[0m downcast-rs v1.2.1
+2026-06-25T09:50:42.8336902Z [1m[92m    Checking[0m wasmi_core v0.13.0
+2026-06-25T09:50:43.1373703Z [1m[92m    Checking[0m wasmparser-nostd v0.100.2
+2026-06-25T09:50:43.6753209Z [1m[92m   Compiling[0m wasmparser v0.116.1
+2026-06-25T09:50:44.7713601Z [1m[92m    Checking[0m ark-poly v0.4.2
+2026-06-25T09:50:45.3673186Z [1m[92m    Checking[0m ark-ec v0.4.2
+2026-06-25T09:50:45.3793304Z [1m[92m    Checking[0m ecdsa v0.16.9
+2026-06-25T09:50:45.8023788Z [1m[92m   Compiling[0m soroban-env-common v25.0.1
+2026-06-25T09:50:46.0103727Z [1m[92m   Compiling[0m curve25519-dalek-derive v0.1.1
+2026-06-25T09:50:46.5203518Z [1m[92m   Compiling[0m base64 v0.22.1
+2026-06-25T09:50:46.7712108Z [1m[92m    Checking[0m wasmi_arena v0.4.1
+2026-06-25T09:50:46.8643867Z [1m[92m    Checking[0m spin v0.9.8
+2026-06-25T09:50:46.9933269Z [1m[92m   Compiling[0m heapless v0.8.0
+2026-06-25T09:50:47.1553628Z [1m[92m    Checking[0m byteorder v1.5.0
+2026-06-25T09:50:47.1764509Z [1m[92m    Checking[0m smallvec v1.15.1
+2026-06-25T09:50:47.4742500Z [1m[92m    Checking[0m soroban-wasmi v0.31.1-soroban.20.0.1
+2026-06-25T09:50:49.2662973Z [1m[92m    Checking[0m hash32 v0.3.1
+2026-06-25T09:50:52.2033729Z [1m[92m    Checking[0m primeorder v0.13.6
+2026-06-25T09:50:52.4093671Z [1m[92m    Checking[0m ed25519 v2.2.3
+2026-06-25T09:50:52.4772966Z [1m[92m   Compiling[0m stellar-strkey v0.0.16
+2026-06-25T09:50:52.5743471Z [1m[92m   Compiling[0m static_assertions v1.1.0
+2026-06-25T09:50:52.6113753Z [1m[92m   Compiling[0m soroban-env-host v25.0.1
+2026-06-25T09:50:52.9003498Z [1m[92m    Checking[0m stable_deref_trait v1.2.1
+2026-06-25T09:50:52.9551016Z [1m[92m    Checking[0m keccak v0.1.6
+2026-06-25T09:50:53.0552983Z [1m[92m    Checking[0m sha3 v0.10.8
+2026-06-25T09:50:53.4163263Z [1m[92m    Checking[0m ed25519-dalek v2.2.0
+2026-06-25T09:50:53.5323144Z [1m[92m    Checking[0m p256 v0.13.2
+2026-06-25T09:50:53.5642360Z [1m[92m    Checking[0m ark-bls12-381 v0.4.0
+2026-06-25T09:50:53.7272762Z [1m[92m    Checking[0m ark-bn254 v0.4.0
+2026-06-25T09:50:53.9973155Z [1m[92m    Checking[0m k256 v0.13.4
+2026-06-25T09:50:54.1492902Z [1m[92m   Compiling[0m soroban-builtin-sdk-macros v25.0.1
+2026-06-25T09:50:54.2908491Z [1m[92m   Compiling[0m soroban-sdk v25.2.0
+2026-06-25T09:50:54.4193860Z [1m[92m   Compiling[0m macro-string v0.1.4
+2026-06-25T09:50:54.7223171Z [1m[92m    Checking[0m hex-literal v0.4.1
+2026-06-25T09:50:54.7583174Z [1m[92m   Compiling[0m heck v0.5.0
+2026-06-25T09:50:55.6233232Z [1m[92m   Compiling[0m bytes-lit v0.0.5
+2026-06-25T09:50:55.8443288Z [1m[92m   Compiling[0m visibility v0.1.1
+2026-06-25T09:50:57.6556194Z [1m[92m   Compiling[0m soroban-spec v25.3.0
+2026-06-25T09:50:57.7774733Z [1m[92m   Compiling[0m soroban-spec-rust v25.3.0
+2026-06-25T09:50:58.2444787Z [1m[92m   Compiling[0m soroban-env-macros v25.0.1
+2026-06-25T09:51:00.2425761Z [1m[92m   Compiling[0m soroban-sdk-macros v25.3.0
+2026-06-25T09:51:03.5396783Z [1m[92m    Checking[0m liquifact_escrow v0.1.0 (/home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow)
+2026-06-25T09:51:04.1147015Z [1m[91merror[E0081][0m[1m: discriminant value `164` assigned more than once[0m
+2026-06-25T09:51:04.1147953Z    [1m[94m--> [0mescrow/src/lib.rs:181:1
+2026-06-25T09:51:04.1148457Z     [1m[94m|[0m
+2026-06-25T09:51:04.1149036Z [1m[94m181[0m [1m[94m|[0m pub enum EscrowError {
+2026-06-25T09:51:04.1149668Z     [1m[94m|[0m [1m[91m^^^^^^^^^^^^^^^^^^^^[0m
+2026-06-25T09:51:04.1150161Z [1m[94m...[0m
+2026-06-25T09:51:04.1150691Z [1m[94m354[0m [1m[94m|[0m     FundingDeadlinePassed = 164,
+2026-06-25T09:51:04.1151466Z     [1m[94m|[0m                             [1m[94m---[0m [1m[94m`164` assigned here[0m
+2026-06-25T09:51:04.1152379Z [1m[94m...[0m
+2026-06-25T09:51:04.1152931Z [1m[94m368[0m [1m[94m|[0m     InsufficientContractBalance = 164,
+2026-06-25T09:51:04.1153648Z     [1m[94m|[0m                                   [1m[94m---[0m [1m[94m`164` assigned here[0m
+2026-06-25T09:51:04.1154041Z 
+2026-06-25T09:51:04.3645288Z [1mFor more information about this error, try `rustc --explain E0081`.[0m
+2026-06-25T09:51:04.3793877Z [1m[91merror[0m: could not compile `liquifact_escrow` (lib) due to 1 previous error
+2026-06-25T09:51:04.4293862Z ##[error]Process completed with exit code 101.
+2026-06-25T09:51:04.4453859Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-06-25T09:51:04.4455244Z Post job cleanup.
+2026-06-25T09:51:04.5274850Z [command]/usr/bin/git version
+2026-06-25T09:51:04.5312087Z git version 2.54.0
+2026-06-25T09:51:04.5348571Z Temporarily overriding HOME='/home/runner/work/_temp/057b2bf1-3c23-45c1-b952-07e49bda14cf' before making global git config changes
+2026-06-25T09:51:04.5349852Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-25T09:51:04.5354564Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:51:04.5390456Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-25T09:51:04.5423226Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-25T09:51:04.5637084Z fatal: No url found for submodule path 'Liquifact-contracts' in .gitmodules
+2026-06-25T09:51:04.5674114Z ##[warning]The process '/usr/bin/git' failed with exit code 128
+2026-06-25T09:51:04.5793008Z Cleaning up orphan processes
+2026-06-25T09:51:04.6071486Z ##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/ci_logs3.txt
+++ b/ci_logs3.txt
@@ -1,0 +1,1441 @@
+﻿2026-06-25T09:52:42.1855218Z Current runner version: '2.335.1'
+2026-06-25T09:52:42.1876747Z ##[group]Runner Image Provisioner
+2026-06-25T09:52:42.1877777Z Hosted Compute Agent
+2026-06-25T09:52:42.1878313Z Version: 20260611.554
+2026-06-25T09:52:42.1878882Z Commit: 5e0782fdc9014723d3be820dd114dd31555c2bd1
+2026-06-25T09:52:42.1879468Z Build Date: 2026-06-11T21:40:46Z
+2026-06-25T09:52:42.1880060Z Worker ID: {294dac7c-7d02-458d-b6c6-e8d870859988}
+2026-06-25T09:52:42.1880644Z Azure Region: westus
+2026-06-25T09:52:42.1881090Z ##[endgroup]
+2026-06-25T09:52:42.1882317Z ##[group]Operating System
+2026-06-25T09:52:42.1882808Z Ubuntu
+2026-06-25T09:52:42.1883263Z 24.04.4
+2026-06-25T09:52:42.1883693Z LTS
+2026-06-25T09:52:42.1884103Z ##[endgroup]
+2026-06-25T09:52:42.1884614Z ##[group]Runner Image
+2026-06-25T09:52:42.1885116Z Image: ubuntu-24.04
+2026-06-25T09:52:42.1885637Z Version: 20260615.205.1
+2026-06-25T09:52:42.1886640Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260615.205/images/ubuntu/Ubuntu2404-Readme.md
+2026-06-25T09:52:42.1888153Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260615.205
+2026-06-25T09:52:42.1888918Z ##[endgroup]
+2026-06-25T09:52:42.1889908Z ##[group]GITHUB_TOKEN Permissions
+2026-06-25T09:52:42.1891472Z Contents: read
+2026-06-25T09:52:42.1891963Z Metadata: read
+2026-06-25T09:52:42.1892538Z Packages: read
+2026-06-25T09:52:42.1892986Z ##[endgroup]
+2026-06-25T09:52:42.1894743Z Secret source: None
+2026-06-25T09:52:42.1895405Z Prepare workflow directory
+2026-06-25T09:52:42.2159623Z Prepare all required actions
+2026-06-25T09:52:42.2190424Z Getting action download info
+2026-06-25T09:52:42.6360104Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2026-06-25T09:52:42.7823836Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+2026-06-25T09:52:42.9893924Z Download action repository 'Swatinem/rust-cache@v2' (SHA:e18b497796c12c097a38f9edb9d0641fb99eee32)
+2026-06-25T09:52:43.6462473Z Download action repository 'taiki-e/install-action@cargo-llvm-cov' (SHA:901c6c5742b8b5bab0a7cf0bf63286ad5e3120f3)
+2026-06-25T09:52:44.2167543Z Complete job name: fmt-build-test
+2026-06-25T09:52:44.2896211Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-06-25T09:52:44.2904856Z ##[group]Run actions/checkout@v4
+2026-06-25T09:52:44.2905829Z with:
+2026-06-25T09:52:44.2906577Z   repository: Liquifact/Liquifact-contracts
+2026-06-25T09:52:44.2914334Z   token: ***
+2026-06-25T09:52:44.2915027Z   ssh-strict: true
+2026-06-25T09:52:44.2915729Z   ssh-user: git
+2026-06-25T09:52:44.2916447Z   persist-credentials: true
+2026-06-25T09:52:44.2917379Z   clean: true
+2026-06-25T09:52:44.2918111Z   sparse-checkout-cone-mode: true
+2026-06-25T09:52:44.2918976Z   fetch-depth: 1
+2026-06-25T09:52:44.2919684Z   fetch-tags: false
+2026-06-25T09:52:44.2920414Z   show-progress: true
+2026-06-25T09:52:44.2921153Z   lfs: false
+2026-06-25T09:52:44.2921862Z   submodules: false
+2026-06-25T09:52:44.2922595Z   set-safe-directory: true
+2026-06-25T09:52:44.2923568Z ##[endgroup]
+2026-06-25T09:52:44.3915334Z Syncing repository: Liquifact/Liquifact-contracts
+2026-06-25T09:52:44.3917797Z ##[group]Getting Git version info
+2026-06-25T09:52:44.3919600Z Working directory is '/home/runner/work/Liquifact-contracts/Liquifact-contracts'
+2026-06-25T09:52:44.3921545Z [command]/usr/bin/git version
+2026-06-25T09:52:44.3969361Z git version 2.54.0
+2026-06-25T09:52:44.3996072Z ##[endgroup]
+2026-06-25T09:52:44.4007881Z Temporarily overriding HOME='/home/runner/work/_temp/0d98d104-20dc-4af5-bf2e-f66b2853a948' before making global git config changes
+2026-06-25T09:52:44.4011129Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-25T09:52:44.4014087Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:52:44.4042555Z Deleting the contents of '/home/runner/work/Liquifact-contracts/Liquifact-contracts'
+2026-06-25T09:52:44.4048488Z ##[group]Initializing the repository
+2026-06-25T09:52:44.4052206Z [command]/usr/bin/git init /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:52:44.4142107Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-06-25T09:52:44.4144393Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-06-25T09:52:44.4146546Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-06-25T09:52:44.4148556Z hint: call:
+2026-06-25T09:52:44.4149637Z hint:
+2026-06-25T09:52:44.4150744Z hint: 	git config --global init.defaultBranch <name>
+2026-06-25T09:52:44.4152219Z hint:
+2026-06-25T09:52:44.4153588Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-06-25T09:52:44.4155691Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-06-25T09:52:44.4157493Z hint:
+2026-06-25T09:52:44.4158498Z hint: 	git branch -m <name>
+2026-06-25T09:52:44.4159512Z hint:
+2026-06-25T09:52:44.4160472Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-06-25T09:52:44.4162187Z Initialized empty Git repository in /home/runner/work/Liquifact-contracts/Liquifact-contracts/.git/
+2026-06-25T09:52:44.4165550Z [command]/usr/bin/git remote add origin https://github.com/Liquifact/Liquifact-contracts
+2026-06-25T09:52:44.4182284Z ##[endgroup]
+2026-06-25T09:52:44.4184083Z ##[group]Disabling automatic garbage collection
+2026-06-25T09:52:44.4185776Z [command]/usr/bin/git config --local gc.auto 0
+2026-06-25T09:52:44.4209873Z ##[endgroup]
+2026-06-25T09:52:44.4211646Z ##[group]Setting up auth
+2026-06-25T09:52:44.4215527Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-25T09:52:44.4242240Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-25T09:52:44.4498282Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-06-25T09:52:44.4525830Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-06-25T09:52:44.4793831Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-06-25T09:52:44.4845721Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-06-25T09:52:44.5108123Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-06-25T09:52:44.5139680Z ##[endgroup]
+2026-06-25T09:52:44.5140882Z ##[group]Fetching the repository
+2026-06-25T09:52:44.5146726Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +9ebfdcb1f609307caea8b492101bf30bf0fa138e:refs/remotes/pull/427/merge
+2026-06-25T09:52:45.1074622Z From https://github.com/Liquifact/Liquifact-contracts
+2026-06-25T09:52:45.1075686Z  * [new ref]         9ebfdcb1f609307caea8b492101bf30bf0fa138e -> pull/427/merge
+2026-06-25T09:52:45.1095807Z ##[endgroup]
+2026-06-25T09:52:45.1096350Z ##[group]Determining the checkout info
+2026-06-25T09:52:45.1098435Z ##[endgroup]
+2026-06-25T09:52:45.1102814Z [command]/usr/bin/git sparse-checkout disable
+2026-06-25T09:52:45.1134995Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-06-25T09:52:45.1157178Z ##[group]Checking out the ref
+2026-06-25T09:52:45.1160230Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/427/merge
+2026-06-25T09:52:45.1458535Z Note: switching to 'refs/remotes/pull/427/merge'.
+2026-06-25T09:52:45.1459141Z 
+2026-06-25T09:52:45.1459376Z You are in 'detached HEAD' state. You can look around, make experimental
+2026-06-25T09:52:45.1459800Z changes and commit them, and you can discard any commits you make in this
+2026-06-25T09:52:45.1460218Z state without impacting any branches by switching back to a branch.
+2026-06-25T09:52:45.1460466Z 
+2026-06-25T09:52:45.1460643Z If you want to create a new branch to retain commits you create, you may
+2026-06-25T09:52:45.1461032Z do so (now or later) by using -c with the switch command. Example:
+2026-06-25T09:52:45.1461247Z 
+2026-06-25T09:52:45.1461357Z   git switch -c <new-branch-name>
+2026-06-25T09:52:45.1461525Z 
+2026-06-25T09:52:45.1461626Z Or undo this operation with:
+2026-06-25T09:52:45.1461781Z 
+2026-06-25T09:52:45.1461870Z   git switch -
+2026-06-25T09:52:45.1462026Z 
+2026-06-25T09:52:45.1462229Z Turn off this advice by setting config variable advice.detachedHead to false
+2026-06-25T09:52:45.1462521Z 
+2026-06-25T09:52:45.1462823Z HEAD is now at 9ebfdcb Merge b1ad78ade1243fe49437d3f8a6fd17128cb6a4ca into f3c49bc43a4afd486efc2e2beb59bd144adb5029
+2026-06-25T09:52:45.1464670Z ##[endgroup]
+2026-06-25T09:52:45.1498891Z [command]/usr/bin/git log -1 --format=%H
+2026-06-25T09:52:45.1517863Z 9ebfdcb1f609307caea8b492101bf30bf0fa138e
+2026-06-25T09:52:45.1803421Z ##[group]Run dtolnay/rust-toolchain@stable
+2026-06-25T09:52:45.1803743Z with:
+2026-06-25T09:52:45.1803988Z   components: rustfmt, clippy, llvm-tools-preview
+2026-06-25T09:52:45.1804274Z   toolchain: stable
+2026-06-25T09:52:45.1804487Z ##[endgroup]
+2026-06-25T09:52:45.1908208Z ##[group]Run : parse toolchain version
+2026-06-25T09:52:45.1908587Z [36;1m: parse toolchain version[0m
+2026-06-25T09:52:45.1908862Z [36;1mif [[ -z $toolchain ]]; then[0m
+2026-06-25T09:52:45.1909332Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+2026-06-25T09:52:45.1909827Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+2026-06-25T09:52:45.1910103Z [36;1m  exit 1[0m
+2026-06-25T09:52:45.1910426Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+2026-06-25T09:52:45.1910784Z [36;1m  if [[ Linux == macOS ]]; then[0m
+2026-06-25T09:52:45.1911271Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:52:45.1911717Z [36;1m  else[0m
+2026-06-25T09:52:45.1912086Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:52:45.1912482Z [36;1m  fi[0m
+2026-06-25T09:52:45.1912777Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+2026-06-25T09:52:45.1913224Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:52:45.1913612Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+2026-06-25T09:52:45.1914044Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:52:45.1914482Z [36;1melse[0m
+2026-06-25T09:52:45.1914730Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:52:45.1915013Z [36;1mfi[0m
+2026-06-25T09:52:45.2094810Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:45.2095170Z env:
+2026-06-25T09:52:45.2095384Z   toolchain: stable
+2026-06-25T09:52:45.2095615Z ##[endgroup]
+2026-06-25T09:52:45.2225434Z ##[group]Run : construct rustup command line
+2026-06-25T09:52:45.2225779Z [36;1m: construct rustup command line[0m
+2026-06-25T09:52:45.2226194Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:52:45.2226741Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:52:45.2227566Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:52:45.2253454Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:45.2253912Z env:
+2026-06-25T09:52:45.2254105Z   targets: 
+2026-06-25T09:52:45.2254345Z   components: rustfmt, clippy, llvm-tools-preview
+2026-06-25T09:52:45.2254626Z ##[endgroup]
+2026-06-25T09:52:45.2332298Z ##[group]Run : set $CARGO_HOME
+2026-06-25T09:52:45.2332578Z [36;1m: set $CARGO_HOME[0m
+2026-06-25T09:52:45.2332886Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+2026-06-25T09:52:45.2357203Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:45.2357605Z ##[endgroup]
+2026-06-25T09:52:45.2433025Z ##[group]Run : install rustup if needed
+2026-06-25T09:52:45.2433333Z [36;1m: install rustup if needed[0m
+2026-06-25T09:52:45.2433612Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+2026-06-25T09:52:45.2434267Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+2026-06-25T09:52:45.2434899Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+2026-06-25T09:52:45.2435161Z [36;1mfi[0m
+2026-06-25T09:52:45.2459249Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:45.2459563Z env:
+2026-06-25T09:52:45.2459939Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:45.2460192Z ##[endgroup]
+2026-06-25T09:52:45.2535122Z ##[group]Run rustup toolchain install stable --component rustfmt --component clippy --component llvm-tools-preview --profile minimal --no-self-update
+2026-06-25T09:52:45.2535986Z [36;1mrustup toolchain install stable --component rustfmt --component clippy --component llvm-tools-preview --profile minimal --no-self-update[0m
+2026-06-25T09:52:45.2560675Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:45.2560996Z env:
+2026-06-25T09:52:45.2561204Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:45.2561454Z   RUSTUP_PERMIT_COPY_RENAME: 1
+2026-06-25T09:52:45.2561688Z ##[endgroup]
+2026-06-25T09:52:45.8233700Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+2026-06-25T09:52:45.9303194Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T09:52:45.9396327Z info: component clippy is up to date
+2026-06-25T09:52:45.9396963Z info: component rustfmt is up to date
+2026-06-25T09:52:45.9399892Z info: downloading component llvm-tools
+2026-06-25T09:52:48.3959726Z 
+2026-06-25T09:52:48.4037824Z   stable-x86_64-unknown-linux-gnu updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.96.0 (ac68faa20 2026-05-25))
+2026-06-25T09:52:48.4038245Z 
+2026-06-25T09:52:48.4097574Z ##[group]Run rustup default stable
+2026-06-25T09:52:48.4097852Z [36;1mrustup default stable[0m
+2026-06-25T09:52:48.4124658Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:48.4124948Z env:
+2026-06-25T09:52:48.4125121Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:48.4125329Z ##[endgroup]
+2026-06-25T09:52:48.4214273Z info: using existing install for stable-x86_64-unknown-linux-gnu
+2026-06-25T09:52:48.4220650Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+2026-06-25T09:52:48.4221034Z 
+2026-06-25T09:52:48.4297086Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T09:52:48.4297508Z 
+2026-06-25T09:52:48.4329591Z ##[group]Run : create cachekey
+2026-06-25T09:52:48.4329891Z [36;1m: create cachekey[0m
+2026-06-25T09:52:48.4330297Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+2026-06-25T09:52:48.4330798Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+2026-06-25T09:52:48.4331185Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+2026-06-25T09:52:48.4358056Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:48.4358327Z env:
+2026-06-25T09:52:48.4358503Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:48.4358727Z ##[endgroup]
+2026-06-25T09:52:48.4695626Z ##[group]Run : disable incremental compilation
+2026-06-25T09:52:48.4695981Z [36;1m: disable incremental compilation[0m
+2026-06-25T09:52:48.4696248Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+2026-06-25T09:52:48.4696567Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+2026-06-25T09:52:48.4697199Z [36;1mfi[0m
+2026-06-25T09:52:48.4723693Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:48.4724017Z env:
+2026-06-25T09:52:48.4724203Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:48.4724416Z ##[endgroup]
+2026-06-25T09:52:48.4784735Z ##[group]Run : enable colors in Cargo output
+2026-06-25T09:52:48.4785016Z [36;1m: enable colors in Cargo output[0m
+2026-06-25T09:52:48.4785298Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+2026-06-25T09:52:48.4785569Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+2026-06-25T09:52:48.4785806Z [36;1mfi[0m
+2026-06-25T09:52:48.4809212Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:48.4809492Z env:
+2026-06-25T09:52:48.4809658Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:48.4809861Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:52:48.4810037Z ##[endgroup]
+2026-06-25T09:52:48.4869911Z ##[group]Run : enable Cargo sparse registry
+2026-06-25T09:52:48.4870344Z [36;1m: enable Cargo sparse registry[0m
+2026-06-25T09:52:48.4870640Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+2026-06-25T09:52:48.4871219Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+2026-06-25T09:52:48.4871771Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+2026-06-25T09:52:48.4872204Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-06-25T09:52:48.4872615Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+2026-06-25T09:52:48.4872990Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+2026-06-25T09:52:48.4873419Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-06-25T09:52:48.4873814Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+2026-06-25T09:52:48.4874081Z [36;1m  fi[0m
+2026-06-25T09:52:48.4874249Z [36;1mfi[0m
+2026-06-25T09:52:48.4897034Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:48.4897337Z env:
+2026-06-25T09:52:48.4897508Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:48.4897724Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:52:48.4897908Z   CARGO_TERM_COLOR: always
+2026-06-25T09:52:48.4898095Z ##[endgroup]
+2026-06-25T09:52:48.5208154Z ##[group]Run : work around spurious network errors in curl 8.0
+2026-06-25T09:52:48.5208531Z [36;1m: work around spurious network errors in curl 8.0[0m
+2026-06-25T09:52:48.5209002Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+2026-06-25T09:52:48.5209496Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+2026-06-25T09:52:48.5209852Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+2026-06-25T09:52:48.5210101Z [36;1mfi[0m
+2026-06-25T09:52:48.5236262Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:48.5236532Z env:
+2026-06-25T09:52:48.5236698Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:48.5236997Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:52:48.5237183Z   CARGO_TERM_COLOR: always
+2026-06-25T09:52:48.5237372Z ##[endgroup]
+2026-06-25T09:52:48.5425162Z ##[group]Run rustc +stable --version --verbose
+2026-06-25T09:52:48.5425479Z [36;1mrustc +stable --version --verbose[0m
+2026-06-25T09:52:48.5452098Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T09:52:48.5452371Z env:
+2026-06-25T09:52:48.5452540Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:48.5452750Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:52:48.5452942Z   CARGO_TERM_COLOR: always
+2026-06-25T09:52:48.5453285Z ##[endgroup]
+2026-06-25T09:52:48.5603613Z rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T09:52:48.5604015Z binary: rustc
+2026-06-25T09:52:48.5604248Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T09:52:48.5604556Z commit-date: 2026-05-25
+2026-06-25T09:52:48.5604757Z host: x86_64-unknown-linux-gnu
+2026-06-25T09:52:48.5604987Z release: 1.96.0
+2026-06-25T09:52:48.5605490Z LLVM version: 22.1.2
+2026-06-25T09:52:48.5715942Z ##[group]Run Swatinem/rust-cache@v2
+2026-06-25T09:52:48.5716182Z with:
+2026-06-25T09:52:48.5716579Z   prefix-key: v0-rust
+2026-06-25T09:52:48.5717023Z   add-job-id-key: true
+2026-06-25T09:52:48.5717311Z   add-rust-environment-hash-key: true
+2026-06-25T09:52:48.5717665Z   cache-targets: true
+2026-06-25T09:52:48.5717968Z   cache-all-crates: false
+2026-06-25T09:52:48.5718241Z   cache-workspace-crates: false
+2026-06-25T09:52:48.5718583Z   save-if: true
+2026-06-25T09:52:48.5718846Z   cache-provider: github
+2026-06-25T09:52:48.5719214Z   cache-bin: true
+2026-06-25T09:52:48.5719515Z   lookup-only: false
+2026-06-25T09:52:48.5719760Z   cmd-format: {0}
+2026-06-25T09:52:48.5720060Z env:
+2026-06-25T09:52:48.5720312Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:48.5720625Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:52:48.5720940Z   CARGO_TERM_COLOR: always
+2026-06-25T09:52:48.5721217Z ##[endgroup]
+2026-06-25T09:52:48.7979883Z (node:2151) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+2026-06-25T09:52:48.7980999Z (Use `node --trace-deprecation ...` to show where the warning was created)
+2026-06-25T09:52:48.9776350Z ##[group]Cache Configuration
+2026-06-25T09:52:48.9777269Z Cache Provider:
+2026-06-25T09:52:48.9777974Z     github
+2026-06-25T09:52:48.9778481Z Workspaces:
+2026-06-25T09:52:48.9779067Z     /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:52:48.9779684Z Cache Paths:
+2026-06-25T09:52:48.9780156Z     /home/runner/.cargo/bin
+2026-06-25T09:52:48.9780656Z     /home/runner/.cargo/.crates.toml
+2026-06-25T09:52:48.9781242Z     /home/runner/.cargo/.crates2.json
+2026-06-25T09:52:48.9781778Z     /home/runner/.cargo/registry
+2026-06-25T09:52:48.9782287Z     /home/runner/.cargo/git
+2026-06-25T09:52:48.9782905Z     /home/runner/work/Liquifact-contracts/Liquifact-contracts/target
+2026-06-25T09:52:48.9783568Z Restore Key:
+2026-06-25T09:52:48.9784058Z     v0-rust-fmt-build-test-Linux-x64-4107bf91
+2026-06-25T09:52:48.9784638Z Cache Key:
+2026-06-25T09:52:48.9785151Z     v0-rust-fmt-build-test-Linux-x64-4107bf91-e1b782ec
+2026-06-25T09:52:48.9785732Z .. Prefix:
+2026-06-25T09:52:48.9786186Z   - v0-rust-fmt-build-test-Linux-x64
+2026-06-25T09:52:48.9786729Z .. Environment considered:
+2026-06-25T09:52:48.9787437Z   - Rust Versions:
+2026-06-25T09:52:48.9788053Z     - 1.96.0 x86_64-unknown-linux-gnu ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T09:52:48.9788846Z     - 1.96.0 x86_64-unknown-linux-gnu ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T09:52:48.9789515Z   - CARGO_HOME
+2026-06-25T09:52:48.9789977Z   - CARGO_INCREMENTAL
+2026-06-25T09:52:48.9790471Z   - CARGO_TERM_COLOR
+2026-06-25T09:52:48.9790932Z .. Lockfiles considered:
+2026-06-25T09:52:48.9791546Z   - /home/runner/work/Liquifact-contracts/Liquifact-contracts/Cargo.lock
+2026-06-25T09:52:48.9792371Z   - /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/Cargo.toml
+2026-06-25T09:52:48.9793301Z ##[endgroup]
+2026-06-25T09:52:48.9793605Z 
+2026-06-25T09:52:48.9793899Z ... Restoring cache ...
+2026-06-25T09:52:49.2292302Z No cache found.
+2026-06-25T09:52:49.2388231Z ##[group]Run cargo fmt -p liquifact_escrow -- --check
+2026-06-25T09:52:49.2388557Z [36;1mcargo fmt -p liquifact_escrow -- --check[0m
+2026-06-25T09:52:49.2417044Z shell: /usr/bin/bash -e {0}
+2026-06-25T09:52:49.2417248Z env:
+2026-06-25T09:52:49.2417419Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:49.2417639Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:52:49.2417822Z   CARGO_TERM_COLOR: always
+2026-06-25T09:52:49.2418004Z   CACHE_ON_FAILURE: false
+2026-06-25T09:52:49.2418346Z ##[endgroup]
+2026-06-25T09:52:49.4579163Z ##[group]Run cargo clippy -p liquifact_escrow -- -D warnings
+2026-06-25T09:52:49.4579734Z [36;1mcargo clippy -p liquifact_escrow -- -D warnings[0m
+2026-06-25T09:52:49.4618267Z shell: /usr/bin/bash -e {0}
+2026-06-25T09:52:49.4618580Z env:
+2026-06-25T09:52:49.4618827Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:52:49.4619160Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:52:49.4619444Z   CARGO_TERM_COLOR: always
+2026-06-25T09:52:49.4619733Z   CACHE_ON_FAILURE: false
+2026-06-25T09:52:49.4620011Z ##[endgroup]
+2026-06-25T09:52:49.7247834Z [1m[92m    Updating[0m crates.io index
+2026-06-25T09:52:49.9795354Z [1m[92m Downloading[0m crates ...
+2026-06-25T09:52:50.1313987Z [1m[92m  Downloaded[0m ark-bn254 v0.4.0
+2026-06-25T09:52:50.1355740Z [1m[92m  Downloaded[0m arbitrary v1.3.2
+2026-06-25T09:52:50.1376437Z [1m[92m  Downloaded[0m serde_derive v1.0.228
+2026-06-25T09:52:50.1405687Z [1m[92m  Downloaded[0m sha2 v0.10.9
+2026-06-25T09:52:50.1431438Z [1m[92m  Downloaded[0m time-macros v0.2.27
+2026-06-25T09:52:50.1453050Z [1m[92m  Downloaded[0m static_assertions v1.1.0
+2026-06-25T09:52:50.1469847Z [1m[92m  Downloaded[0m soroban-builtin-sdk-macros v25.0.1
+2026-06-25T09:52:50.1480674Z [1m[92m  Downloaded[0m typenum v1.19.0
+2026-06-25T09:52:50.1508877Z [1m[92m  Downloaded[0m subtle v2.6.1
+2026-06-25T09:52:50.1522811Z [1m[92m  Downloaded[0m escape-bytes v0.1.1
+2026-06-25T09:52:50.1539603Z [1m[92m  Downloaded[0m wasmi_core v0.13.0
+2026-06-25T09:52:50.1556628Z [1m[92m  Downloaded[0m version_check v0.9.5
+2026-06-25T09:52:50.1572231Z [1m[92m  Downloaded[0m time-core v0.1.8
+2026-06-25T09:52:50.1585325Z [1m[92m  Downloaded[0m strsim v0.11.1
+2026-06-25T09:52:50.1600785Z [1m[92m  Downloaded[0m zeroize_derive v1.4.3
+2026-06-25T09:52:50.1614136Z [1m[92m  Downloaded[0m soroban-env-common v25.0.1
+2026-06-25T09:52:50.1642479Z [1m[92m  Downloaded[0m zmij v1.0.21
+2026-06-25T09:52:50.1661771Z [1m[92m  Downloaded[0m zeroize v1.8.2
+2026-06-25T09:52:50.1678478Z [1m[92m  Downloaded[0m stellar-strkey v0.0.13
+2026-06-25T09:52:50.1705729Z [1m[92m  Downloaded[0m smallvec v1.15.1
+2026-06-25T09:52:50.1728080Z [1m[92m  Downloaded[0m heapless v0.8.0
+2026-06-25T09:52:50.1762969Z [1m[92m  Downloaded[0m unicode-ident v1.0.24
+2026-06-25T09:52:50.1789742Z [1m[92m  Downloaded[0m darling v0.20.11
+2026-06-25T09:52:50.1834338Z [1m[92m  Downloaded[0m num-conv v0.2.0
+2026-06-25T09:52:50.1843171Z [1m[92m  Downloaded[0m ppv-lite86 v0.2.21
+2026-06-25T09:52:50.1857261Z [1m[92m  Downloaded[0m rand_chacha v0.3.1
+2026-06-25T09:52:50.1870640Z [1m[92m  Downloaded[0m ark-ff v0.4.2
+2026-06-25T09:52:50.1907160Z [1m[92m  Downloaded[0m wasmparser-nostd v0.100.2
+2026-06-25T09:52:50.1951221Z [1m[92m  Downloaded[0m serde_with v3.12.0
+2026-06-25T09:52:50.2020400Z [1m[92m  Downloaded[0m soroban-wasmi v0.31.1-soroban.20.0.1
+2026-06-25T09:52:50.2076251Z [1m[92m  Downloaded[0m time v0.3.47
+2026-06-25T09:52:50.2180670Z [1m[92m  Downloaded[0m wasmparser v0.116.1
+2026-06-25T09:52:50.2225984Z [1m[92m  Downloaded[0m libm v0.2.16
+2026-06-25T09:52:50.2314875Z [1m[92m  Downloaded[0m itertools v0.10.5
+2026-06-25T09:52:50.2367541Z [1m[92m  Downloaded[0m indexmap v2.13.0
+2026-06-25T09:52:50.2404814Z [1m[92m  Downloaded[0m syn v2.0.117
+2026-06-25T09:52:50.2490307Z [1m[92m  Downloaded[0m zerocopy v0.8.42
+2026-06-25T09:52:50.2622734Z [1m[92m  Downloaded[0m hashbrown v0.16.1
+2026-06-25T09:52:50.2663311Z [1m[92m  Downloaded[0m syn v1.0.109
+2026-06-25T09:52:50.2738411Z [1m[92m  Downloaded[0m chrono v0.4.44
+2026-06-25T09:52:50.2791569Z [1m[92m  Downloaded[0m soroban-sdk v25.2.0
+2026-06-25T09:52:50.2837972Z [1m[92m  Downloaded[0m curve25519-dalek v4.1.3
+2026-06-25T09:52:50.2929304Z [1m[92m  Downloaded[0m k256 v0.13.4
+2026-06-25T09:52:50.2972092Z [1m[92m  Downloaded[0m memchr v2.8.0
+2026-06-25T09:52:50.3019016Z [1m[92m  Downloaded[0m hmac v0.12.1
+2026-06-25T09:52:50.3035398Z [1m[92m  Downloaded[0m ethnum v1.5.2
+2026-06-25T09:52:50.3069622Z [1m[92m  Downloaded[0m schemars v0.8.22
+2026-06-25T09:52:50.3173379Z [1m[92m  Downloaded[0m getrandom v0.2.17
+2026-06-25T09:52:50.3200195Z [1m[92m  Downloaded[0m base64ct v1.8.3
+2026-06-25T09:52:50.3223558Z [1m[92m  Downloaded[0m p256 v0.13.2
+2026-06-25T09:52:50.3251069Z [1m[92m  Downloaded[0m indexmap v1.9.3
+2026-06-25T09:52:50.3277040Z [1m[92m  Downloaded[0m iana-time-zone v0.1.65
+2026-06-25T09:52:50.3300355Z [1m[92m  Downloaded[0m ff v0.13.1
+2026-06-25T09:52:50.3312862Z [1m[92m  Downloaded[0m rand v0.8.5
+2026-06-25T09:52:50.3341435Z [1m[92m  Downloaded[0m proc-macro2 v1.0.106
+2026-06-25T09:52:50.3364910Z [1m[92m  Downloaded[0m soroban-env-host v25.0.1
+2026-06-25T09:52:50.3554336Z [1m[92m  Downloaded[0m primeorder v0.13.6
+2026-06-25T09:52:50.3565431Z [1m[92m  Downloaded[0m paste v1.0.15
+2026-06-25T09:52:50.3590757Z [1m[92m  Downloaded[0m num-traits v0.2.19
+2026-06-25T09:52:50.3612194Z [1m[92m  Downloaded[0m num-integer v0.1.46
+2026-06-25T09:52:50.3625188Z [1m[92m  Downloaded[0m ecdsa v0.16.9
+2026-06-25T09:52:50.3639495Z [1m[92m  Downloaded[0m der v0.7.10
+2026-06-25T09:52:50.3680767Z [1m[92m  Downloaded[0m serde_json v1.0.149
+2026-06-25T09:52:50.3739268Z [1m[92m  Downloaded[0m rand_core v0.6.4
+2026-06-25T09:52:50.3750161Z [1m[92m  Downloaded[0m macro-string v0.1.4
+2026-06-25T09:52:50.3765167Z [1m[92m  Downloaded[0m indexmap-nostd v0.4.0
+2026-06-25T09:52:50.3775279Z [1m[92m  Downloaded[0m fnv v1.0.7
+2026-06-25T09:52:50.3782999Z [1m[92m  Downloaded[0m sha3 v0.10.8
+2026-06-25T09:52:50.3817935Z [1m[92m  Downloaded[0m powerfmt v0.2.0
+2026-06-25T09:52:50.3827313Z [1m[92m  Downloaded[0m num-bigint v0.4.6
+2026-06-25T09:52:50.3865138Z [1m[92m  Downloaded[0m hex v0.4.3
+2026-06-25T09:52:50.3878499Z [1m[92m  Downloaded[0m hashbrown v0.13.2
+2026-06-25T09:52:50.3908847Z [1m[92m  Downloaded[0m hashbrown v0.12.3
+2026-06-25T09:52:50.3938286Z [1m[92m  Downloaded[0m either v1.15.0
+2026-06-25T09:52:50.3951112Z [1m[92m  Downloaded[0m digest v0.10.7
+2026-06-25T09:52:50.3965582Z [1m[92m  Downloaded[0m deranged v0.5.8
+2026-06-25T09:52:50.3977357Z [1m[92m  Downloaded[0m libc v0.2.183
+2026-06-25T09:52:50.4284132Z [1m[92m  Downloaded[0m byteorder v1.5.0
+2026-06-25T09:52:50.4296653Z [1m[92m  Downloaded[0m generic-array v0.14.9
+2026-06-25T09:52:50.4308272Z [1m[92m  Downloaded[0m darling_macro v0.20.11
+2026-06-25T09:52:50.4313051Z [1m[92m  Downloaded[0m hash32 v0.3.1
+2026-06-25T09:52:50.4324353Z [1m[92m  Downloaded[0m dtor v0.1.1
+2026-06-25T09:52:50.4332564Z [1m[92m  Downloaded[0m downcast-rs v1.2.1
+2026-06-25T09:52:50.4342745Z [1m[92m  Downloaded[0m ctor v0.5.0
+2026-06-25T09:52:50.4350916Z [1m[92m  Downloaded[0m cpufeatures v0.2.17
+2026-06-25T09:52:50.4361383Z [1m[92m  Downloaded[0m ark-std v0.4.0
+2026-06-25T09:52:50.4372777Z [1m[92m  Downloaded[0m keccak v0.1.6
+2026-06-25T09:52:50.4381922Z [1m[92m  Downloaded[0m ed25519-dalek v2.2.0
+2026-06-25T09:52:50.4406274Z [1m[92m  Downloaded[0m const-oid v0.9.6
+2026-06-25T09:52:50.4421140Z [1m[92m  Downloaded[0m soroban-env-macros v25.0.1
+2026-06-25T09:52:50.4429860Z [1m[92m  Downloaded[0m serde_with_macros v3.12.0
+2026-06-25T09:52:50.4443858Z [1m[92m  Downloaded[0m cfg_eval v0.1.2
+2026-06-25T09:52:50.4457109Z [1m[92m  Downloaded[0m ark-poly v0.4.2
+2026-06-25T09:52:50.4478729Z [1m[92m  Downloaded[0m once_cell v1.21.4
+2026-06-25T09:52:50.4498275Z [1m[92m  Downloaded[0m ctor-proc-macro v0.0.6
+2026-06-25T09:52:50.4504546Z [1m[92m  Downloaded[0m thiserror-impl v1.0.69
+2026-06-25T09:52:50.4514756Z [1m[92m  Downloaded[0m thiserror v1.0.69
+2026-06-25T09:52:50.4558318Z [1m[92m  Downloaded[0m prettyplease v0.2.37
+2026-06-25T09:52:50.4586097Z [1m[92m  Downloaded[0m serde_core v1.0.228
+2026-06-25T09:52:50.4607800Z [1m[92m  Downloaded[0m quote v1.0.45
+2026-06-25T09:52:50.4629589Z [1m[92m  Downloaded[0m pkcs8 v0.10.2
+2026-06-25T09:52:50.4651152Z [1m[92m  Downloaded[0m itoa v1.0.17
+2026-06-25T09:52:50.4662343Z [1m[92m  Downloaded[0m group v0.13.0
+2026-06-25T09:52:50.4675197Z [1m[92m  Downloaded[0m derivative v2.2.0
+2026-06-25T09:52:50.4736653Z [1m[92m  Downloaded[0m wasmi_arena v0.4.1
+2026-06-25T09:52:50.4743880Z [1m[92m  Downloaded[0m visibility v0.1.1
+2026-06-25T09:52:50.4754524Z [1m[92m  Downloaded[0m soroban-spec-rust v25.3.0
+2026-06-25T09:52:50.4761763Z [1m[92m  Downloaded[0m soroban-spec v25.3.0
+2026-06-25T09:52:50.4768918Z [1m[92m  Downloaded[0m num-derive v0.4.2
+2026-06-25T09:52:50.4782935Z [1m[92m  Downloaded[0m ident_case v1.0.1
+2026-06-25T09:52:50.4789485Z [1m[92m  Downloaded[0m hex-literal v0.4.1
+2026-06-25T09:52:50.4797226Z [1m[92m  Downloaded[0m elliptic-curve v0.13.8
+2026-06-25T09:52:50.4827520Z [1m[92m  Downloaded[0m rustc_version v0.4.1
+2026-06-25T09:52:50.4838279Z [1m[92m  Downloaded[0m darling_core v0.20.11
+2026-06-25T09:52:50.4878518Z [1m[92m  Downloaded[0m crypto-bigint v0.5.5
+2026-06-25T09:52:50.4934458Z [1m[92m  Downloaded[0m base64 v0.22.1
+2026-06-25T09:52:50.4964544Z [1m[92m  Downloaded[0m soroban-sdk-macros v25.3.0
+2026-06-25T09:52:50.4982265Z [1m[92m  Downloaded[0m rfc6979 v0.4.0
+2026-06-25T09:52:50.4990466Z [1m[92m  Downloaded[0m heck v0.5.0
+2026-06-25T09:52:50.5000567Z [1m[92m  Downloaded[0m stellar-strkey v0.0.16
+2026-06-25T09:52:50.5025690Z [1m[92m  Downloaded[0m ed25519 v2.2.3
+2026-06-25T09:52:50.5039923Z [1m[92m  Downloaded[0m derive_arbitrary v1.3.2
+2026-06-25T09:52:50.5047756Z [1m[92m  Downloaded[0m data-encoding v2.10.0
+2026-06-25T09:52:50.5054902Z [1m[92m  Downloaded[0m crypto-common v0.1.6
+2026-06-25T09:52:50.5062368Z [1m[92m  Downloaded[0m ark-bls12-381 v0.4.0
+2026-06-25T09:52:50.5090013Z [1m[92m  Downloaded[0m equivalent v1.0.2
+2026-06-25T09:52:50.5097381Z [1m[92m  Downloaded[0m crate-git-revision v0.0.6
+2026-06-25T09:52:50.5107166Z [1m[92m  Downloaded[0m autocfg v1.5.0
+2026-06-25T09:52:50.5122465Z [1m[92m  Downloaded[0m ark-ff-macros v0.4.2
+2026-06-25T09:52:50.5133597Z [1m[92m  Downloaded[0m soroban-ledger-snapshot v25.3.0
+2026-06-25T09:52:50.5141890Z [1m[92m  Downloaded[0m signature v2.2.0
+2026-06-25T09:52:50.5152914Z [1m[92m  Downloaded[0m dyn-clone v1.0.20
+2026-06-25T09:52:50.5165549Z [1m[92m  Downloaded[0m curve25519-dalek-derive v0.1.1
+2026-06-25T09:52:50.5173505Z [1m[92m  Downloaded[0m base16ct v0.2.0
+2026-06-25T09:52:50.5184136Z [1m[92m  Downloaded[0m ark-serialize v0.4.2
+2026-06-25T09:52:50.5192639Z [1m[92m  Downloaded[0m stable_deref_trait v1.2.1
+2026-06-25T09:52:50.5199245Z [1m[92m  Downloaded[0m sec1 v0.7.3
+2026-06-25T09:52:50.5211821Z [1m[92m  Downloaded[0m dtor-proc-macro v0.0.6
+2026-06-25T09:52:50.5220589Z [1m[92m  Downloaded[0m cfg-if v1.0.4
+2026-06-25T09:52:50.5237492Z [1m[92m  Downloaded[0m bytes-lit v0.0.5
+2026-06-25T09:52:50.5240382Z [1m[92m  Downloaded[0m block-buffer v0.10.4
+2026-06-25T09:52:50.5248856Z [1m[92m  Downloaded[0m ark-serialize-derive v0.4.2
+2026-06-25T09:52:50.5255849Z [1m[92m  Downloaded[0m spki v0.7.3
+2026-06-25T09:52:50.5269944Z [1m[92m  Downloaded[0m spin v0.9.8
+2026-06-25T09:52:50.5289385Z [1m[92m  Downloaded[0m ark-ff-asm v0.4.2
+2026-06-25T09:52:50.5296518Z [1m[92m  Downloaded[0m serde v1.0.228
+2026-06-25T09:52:50.5324315Z [1m[92m  Downloaded[0m ark-ec v0.4.2
+2026-06-25T09:52:50.5357253Z [1m[92m  Downloaded[0m stellar-xdr v25.0.0
+2026-06-25T09:52:50.6095448Z [1m[92m  Downloaded[0m ahash v0.8.12
+2026-06-25T09:52:50.6113411Z [1m[92m  Downloaded[0m semver v1.0.27
+2026-06-25T09:52:50.7021261Z [1m[92m   Compiling[0m proc-macro2 v1.0.106
+2026-06-25T09:52:50.7021977Z [1m[92m   Compiling[0m unicode-ident v1.0.24
+2026-06-25T09:52:50.7022629Z [1m[92m   Compiling[0m quote v1.0.45
+2026-06-25T09:52:50.7023086Z [1m[92m   Compiling[0m version_check v0.9.5
+2026-06-25T09:52:50.8161049Z [1m[92m   Compiling[0m typenum v1.19.0
+2026-06-25T09:52:50.9535477Z [1m[92m   Compiling[0m serde_core v1.0.228
+2026-06-25T09:52:50.9878612Z [1m[92m   Compiling[0m zmij v1.0.21
+2026-06-25T09:52:50.9958532Z [1m[92m   Compiling[0m serde v1.0.228
+2026-06-25T09:52:51.1270886Z [1m[92m   Compiling[0m serde_json v1.0.149
+2026-06-25T09:52:51.2198176Z [1m[92m   Compiling[0m itoa v1.0.17
+2026-06-25T09:52:51.3083343Z [1m[92m   Compiling[0m memchr v2.8.0
+2026-06-25T09:52:51.4918185Z [1m[92m   Compiling[0m syn v2.0.117
+2026-06-25T09:52:51.5145084Z [1m[92m   Compiling[0m generic-array v0.14.9
+2026-06-25T09:52:51.6279350Z [1m[92m    Checking[0m cfg-if v1.0.4
+2026-06-25T09:52:51.8177654Z [1m[92m    Checking[0m subtle v2.6.1
+2026-06-25T09:52:51.8818720Z [1m[92m   Compiling[0m autocfg v1.5.0
+2026-06-25T09:52:52.1398138Z [1m[92m    Checking[0m const-oid v0.9.6
+2026-06-25T09:52:52.1728077Z [1m[92m   Compiling[0m libc v0.2.183
+2026-06-25T09:52:52.2148338Z [1m[92m   Compiling[0m num-traits v0.2.19
+2026-06-25T09:52:52.3168165Z [1m[92m   Compiling[0m zerocopy v0.8.42
+2026-06-25T09:52:53.0940333Z [1m[92m    Checking[0m getrandom v0.2.17
+2026-06-25T09:52:53.1688068Z [1m[92m    Checking[0m rand_core v0.6.4
+2026-06-25T09:52:53.8290057Z [1m[92m   Compiling[0m fnv v1.0.7
+2026-06-25T09:52:53.8375172Z [1m[92m   Compiling[0m syn v1.0.109
+2026-06-25T09:52:53.8650542Z [1m[92m   Compiling[0m ident_case v1.0.1
+2026-06-25T09:52:53.9140288Z [1m[92m   Compiling[0m strsim v0.11.1
+2026-06-25T09:52:54.1448247Z [1m[92m   Compiling[0m darling_core v0.20.11
+2026-06-25T09:52:54.9778518Z [1m[92m   Compiling[0m semver v1.0.27
+2026-06-25T09:52:55.3078186Z [1m[92m   Compiling[0m serde_derive v1.0.228
+2026-06-25T09:52:56.0547995Z [1m[92m   Compiling[0m zeroize_derive v1.4.3
+2026-06-25T09:52:56.0818125Z [1m[92m   Compiling[0m darling_macro v0.20.11
+2026-06-25T09:52:56.2908255Z [1m[92m   Compiling[0m paste v1.0.15
+2026-06-25T09:52:56.4158603Z [1m[92m    Checking[0m zeroize v1.8.2
+2026-06-25T09:52:56.4316608Z [1m[92m   Compiling[0m schemars v0.8.22
+2026-06-25T09:52:56.5408264Z [1m[92m   Compiling[0m darling v0.20.11
+2026-06-25T09:52:56.5743867Z [1m[92m    Checking[0m ppv-lite86 v0.2.21
+2026-06-25T09:52:56.7968332Z [1m[92m   Compiling[0m crypto-common v0.1.6
+2026-06-25T09:52:56.8508430Z [1m[92m   Compiling[0m block-buffer v0.10.4
+2026-06-25T09:52:56.9557369Z [1m[92m   Compiling[0m dyn-clone v1.0.20
+2026-06-25T09:52:56.9668349Z [1m[92m    Checking[0m digest v0.10.7
+2026-06-25T09:52:57.0828810Z [1m[92m    Checking[0m rand_chacha v0.3.1
+2026-06-25T09:52:57.1338393Z [1m[92m   Compiling[0m serde_with_macros v3.12.0
+2026-06-25T09:52:57.4994497Z [1m[92m   Compiling[0m cfg_eval v0.1.2
+2026-06-25T09:52:57.6728604Z [1m[92m   Compiling[0m num-integer v0.1.46
+2026-06-25T09:52:57.8756462Z [1m[92m   Compiling[0m data-encoding v2.10.0
+2026-06-25T09:52:57.9138444Z [1m[92m   Compiling[0m cpufeatures v0.2.17
+2026-06-25T09:52:57.9416451Z [1m[92m   Compiling[0m sha2 v0.10.9
+2026-06-25T09:52:58.1708277Z [1m[92m   Compiling[0m crate-git-revision v0.0.6
+2026-06-25T09:52:58.3138450Z [1m[92m   Compiling[0m stellar-strkey v0.0.13
+2026-06-25T09:52:58.3668259Z [1m[92m   Compiling[0m stellar-xdr v25.0.0
+2026-06-25T09:52:58.4729679Z [1m[92m   Compiling[0m hex v0.4.3
+2026-06-25T09:52:58.6349298Z [1m[92m   Compiling[0m num-bigint v0.4.6
+2026-06-25T09:52:58.6518604Z [1m[92m    Checking[0m rand v0.8.5
+2026-06-25T09:52:59.0313114Z [1m[92m   Compiling[0m serde_with v3.12.0
+2026-06-25T09:52:59.0798969Z [1m[92m   Compiling[0m ahash v0.8.12
+2026-06-25T09:52:59.1768310Z [1m[92m   Compiling[0m ethnum v1.5.2
+2026-06-25T09:52:59.2568285Z [1m[92m   Compiling[0m escape-bytes v0.1.1
+2026-06-25T09:52:59.3618136Z [1m[92m    Checking[0m ark-std v0.4.0
+2026-06-25T09:52:59.7530677Z [1m[92m   Compiling[0m ark-serialize-derive v0.4.2
+2026-06-25T09:52:59.7698666Z [1m[92m    Checking[0m der v0.7.10
+2026-06-25T09:53:00.0037256Z [1m[92m   Compiling[0m rustc_version v0.4.1
+2026-06-25T09:53:00.1863369Z [1m[92m    Checking[0m ff v0.13.1
+2026-06-25T09:53:00.1965704Z [1m[92m    Checking[0m either v1.15.0
+2026-06-25T09:53:00.2237941Z [1m[92m    Checking[0m once_cell v1.21.4
+2026-06-25T09:53:00.2977149Z [1m[92m    Checking[0m base16ct v0.2.0
+2026-06-25T09:53:00.3018587Z [1m[92m    Checking[0m itertools v0.10.5
+2026-06-25T09:53:00.3448851Z [1m[92m    Checking[0m sec1 v0.7.3
+2026-06-25T09:53:00.5058085Z [1m[92m    Checking[0m group v0.13.0
+2026-06-25T09:53:00.5947978Z [1m[92m    Checking[0m ark-serialize v0.4.2
+2026-06-25T09:53:00.7210533Z [1m[92m   Compiling[0m ark-ff-macros v0.4.2
+2026-06-25T09:53:01.0763111Z [1m[92m   Compiling[0m ark-ff-asm v0.4.2
+2026-06-25T09:53:01.3178792Z [1m[92m   Compiling[0m derivative v2.2.0
+2026-06-25T09:53:01.3299762Z [1m[92m    Checking[0m signature v2.2.0
+2026-06-25T09:53:01.3800801Z [1m[92m    Checking[0m crypto-bigint v0.5.5
+2026-06-25T09:53:01.4098177Z [1m[92m   Compiling[0m libm v0.2.16
+2026-06-25T09:53:01.5717285Z [1m[92m    Checking[0m hashbrown v0.13.2
+2026-06-25T09:53:01.9115521Z [1m[92m    Checking[0m hmac v0.12.1
+2026-06-25T09:53:01.9718822Z [1m[92m   Compiling[0m equivalent v1.0.2
+2026-06-25T09:53:02.1880197Z [1m[92m   Compiling[0m thiserror v1.0.69
+2026-06-25T09:53:02.2154322Z [1m[92m    Checking[0m elliptic-curve v0.13.8
+2026-06-25T09:53:02.3277961Z [1m[92m   Compiling[0m hashbrown v0.16.1
+2026-06-25T09:53:02.4448034Z [1m[92m    Checking[0m rfc6979 v0.4.0
+2026-06-25T09:53:02.6038080Z [1m[92m    Checking[0m ark-ff v0.4.2
+2026-06-25T09:53:02.7573109Z [1m[92m   Compiling[0m indexmap v2.13.0
+2026-06-25T09:53:03.0748279Z [1m[92m   Compiling[0m curve25519-dalek v4.1.3
+2026-06-25T09:53:03.2648379Z [1m[92m   Compiling[0m num-derive v0.4.2
+2026-06-25T09:53:03.2667597Z [1m[92m   Compiling[0m thiserror-impl v1.0.69
+2026-06-25T09:53:03.8403259Z [1m[92m    Checking[0m downcast-rs v1.2.1
+2026-06-25T09:53:03.8674959Z [1m[92m    Checking[0m indexmap-nostd v0.4.0
+2026-06-25T09:53:04.3248332Z [1m[92m   Compiling[0m prettyplease v0.2.37
+2026-06-25T09:53:04.4718274Z [1m[92m    Checking[0m wasmparser-nostd v0.100.2
+2026-06-25T09:53:04.7988448Z [1m[92m    Checking[0m wasmi_core v0.13.0
+2026-06-25T09:53:05.0018220Z [1m[92m   Compiling[0m wasmparser v0.116.1
+2026-06-25T09:53:06.3068911Z [1m[92m    Checking[0m ark-poly v0.4.2
+2026-06-25T09:53:06.4548244Z [1m[92m    Checking[0m ecdsa v0.16.9
+2026-06-25T09:53:06.7878720Z [1m[92m    Checking[0m ark-ec v0.4.2
+2026-06-25T09:53:06.8058279Z [1m[92m   Compiling[0m soroban-env-common v25.0.1
+2026-06-25T09:53:06.9808795Z [1m[92m   Compiling[0m curve25519-dalek-derive v0.1.1
+2026-06-25T09:53:07.3408342Z [1m[92m   Compiling[0m base64 v0.22.1
+2026-06-25T09:53:07.8498308Z [1m[92m   Compiling[0m heapless v0.8.0
+2026-06-25T09:53:08.1398563Z [1m[92m    Checking[0m smallvec v1.15.1
+2026-06-25T09:53:08.2568229Z [1m[92m    Checking[0m byteorder v1.5.0
+2026-06-25T09:53:08.3228865Z [1m[92m    Checking[0m wasmi_arena v0.4.1
+2026-06-25T09:53:08.3478241Z [1m[92m    Checking[0m spin v0.9.8
+2026-06-25T09:53:08.3938563Z [1m[92m    Checking[0m hash32 v0.3.1
+2026-06-25T09:53:08.4168783Z [1m[92m    Checking[0m soroban-wasmi v0.31.1-soroban.20.0.1
+2026-06-25T09:53:12.0942621Z [1m[92m    Checking[0m primeorder v0.13.6
+2026-06-25T09:53:12.2608152Z [1m[92m    Checking[0m ed25519 v2.2.3
+2026-06-25T09:53:12.3229497Z [1m[92m   Compiling[0m stellar-strkey v0.0.16
+2026-06-25T09:53:12.3678547Z [1m[92m   Compiling[0m static_assertions v1.1.0
+2026-06-25T09:53:12.3958387Z [1m[92m    Checking[0m stable_deref_trait v1.2.1
+2026-06-25T09:53:12.4218386Z [1m[92m   Compiling[0m soroban-env-host v25.0.1
+2026-06-25T09:53:12.4448091Z [1m[92m    Checking[0m keccak v0.1.6
+2026-06-25T09:53:12.5478759Z [1m[92m    Checking[0m sha3 v0.10.8
+2026-06-25T09:53:12.6868595Z [1m[92m    Checking[0m ed25519-dalek v2.2.0
+2026-06-25T09:53:12.7818746Z [1m[92m    Checking[0m p256 v0.13.2
+2026-06-25T09:53:12.9469134Z [1m[92m    Checking[0m ark-bn254 v0.4.0
+2026-06-25T09:53:12.9507984Z [1m[92m    Checking[0m ark-bls12-381 v0.4.0
+2026-06-25T09:53:13.1510086Z [1m[92m    Checking[0m k256 v0.13.4
+2026-06-25T09:53:13.3963329Z [1m[92m   Compiling[0m soroban-builtin-sdk-macros v25.0.1
+2026-06-25T09:53:13.3986674Z [1m[92m   Compiling[0m soroban-sdk v25.2.0
+2026-06-25T09:53:13.4998336Z [1m[92m   Compiling[0m macro-string v0.1.4
+2026-06-25T09:53:13.8755120Z [1m[92m    Checking[0m hex-literal v0.4.1
+2026-06-25T09:53:13.9047756Z [1m[92m   Compiling[0m heck v0.5.0
+2026-06-25T09:53:14.5198232Z [1m[92m   Compiling[0m bytes-lit v0.0.5
+2026-06-25T09:53:14.7068229Z [1m[92m   Compiling[0m visibility v0.1.1
+2026-06-25T09:53:16.5717516Z [1m[92m   Compiling[0m soroban-spec v25.3.0
+2026-06-25T09:53:16.6654650Z [1m[92m   Compiling[0m soroban-spec-rust v25.3.0
+2026-06-25T09:53:17.0329236Z [1m[92m   Compiling[0m soroban-env-macros v25.0.1
+2026-06-25T09:53:18.7284705Z [1m[92m   Compiling[0m soroban-sdk-macros v25.3.0
+2026-06-25T09:53:21.6407587Z [1m[92m    Checking[0m liquifact_escrow v0.1.0 (/home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow)
+2026-06-25T09:53:22.2518470Z [1m[92m    Finished[0m `dev` profile [unoptimized + debuginfo] target(s) in 32.73s
+2026-06-25T09:53:22.3057608Z ##[group]Run cargo build
+2026-06-25T09:53:22.3058094Z [36;1mcargo build[0m
+2026-06-25T09:53:22.3098291Z shell: /usr/bin/bash -e {0}
+2026-06-25T09:53:22.3098559Z env:
+2026-06-25T09:53:22.3098760Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:53:22.3099028Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:53:22.3099258Z   CARGO_TERM_COLOR: always
+2026-06-25T09:53:22.3099502Z   CACHE_ON_FAILURE: false
+2026-06-25T09:53:22.3099741Z ##[endgroup]
+2026-06-25T09:53:22.5207531Z [1m[92m   Compiling[0m cfg-if v1.0.4
+2026-06-25T09:53:22.5208080Z [1m[92m   Compiling[0m typenum v1.19.0
+2026-06-25T09:53:22.5236714Z [1m[92m   Compiling[0m zmij v1.0.21
+2026-06-25T09:53:22.5239505Z [1m[92m   Compiling[0m itoa v1.0.17
+2026-06-25T09:53:22.5486952Z [1m[92m   Compiling[0m memchr v2.8.0
+2026-06-25T09:53:22.6365993Z [1m[92m   Compiling[0m zeroize v1.8.2
+2026-06-25T09:53:22.7468794Z [1m[92m   Compiling[0m subtle v2.6.1
+2026-06-25T09:53:22.7498986Z [1m[92m   Compiling[0m const-oid v0.9.6
+2026-06-25T09:53:22.8290706Z [1m[92m   Compiling[0m libc v0.2.183
+2026-06-25T09:53:22.8708754Z [1m[92m   Compiling[0m cpufeatures v0.2.17
+2026-06-25T09:53:22.9058370Z [1m[92m   Compiling[0m num-traits v0.2.19
+2026-06-25T09:53:23.0498254Z [1m[92m   Compiling[0m serde_json v1.0.149
+2026-06-25T09:53:23.1777949Z [1m[92m   Compiling[0m generic-array v0.14.9
+2026-06-25T09:53:23.4579151Z [1m[92m   Compiling[0m zerocopy v0.8.42
+2026-06-25T09:53:23.5272799Z [1m[92m   Compiling[0m getrandom v0.2.17
+2026-06-25T09:53:23.6129689Z [1m[92m   Compiling[0m crypto-common v0.1.6
+2026-06-25T09:53:23.6428307Z [1m[92m   Compiling[0m block-buffer v0.10.4
+2026-06-25T09:53:23.6648207Z [1m[92m   Compiling[0m rand_core v0.6.4
+2026-06-25T09:53:23.7058260Z [1m[92m   Compiling[0m digest v0.10.7
+2026-06-25T09:53:23.7968256Z [1m[92m   Compiling[0m crate-git-revision v0.0.6
+2026-06-25T09:53:23.8419311Z [1m[92m   Compiling[0m semver v1.0.27
+2026-06-25T09:53:24.0718954Z [1m[92m   Compiling[0m data-encoding v2.10.0
+2026-06-25T09:53:24.1362772Z [1m[92m   Compiling[0m stellar-strkey v0.0.13
+2026-06-25T09:53:24.2328246Z [1m[92m   Compiling[0m schemars v0.8.22
+2026-06-25T09:53:24.7958271Z [1m[92m   Compiling[0m stellar-xdr v25.0.0
+2026-06-25T09:53:24.8738080Z [1m[92m   Compiling[0m escape-bytes v0.1.1
+2026-06-25T09:53:24.8828415Z [1m[92m   Compiling[0m ethnum v1.5.2
+2026-06-25T09:53:24.9408278Z [1m[92m   Compiling[0m sha2 v0.10.9
+2026-06-25T09:53:25.2232551Z [1m[92m   Compiling[0m serde_with v3.12.0
+2026-06-25T09:53:25.3138225Z [1m[92m   Compiling[0m num-integer v0.1.46
+2026-06-25T09:53:25.5268244Z [1m[92m   Compiling[0m num-bigint v0.4.6
+2026-06-25T09:53:25.5508594Z [1m[92m   Compiling[0m rustc_version v0.4.1
+2026-06-25T09:53:25.7619958Z [1m[92m   Compiling[0m ff v0.13.1
+2026-06-25T09:53:25.8234187Z [1m[92m   Compiling[0m der v0.7.10
+2026-06-25T09:53:26.4870030Z [1m[92m   Compiling[0m ppv-lite86 v0.2.21
+2026-06-25T09:53:26.5858549Z [1m[92m   Compiling[0m either v1.15.0
+2026-06-25T09:53:26.6988427Z [1m[92m   Compiling[0m base16ct v0.2.0
+2026-06-25T09:53:26.7458301Z [1m[92m   Compiling[0m rand_chacha v0.3.1
+2026-06-25T09:53:26.7868498Z [1m[92m   Compiling[0m once_cell v1.21.4
+2026-06-25T09:53:26.8048052Z [1m[92m   Compiling[0m hashbrown v0.16.1
+2026-06-25T09:53:26.8588236Z [1m[92m   Compiling[0m equivalent v1.0.2
+2026-06-25T09:53:26.8868265Z [1m[92m   Compiling[0m rand v0.8.5
+2026-06-25T09:53:27.1192333Z [1m[92m   Compiling[0m ahash v0.8.12
+2026-06-25T09:53:27.2148013Z [1m[92m   Compiling[0m sec1 v0.7.3
+2026-06-25T09:53:27.2521494Z [1m[92m   Compiling[0m indexmap v2.13.0
+2026-06-25T09:53:27.3888270Z [1m[92m   Compiling[0m ark-std v0.4.0
+2026-06-25T09:53:27.4408975Z [1m[92m   Compiling[0m itertools v0.10.5
+2026-06-25T09:53:27.5128897Z [1m[92m   Compiling[0m ark-serialize v0.4.2
+2026-06-25T09:53:27.6628290Z [1m[92m   Compiling[0m group v0.13.0
+2026-06-25T09:53:27.7068095Z [1m[92m   Compiling[0m signature v2.2.0
+2026-06-25T09:53:27.8008997Z [1m[92m   Compiling[0m crypto-bigint v0.5.5
+2026-06-25T09:53:28.1043185Z [1m[92m   Compiling[0m base64 v0.22.1
+2026-06-25T09:53:28.1570192Z [1m[92m   Compiling[0m ark-ff v0.4.2
+2026-06-25T09:53:28.3388427Z [1m[92m   Compiling[0m wasmparser v0.116.1
+2026-06-25T09:53:28.8599458Z [1m[92m   Compiling[0m elliptic-curve v0.13.8
+2026-06-25T09:53:29.0668989Z [1m[92m   Compiling[0m hashbrown v0.13.2
+2026-06-25T09:53:29.4378198Z [1m[92m   Compiling[0m hmac v0.12.1
+2026-06-25T09:53:29.5068277Z [1m[92m   Compiling[0m rfc6979 v0.4.0
+2026-06-25T09:53:29.5578096Z [1m[92m   Compiling[0m libm v0.2.16
+2026-06-25T09:53:30.6628296Z [1m[92m   Compiling[0m curve25519-dalek v4.1.3
+2026-06-25T09:53:30.8648149Z [1m[92m   Compiling[0m indexmap-nostd v0.4.0
+2026-06-25T09:53:30.9928259Z [1m[92m   Compiling[0m downcast-rs v1.2.1
+2026-06-25T09:53:31.0228337Z [1m[92m   Compiling[0m static_assertions v1.1.0
+2026-06-25T09:53:31.0498613Z [1m[92m   Compiling[0m wasmi_core v0.13.0
+2026-06-25T09:53:31.4258066Z [1m[92m   Compiling[0m wasmparser-nostd v0.100.2
+2026-06-25T09:53:32.0048633Z [1m[92m   Compiling[0m ark-poly v0.4.2
+2026-06-25T09:53:32.6560664Z [1m[92m   Compiling[0m ark-ec v0.4.2
+2026-06-25T09:53:33.8753211Z [1m[92m   Compiling[0m ecdsa v0.16.9
+2026-06-25T09:53:33.9100323Z [1m[92m   Compiling[0m soroban-env-common v25.0.1
+2026-06-25T09:53:34.0948678Z [1m[92m   Compiling[0m spin v0.9.8
+2026-06-25T09:53:34.1568194Z [1m[92m   Compiling[0m hex v0.4.3
+2026-06-25T09:53:34.1748233Z [1m[92m   Compiling[0m smallvec v1.15.1
+2026-06-25T09:53:34.2968165Z [1m[92m   Compiling[0m byteorder v1.5.0
+2026-06-25T09:53:34.3298255Z [1m[92m   Compiling[0m wasmi_arena v0.4.1
+2026-06-25T09:53:34.4018318Z [1m[92m   Compiling[0m hash32 v0.3.1
+2026-06-25T09:53:34.4208674Z [1m[92m   Compiling[0m soroban-wasmi v0.31.1-soroban.20.0.1
+2026-06-25T09:53:36.8598214Z [1m[92m   Compiling[0m serde_core v1.0.228
+2026-06-25T09:53:38.2038201Z [1m[92m   Compiling[0m primeorder v0.13.6
+2026-06-25T09:53:38.3758242Z [1m[92m   Compiling[0m ed25519 v2.2.3
+2026-06-25T09:53:38.4828434Z [1m[92m   Compiling[0m stellar-strkey v0.0.16
+2026-06-25T09:53:38.5748262Z [1m[92m   Compiling[0m keccak v0.1.6
+2026-06-25T09:53:38.6538237Z [1m[92m   Compiling[0m stable_deref_trait v1.2.1
+2026-06-25T09:53:38.6788179Z [1m[92m   Compiling[0m heapless v0.8.0
+2026-06-25T09:53:38.7353847Z [1m[92m   Compiling[0m sha3 v0.10.8
+2026-06-25T09:53:38.9568530Z [1m[92m   Compiling[0m ed25519-dalek v2.2.0
+2026-06-25T09:53:39.0048830Z [1m[92m   Compiling[0m p256 v0.13.2
+2026-06-25T09:53:39.1368053Z [1m[92m   Compiling[0m k256 v0.13.4
+2026-06-25T09:53:39.2958306Z [1m[92m   Compiling[0m ark-bls12-381 v0.4.0
+2026-06-25T09:53:39.6638336Z [1m[92m   Compiling[0m ark-bn254 v0.4.0
+2026-06-25T09:53:39.8848455Z [1m[92m   Compiling[0m soroban-sdk v25.2.0
+2026-06-25T09:53:40.0017489Z [1m[92m   Compiling[0m hex-literal v0.4.1
+2026-06-25T09:53:40.3302466Z [1m[92m   Compiling[0m serde v1.0.228
+2026-06-25T09:53:42.6077284Z [1m[92m   Compiling[0m soroban-spec v25.3.0
+2026-06-25T09:53:42.8998322Z [1m[92m   Compiling[0m soroban-spec-rust v25.3.0
+2026-06-25T09:53:43.1748051Z [1m[92m   Compiling[0m soroban-env-macros v25.0.1
+2026-06-25T09:53:45.1080863Z [1m[92m   Compiling[0m soroban-sdk-macros v25.3.0
+2026-06-25T09:53:45.2725821Z [1m[92m   Compiling[0m soroban-env-host v25.0.1
+2026-06-25T09:53:51.5188238Z [1m[92m   Compiling[0m liquifact_escrow v0.1.0 (/home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow)
+2026-06-25T09:53:52.4405538Z [1m[92m    Finished[0m `dev` profile [unoptimized + debuginfo] target(s) in 30.05s
+2026-06-25T09:53:52.4532306Z ##[group]Run cargo test
+2026-06-25T09:53:52.4532520Z [36;1mcargo test[0m
+2026-06-25T09:53:52.4559155Z shell: /usr/bin/bash -e {0}
+2026-06-25T09:53:52.4559353Z env:
+2026-06-25T09:53:52.4559511Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T09:53:52.4559722Z   CARGO_INCREMENTAL: 0
+2026-06-25T09:53:52.4559893Z   CARGO_TERM_COLOR: always
+2026-06-25T09:53:52.4560082Z   CACHE_ON_FAILURE: false
+2026-06-25T09:53:52.4560256Z ##[endgroup]
+2026-06-25T09:53:52.5054368Z [1m[92m Downloading[0m crates ...
+2026-06-25T09:53:52.6652052Z [1m[92m  Downloaded[0m bit-vec v0.8.0
+2026-06-25T09:53:52.6668051Z [1m[92m  Downloaded[0m rand_chacha v0.9.0
+2026-06-25T09:53:52.6678995Z [1m[92m  Downloaded[0m unarray v0.1.4
+2026-06-25T09:53:52.6690554Z [1m[92m  Downloaded[0m wait-timeout v0.2.1
+2026-06-25T09:53:52.6705039Z [1m[92m  Downloaded[0m rusty-fork v0.3.1
+2026-06-25T09:53:52.6719115Z [1m[92m  Downloaded[0m tempfile v3.27.0
+2026-06-25T09:53:52.6740369Z [1m[92m  Downloaded[0m rand_core v0.9.5
+2026-06-25T09:53:52.6753032Z [1m[92m  Downloaded[0m rand v0.9.2
+2026-06-25T09:53:52.6783264Z [1m[92m  Downloaded[0m bitflags v2.11.0
+2026-06-25T09:53:52.6818079Z [1m[92m  Downloaded[0m proptest v1.10.0
+2026-06-25T09:53:52.6894416Z [1m[92m  Downloaded[0m bit-set v0.8.0
+2026-06-25T09:53:52.6904955Z [1m[92m  Downloaded[0m getrandom v0.4.2
+2026-06-25T09:53:52.6936077Z [1m[92m  Downloaded[0m getrandom v0.3.4
+2026-06-25T09:53:52.6963451Z [1m[92m  Downloaded[0m rand_xorshift v0.4.0
+2026-06-25T09:53:52.6971993Z [1m[92m  Downloaded[0m fastrand v2.3.0
+2026-06-25T09:53:52.6982441Z [1m[92m  Downloaded[0m quick-error v1.2.3
+2026-06-25T09:53:52.6992726Z [1m[92m  Downloaded[0m errno v0.3.14
+2026-06-25T09:53:52.7035910Z [1m[92m  Downloaded[0m rustix v1.1.4
+2026-06-25T09:53:52.7245308Z [1m[92m  Downloaded[0m regex-syntax v0.8.10
+2026-06-25T09:53:52.7354501Z [1m[92m  Downloaded[0m linux-raw-sys v0.12.1
+2026-06-25T09:53:52.8245289Z [1m[92m   Compiling[0m libc v0.2.183
+2026-06-25T09:53:52.8245939Z [1m[92m   Compiling[0m serde_core v1.0.228
+2026-06-25T09:53:52.8247027Z [1m[92m   Compiling[0m serde v1.0.228
+2026-06-25T09:53:52.8301991Z [1m[92m   Compiling[0m fnv v1.0.7
+2026-06-25T09:53:52.8400738Z [1m[92m   Compiling[0m schemars v0.8.22
+2026-06-25T09:53:52.8430294Z [1m[92m   Compiling[0m dyn-clone v1.0.20
+2026-06-25T09:53:52.8614448Z [1m[92m   Compiling[0m darling_core v0.20.11
+2026-06-25T09:53:52.9010279Z [1m[92m   Compiling[0m once_cell v1.21.4
+2026-06-25T09:53:53.0270469Z [1m[92m   Compiling[0m ahash v0.8.12
+2026-06-25T09:53:53.1258067Z [1m[92m   Compiling[0m hashbrown v0.13.2
+2026-06-25T09:53:53.5592887Z [1m[92m   Compiling[0m thiserror v1.0.69
+2026-06-25T09:53:53.5928134Z [1m[92m   Compiling[0m derive_arbitrary v1.3.2
+2026-06-25T09:53:53.7428065Z [1m[92m   Compiling[0m getrandom v0.2.17
+2026-06-25T09:53:53.8819293Z [1m[92m   Compiling[0m rand_core v0.6.4
+2026-06-25T09:53:54.0198249Z [1m[92m   Compiling[0m rand_chacha v0.3.1
+2026-06-25T09:53:54.1098357Z [1m[92m   Compiling[0m ff v0.13.1
+2026-06-25T09:53:54.1663602Z [1m[92m   Compiling[0m rand v0.8.5
+2026-06-25T09:53:54.4003392Z [1m[92m   Compiling[0m group v0.13.0
+2026-06-25T09:53:54.4528237Z [1m[92m   Compiling[0m signature v2.2.0
+2026-06-25T09:53:54.5208973Z [1m[92m   Compiling[0m crypto-bigint v0.5.5
+2026-06-25T09:53:54.6968657Z [1m[92m   Compiling[0m serde_json v1.0.149
+2026-06-25T09:53:54.8168212Z [1m[92m   Compiling[0m darling_macro v0.20.11
+2026-06-25T09:53:55.0218551Z [1m[92m   Compiling[0m darling v0.20.11
+2026-06-25T09:53:55.0558648Z [1m[92m   Compiling[0m serde_with_macros v3.12.0
+2026-06-25T09:53:55.1368193Z [1m[92m   Compiling[0m hex v0.4.3
+2026-06-25T09:53:55.3124444Z [1m[92m   Compiling[0m ark-std v0.4.0
+2026-06-25T09:53:55.4291769Z [1m[92m   Compiling[0m crate-git-revision v0.0.6
+2026-06-25T09:53:55.6238157Z [1m[92m   Compiling[0m ark-serialize v0.4.2
+2026-06-25T09:53:55.7789032Z [1m[92m   Compiling[0m stellar-strkey v0.0.13
+2026-06-25T09:53:55.7858576Z [1m[92m   Compiling[0m stellar-xdr v25.0.0
+2026-06-25T09:53:55.7877708Z [1m[92m   Compiling[0m ark-ff v0.4.2
+2026-06-25T09:53:55.8767405Z [1m[92m   Compiling[0m elliptic-curve v0.13.8
+2026-06-25T09:53:56.1098358Z [1m[92m   Compiling[0m getrandom v0.3.4
+2026-06-25T09:53:56.2227229Z [1m[92m   Compiling[0m ecdsa v0.16.9
+2026-06-25T09:53:56.2848862Z [1m[92m   Compiling[0m serde_with v3.12.0
+2026-06-25T09:53:56.9293607Z [1m[92m   Compiling[0m soroban-env-common v25.0.1
+2026-06-25T09:53:57.0318207Z [1m[92m   Compiling[0m arbitrary v1.3.2
+2026-06-25T09:53:57.8178004Z [1m[92m   Compiling[0m primeorder v0.13.6
+2026-06-25T09:53:58.1308123Z [1m[92m   Compiling[0m ed25519 v2.2.3
+2026-06-25T09:53:58.2358178Z [1m[92m   Compiling[0m soroban-env-host v25.0.1
+2026-06-25T09:53:58.3323456Z [1m[92m   Compiling[0m getrandom v0.4.2
+2026-06-25T09:53:58.4408228Z [1m[92m   Compiling[0m rustix v1.1.4
+2026-06-25T09:53:58.7181007Z [1m[92m   Compiling[0m ed25519-dalek v2.2.0
+2026-06-25T09:53:58.8899460Z [1m[92m   Compiling[0m p256 v0.13.2
+2026-06-25T09:53:59.1578520Z [1m[92m   Compiling[0m rand_core v0.9.5
+2026-06-25T09:53:59.2888021Z [1m[92m   Compiling[0m k256 v0.13.4
+2026-06-25T09:53:59.7658239Z [1m[92m   Compiling[0m stellar-strkey v0.0.16
+2026-06-25T09:53:59.8254308Z [1m[92m   Compiling[0m ark-poly v0.4.2
+2026-06-25T09:53:59.8749072Z [1m[92m   Compiling[0m dtor-proc-macro v0.0.6
+2026-06-25T09:54:00.0348353Z [1m[92m   Compiling[0m bitflags v2.11.0
+2026-06-25T09:54:00.1768259Z [1m[92m   Compiling[0m linux-raw-sys v0.12.1
+2026-06-25T09:54:00.4218924Z [1m[92m   Compiling[0m ark-ec v0.4.2
+2026-06-25T09:54:01.5988191Z [1m[92m   Compiling[0m ark-bn254 v0.4.0
+2026-06-25T09:54:01.8188533Z [1m[92m   Compiling[0m ark-bls12-381 v0.4.0
+2026-06-25T09:54:01.9598159Z [1m[92m   Compiling[0m dtor v0.1.1
+2026-06-25T09:54:02.0858299Z [1m[92m   Compiling[0m soroban-sdk v25.2.0
+2026-06-25T09:54:02.1908221Z [1m[92m   Compiling[0m ctor-proc-macro v0.0.6
+2026-06-25T09:54:02.3268341Z [1m[92m   Compiling[0m fastrand v2.3.0
+2026-06-25T09:54:02.4698375Z [1m[92m   Compiling[0m tempfile v3.27.0
+2026-06-25T09:54:02.8028278Z [1m[92m   Compiling[0m ctor v0.5.0
+2026-06-25T09:54:03.0138489Z [1m[92m   Compiling[0m wait-timeout v0.2.1
+2026-06-25T09:54:03.1128289Z [1m[92m   Compiling[0m bit-vec v0.8.0
+2026-06-25T09:54:03.2128111Z [1m[92m   Compiling[0m quick-error v1.2.3
+2026-06-25T09:54:03.2528504Z [1m[92m   Compiling[0m rusty-fork v0.3.1
+2026-06-25T09:54:03.2585153Z [1m[92m   Compiling[0m bit-set v0.8.0
+2026-06-25T09:54:03.3447228Z [1m[92m   Compiling[0m rand_xorshift v0.4.0
+2026-06-25T09:54:03.4168367Z [1m[92m   Compiling[0m rand v0.9.2
+2026-06-25T09:54:03.5488118Z [1m[92m   Compiling[0m rand_chacha v0.9.0
+2026-06-25T09:54:03.7328054Z [1m[92m   Compiling[0m unarray v0.1.4
+2026-06-25T09:54:03.7748074Z [1m[92m   Compiling[0m regex-syntax v0.8.10
+2026-06-25T09:54:04.7051478Z [1m[92m   Compiling[0m proptest v1.10.0
+2026-06-25T09:54:12.1690314Z [1m[92m   Compiling[0m soroban-spec v25.3.0
+2026-06-25T09:54:12.4480068Z [1m[92m   Compiling[0m soroban-spec-rust v25.3.0
+2026-06-25T09:54:12.7509555Z [1m[92m   Compiling[0m soroban-env-macros v25.0.1
+2026-06-25T09:54:14.5309362Z [1m[92m   Compiling[0m soroban-sdk-macros v25.3.0
+2026-06-25T09:54:22.9205964Z [1m[92m   Compiling[0m soroban-ledger-snapshot v25.3.0
+2026-06-25T09:54:27.1708471Z [1m[92m   Compiling[0m liquifact_escrow v0.1.0 (/home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow)
+2026-06-25T09:54:27.6135804Z [1m[91merror[E0106][0m[1m: missing lifetime specifiers[0m
+2026-06-25T09:54:27.6137023Z    [1m[94m--> [0mescrow/src/tests/integration.rs:839:27
+2026-06-25T09:54:27.6137703Z     [1m[94m|[0m
+2026-06-25T09:54:27.6138060Z [1m[94m835[0m [1m[94m|[0m     env: &Env,
+2026-06-25T09:54:27.6138471Z     [1m[94m|[0m          [1m[94m----[0m
+2026-06-25T09:54:27.6138874Z [1m[94m836[0m [1m[94m|[0m     target: i128,
+2026-06-25T09:54:27.6139575Z [1m[94m837[0m [1m[94m|[0m     invoice_id: &str,
+2026-06-25T09:54:27.6139998Z     [1m[94m|[0m                 [1m[94m----[0m
+2026-06-25T09:54:27.6140362Z [1m[94m838[0m [1m[94m|[0m ) -> (
+2026-06-25T09:54:27.6140779Z [1m[94m839[0m [1m[94m|[0m     LiquifactEscrowClient<'_>,
+2026-06-25T09:54:27.6143675Z     [1m[94m|[0m                           [1m[91m^^[0m [1m[91mexpected named lifetime parameter[0m
+2026-06-25T09:54:27.6150889Z [1m[94m840[0m [1m[94m|[0m     soroban_sdk::Address,
+2026-06-25T09:54:27.6151490Z [1m[94m841[0m [1m[94m|[0m     soroban_sdk::token::TokenClient<'_>,
+2026-06-25T09:54:27.6152117Z     [1m[94m|[0m                                     [1m[91m^^[0m [1m[91mexpected named lifetime parameter[0m
+2026-06-25T09:54:27.6152659Z     [1m[94m|[0m
+2026-06-25T09:54:27.6153438Z     [1m[94m= [0m[1mhelp[0m: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `env` or `invoice_id`
+2026-06-25T09:54:27.6154346Z [1m[96mhelp[0m: consider introducing a named lifetime parameter
+2026-06-25T09:54:27.6154766Z     [1m[94m|[0m
+2026-06-25T09:54:27.6155144Z [1m[94m834[0m [92m~ [0mfn setup_withdraw_with_token[92m<'a>[0m(
+2026-06-25T09:54:27.6155600Z [1m[94m835[0m [92m~ [0m    env: &[92m'a [0mEnv,
+2026-06-25T09:54:27.6156014Z [1m[94m836[0m [1m[94m|[0m     target: i128,
+2026-06-25T09:54:27.6156459Z [1m[94m837[0m [92m~ [0m    invoice_id: &[92m'a [0mstr,
+2026-06-25T09:54:27.6157015Z [1m[94m838[0m [1m[94m|[0m ) -> (
+2026-06-25T09:54:27.6157433Z [1m[94m839[0m [92m~ [0m    LiquifactEscrowClient<[92m'a[0m>,
+2026-06-25T09:54:27.6157941Z [1m[94m840[0m [1m[94m|[0m     soroban_sdk::Address,
+2026-06-25T09:54:27.6158473Z [1m[94m841[0m [92m~ [0m    soroban_sdk::token::TokenClient<[92m'a[0m>,
+2026-06-25T09:54:27.6158895Z     [1m[94m|[0m
+2026-06-25T09:54:27.6159040Z 
+2026-06-25T09:54:27.6452221Z [1m[33mwarning[0m[1m: unused doc comment[0m
+2026-06-25T09:54:27.6452803Z    [1m[94m--> [0mescrow/src/tests/properties.rs:114:1
+2026-06-25T09:54:27.6453170Z     [1m[94m|[0m
+2026-06-25T09:54:27.6453662Z [1m[94m114[0m [1m[94m|[0m /// Property tests for funding accounting invariants (issue #325).
+2026-06-25T09:54:27.6454657Z     [1m[94m|[0m [1m[33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[33mrustdoc does not generate documentation for macro invocations[0m
+2026-06-25T09:54:27.6455326Z     [1m[94m|[0m
+2026-06-25T09:54:27.6455983Z     [1m[94m= [0m[1mhelp[0m: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
+2026-06-25T09:54:27.6457019Z     [1m[94m= [0m[1mnote[0m: `#[warn(unused_doc_comments)]` (part of `#[warn(unused)]`) on by default
+2026-06-25T09:54:27.6457618Z 
+2026-06-25T09:54:27.6458191Z [1m[33mwarning[0m[1m: unused doc comment[0m
+2026-06-25T09:54:27.6459819Z     [1m[94m--> [0mescrow/src/tests/properties.rs:1151:1
+2026-06-25T09:54:27.6460625Z      [1m[94m|[0m
+2026-06-25T09:54:27.6461400Z [1m[94m1151[0m [1m[94m|[0m [1m[33m/[0m /// Property: sum of all computed payouts never exceeds settle_pool.
+2026-06-25T09:54:27.6462603Z [1m[94m1152[0m [1m[94m|[0m [1m[33m|[0m /// Covers single investor, equal splits, and prime-denominator splits.
+2026-06-25T09:54:27.6463569Z      [1m[94m|[0m [1m[33m|_[0m[1m[94m----------------------------------------------------------------------[0m[1m[33m^[0m
+2026-06-25T09:54:27.6464540Z      [1m[94m|[0m   [1m[94m|[0m
+2026-06-25T09:54:27.6465125Z      [1m[94m|[0m   [1m[94mrustdoc does not generate documentation for macro invocations[0m
+2026-06-25T09:54:27.6465643Z      [1m[94m|[0m
+2026-06-25T09:54:27.6466339Z      [1m[94m= [0m[1mhelp[0m: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
+2026-06-25T09:54:27.6467104Z 
+2026-06-25T09:54:27.6467459Z [1m[33mwarning[0m[1m: unnecessary parentheses around block return value[0m
+2026-06-25T09:54:27.6468294Z    [1m[94m--> [0mescrow/src/tests/properties.rs:100:5
+2026-06-25T09:54:27.6468712Z     [1m[94m|[0m
+2026-06-25T09:54:27.6469034Z [1m[94m100[0m [1m[94m|[0m     (1i128..=max)
+2026-06-25T09:54:27.6469474Z     [1m[94m|[0m     [1m[33m^[0m           [1m[33m^[0m
+2026-06-25T09:54:27.6469822Z     [1m[94m|[0m
+2026-06-25T09:54:27.6470309Z     [1m[94m= [0m[1mnote[0m: `#[warn(unused_parens)]` (part of `#[warn(unused)]`) on by default
+2026-06-25T09:54:27.6470886Z [1m[96mhelp[0m: remove these parentheses
+2026-06-25T09:54:27.6471248Z     [1m[94m|[0m
+2026-06-25T09:54:27.6471642Z [1m[94m100[0m [91m- [0m    [91m([0m1i128..=max[91m)[0m
+2026-06-25T09:54:27.6472101Z [1m[94m100[0m [92m+ [0m    1i128..=max[92m [0m
+2026-06-25T09:54:27.6472456Z     [1m[94m|[0m
+2026-06-25T09:54:27.6472585Z 
+2026-06-25T09:54:28.1710214Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.1727778Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2462:21
+2026-06-25T09:54:28.1757404Z      [1m[94m|[0m
+2026-06-25T09:54:28.1777484Z [1m[94m2462[0m [1m[94m|[0m     assert!(!client.is_settleable());
+2026-06-25T09:54:28.1787739Z      [1m[94m|[0m                     [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.1817397Z      [1m[94m|[0m
+2026-06-25T09:54:28.1837448Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.1867280Z      [1m[94m|[0m
+2026-06-25T09:54:28.1877545Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.1907672Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.1927072Z 
+2026-06-25T09:54:28.1957792Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.1961175Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2473:20
+2026-06-25T09:54:28.1987392Z      [1m[94m|[0m
+2026-06-25T09:54:28.1997853Z [1m[94m2473[0m [1m[94m|[0m     assert!(client.is_settleable());
+2026-06-25T09:54:28.2001307Z      [1m[94m|[0m                    [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.2002384Z      [1m[94m|[0m
+2026-06-25T09:54:28.2003092Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.2003612Z      [1m[94m|[0m
+2026-06-25T09:54:28.2004083Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.2004853Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.2005432Z 
+2026-06-25T09:54:28.2006198Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.2007363Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2486:21
+2026-06-25T09:54:28.2007924Z      [1m[94m|[0m
+2026-06-25T09:54:28.2008474Z [1m[94m2486[0m [1m[94m|[0m     assert!(!client.is_settleable());
+2026-06-25T09:54:28.2009349Z      [1m[94m|[0m                     [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.2010033Z      [1m[94m|[0m
+2026-06-25T09:54:28.2010531Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.2011323Z      [1m[94m|[0m
+2026-06-25T09:54:28.2011759Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.2012480Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.2013011Z 
+2026-06-25T09:54:28.2148553Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.2167496Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2498:20
+2026-06-25T09:54:28.2197585Z      [1m[94m|[0m
+2026-06-25T09:54:28.2228315Z [1m[94m2498[0m [1m[94m|[0m     assert!(client.is_settleable());
+2026-06-25T09:54:28.2257939Z      [1m[94m|[0m                    [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.2262989Z      [1m[94m|[0m
+2026-06-25T09:54:28.2263662Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.2264182Z      [1m[94m|[0m
+2026-06-25T09:54:28.2264695Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.2265449Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.2266006Z 
+2026-06-25T09:54:28.2273399Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.2274468Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2509:21
+2026-06-25T09:54:28.2275057Z      [1m[94m|[0m
+2026-06-25T09:54:28.2275656Z [1m[94m2509[0m [1m[94m|[0m     assert!(!client.is_settleable());
+2026-06-25T09:54:28.2276575Z      [1m[94m|[0m                     [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.2277520Z      [1m[94m|[0m
+2026-06-25T09:54:28.2278127Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.2278691Z      [1m[94m|[0m
+2026-06-25T09:54:28.2279176Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.2279966Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.2280540Z 
+2026-06-25T09:54:28.2448493Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.2477699Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2520:21
+2026-06-25T09:54:28.2507508Z      [1m[94m|[0m
+2026-06-25T09:54:28.2537516Z [1m[94m2520[0m [1m[94m|[0m     assert!(!client.is_settleable());
+2026-06-25T09:54:28.2567811Z      [1m[94m|[0m                     [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.2597362Z      [1m[94m|[0m
+2026-06-25T09:54:28.2598103Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.2598549Z      [1m[94m|[0m
+2026-06-25T09:54:28.2598928Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.2599601Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.2600110Z 
+2026-06-25T09:54:28.2600832Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.2601612Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2531:21
+2026-06-25T09:54:28.2602011Z      [1m[94m|[0m
+2026-06-25T09:54:28.2602423Z [1m[94m2531[0m [1m[94m|[0m     assert!(!client.is_settleable());
+2026-06-25T09:54:28.2603161Z      [1m[94m|[0m                     [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.2603708Z      [1m[94m|[0m
+2026-06-25T09:54:28.2604089Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.2604429Z      [1m[94m|[0m
+2026-06-25T09:54:28.2604724Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.2605299Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.2606036Z 
+2026-06-25T09:54:28.2678175Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.2679222Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2540:16
+2026-06-25T09:54:28.2679740Z      [1m[94m|[0m
+2026-06-25T09:54:28.2680237Z [1m[94m2540[0m [1m[94m|[0m         client.is_settleable();
+2026-06-25T09:54:28.2681118Z      [1m[94m|[0m                [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.2682107Z      [1m[94m|[0m
+2026-06-25T09:54:28.2682707Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.2683216Z      [1m[94m|[0m
+2026-06-25T09:54:28.2683664Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.2684408Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.2684950Z 
+2026-06-25T09:54:28.2762324Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.2763737Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2557:17
+2026-06-25T09:54:28.2764314Z      [1m[94m|[0m
+2026-06-25T09:54:28.2764826Z [1m[94m2557[0m [1m[94m|[0m         !client.is_settleable(),
+2026-06-25T09:54:28.2765611Z      [1m[94m|[0m                 [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.2766259Z      [1m[94m|[0m
+2026-06-25T09:54:28.2766976Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.2767453Z      [1m[94m|[0m
+2026-06-25T09:54:28.2767880Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.2768573Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.2769112Z 
+2026-06-25T09:54:28.2845452Z [1m[91merror[E0599][0m[1m: no method named `all` found for struct `soroban_sdk::events::Events` in the current scope[0m
+2026-06-25T09:54:28.2846320Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2597:40
+2026-06-25T09:54:28.2846714Z      [1m[94m|[0m
+2026-06-25T09:54:28.2847344Z [1m[94m2597[0m [1m[94m|[0m     let contract_events = env.events().all();
+2026-06-25T09:54:28.2848198Z      [1m[94m|[0m                                        [1m[91m^^^[0m [1m[91mmethod not found in `soroban_sdk::events::Events`[0m
+2026-06-25T09:54:28.2848729Z      [1m[94m|[0m
+2026-06-25T09:54:28.2849380Z     [1m[94m::: [0m/home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/soroban-sdk-25.2.0/src/testutils.rs:543:8
+2026-06-25T09:54:28.2849958Z      [1m[94m|[0m
+2026-06-25T09:54:28.2850303Z [1m[94m 543[0m [1m[94m|[0m     fn all(&self) -> ContractEvents;
+2026-06-25T09:54:28.2851063Z      [1m[94m|[0m        [1m[94m---[0m [1m[94mthe method is available for `soroban_sdk::events::Events` here[0m
+2026-06-25T09:54:28.2851607Z      [1m[94m|[0m
+2026-06-25T09:54:28.2852056Z      [1m[94m= [0m[1mhelp[0m: items from traits can only be used if the trait is in scope
+2026-06-25T09:54:28.2852889Z [1m[96mhelp[0m: trait `Events` which provides `all` is implemented but not in scope; perhaps you want to import it
+2026-06-25T09:54:28.2853688Z      [1m[94m|[0m
+2026-06-25T09:54:28.2854154Z [1m[94m   1[0m [92m+ use soroban_sdk::testutils::Events;[0m
+2026-06-25T09:54:28.2854535Z      [1m[94m|[0m
+2026-06-25T09:54:28.2854668Z 
+2026-06-25T09:54:28.2903412Z [1m[91merror[E0599][0m[1m: no method named `all` found for struct `soroban_sdk::events::Events` in the current scope[0m
+2026-06-25T09:54:28.2904226Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2634:40
+2026-06-25T09:54:28.2904642Z      [1m[94m|[0m
+2026-06-25T09:54:28.2905084Z [1m[94m2634[0m [1m[94m|[0m     let contract_events = env.events().all();
+2026-06-25T09:54:28.2905962Z      [1m[94m|[0m                                        [1m[91m^^^[0m [1m[91mmethod not found in `soroban_sdk::events::Events`[0m
+2026-06-25T09:54:28.2907021Z      [1m[94m|[0m
+2026-06-25T09:54:28.2907929Z     [1m[94m::: [0m/home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/soroban-sdk-25.2.0/src/testutils.rs:543:8
+2026-06-25T09:54:28.2908624Z      [1m[94m|[0m
+2026-06-25T09:54:28.2909033Z [1m[94m 543[0m [1m[94m|[0m     fn all(&self) -> ContractEvents;
+2026-06-25T09:54:28.2909837Z      [1m[94m|[0m        [1m[94m---[0m [1m[94mthe method is available for `soroban_sdk::events::Events` here[0m
+2026-06-25T09:54:28.2910385Z      [1m[94m|[0m
+2026-06-25T09:54:28.2911087Z      [1m[94m= [0m[1mhelp[0m: items from traits can only be used if the trait is in scope
+2026-06-25T09:54:28.2911966Z [1m[96mhelp[0m: trait `Events` which provides `all` is implemented but not in scope; perhaps you want to import it
+2026-06-25T09:54:28.2912589Z      [1m[94m|[0m
+2026-06-25T09:54:28.2913024Z [1m[94m   1[0m [92m+ use soroban_sdk::testutils::Events;[0m
+2026-06-25T09:54:28.2913417Z      [1m[94m|[0m
+2026-06-25T09:54:28.2913557Z 
+2026-06-25T09:54:28.3038621Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.3039759Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2694:17
+2026-06-25T09:54:28.3040195Z      [1m[94m|[0m
+2026-06-25T09:54:28.3040607Z [1m[94m2694[0m [1m[94m|[0m         !client.is_settleable(),
+2026-06-25T09:54:28.3041332Z      [1m[94m|[0m                 [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.3041925Z      [1m[94m|[0m
+2026-06-25T09:54:28.3042413Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.3042901Z      [1m[94m|[0m
+2026-06-25T09:54:28.3043245Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.3043865Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.3044283Z 
+2026-06-25T09:54:28.3122465Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.3123591Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2701:16
+2026-06-25T09:54:28.3124274Z      [1m[94m|[0m
+2026-06-25T09:54:28.3124676Z [1m[94m2701[0m [1m[94m|[0m         client.is_settleable(),
+2026-06-25T09:54:28.3125350Z      [1m[94m|[0m                [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.3125903Z      [1m[94m|[0m
+2026-06-25T09:54:28.3126338Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.3126686Z      [1m[94m|[0m
+2026-06-25T09:54:28.3127106Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.3127699Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.3128103Z 
+2026-06-25T09:54:28.3205475Z [1m[91merror[E0599][0m[1m: no method named `is_settleable` found for struct `LiquifactEscrowClient<'a>` in the current scope[0m
+2026-06-25T09:54:28.3206628Z     [1m[94m--> [0mescrow/src/tests/coverage.rs:2708:17
+2026-06-25T09:54:28.3207464Z      [1m[94m|[0m
+2026-06-25T09:54:28.3208041Z [1m[94m2708[0m [1m[94m|[0m         !client.is_settleable(),
+2026-06-25T09:54:28.3209019Z      [1m[94m|[0m                 [1m[91m^^^^^^^^^^^^^[0m [1m[91mmethod not found in `LiquifactEscrowClient<'_>`[0m
+2026-06-25T09:54:28.3209729Z      [1m[94m|[0m
+2026-06-25T09:54:28.3210356Z     [1m[94m::: [0mescrow/src/lib.rs:892:1
+2026-06-25T09:54:28.3210886Z      [1m[94m|[0m
+2026-06-25T09:54:28.3211387Z [1m[94m 892[0m [1m[94m|[0m #[contract]
+2026-06-25T09:54:28.3212143Z      [1m[94m|[0m [1m[94m-----------[0m [1m[94mmethod `is_settleable` not found for this struct[0m
+2026-06-25T09:54:28.3212700Z 
+2026-06-25T09:54:28.4880467Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.4881686Z     [1m[94m--> [0mescrow/src/tests/properties.rs:20:16
+2026-06-25T09:54:28.4882163Z      [1m[94m|[0m
+2026-06-25T09:54:28.4882567Z [1m[94m  20[0m [1m[94m|[0m         client.init(
+2026-06-25T09:54:28.4883075Z      [1m[94m|[0m                [1m[91m^^^^[0m
+2026-06-25T09:54:28.4883496Z [1m[94m...[0m
+2026-06-25T09:54:28.4883857Z [1m[94m  36[0m [1m[94m|[0m             &None,
+2026-06-25T09:54:28.4884813Z      [1m[94m|[0m             [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.4885463Z      [1m[94m|[0m
+2026-06-25T09:54:28.4886213Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.4886687Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.4887243Z      [1m[94m|[0m
+2026-06-25T09:54:28.4887585Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.4888002Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.4888409Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.4888769Z      [1m[94m|[0m
+2026-06-25T09:54:28.4889080Z [1m[94m  35[0m [91m-             &None,[0m
+2026-06-25T09:54:28.4889426Z      [1m[94m|[0m
+2026-06-25T09:54:28.4889571Z 
+2026-06-25T09:54:28.4924918Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.4925636Z     [1m[94m--> [0mescrow/src/tests/properties.rs:63:29
+2026-06-25T09:54:28.4926070Z      [1m[94m|[0m
+2026-06-25T09:54:28.4926439Z [1m[94m  63[0m [1m[94m|[0m         let escrow = client.init(
+2026-06-25T09:54:28.4927102Z      [1m[94m|[0m                             [1m[91m^^^^[0m
+2026-06-25T09:54:28.4927526Z [1m[94m...[0m
+2026-06-25T09:54:28.4927850Z [1m[94m  79[0m [1m[94m|[0m             &None,
+2026-06-25T09:54:28.4928706Z      [1m[94m|[0m             [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.4929345Z      [1m[94m|[0m
+2026-06-25T09:54:28.4929666Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.4930067Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.4930417Z      [1m[94m|[0m
+2026-06-25T09:54:28.4930710Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.4931154Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.4931562Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.4931922Z      [1m[94m|[0m
+2026-06-25T09:54:28.4932204Z [1m[94m  78[0m [91m-             &None,[0m
+2026-06-25T09:54:28.4932555Z      [1m[94m|[0m
+2026-06-25T09:54:28.4932694Z 
+2026-06-25T09:54:28.4996565Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5012507Z     [1m[94m--> [0mescrow/src/tests/properties.rs:149:16
+2026-06-25T09:54:28.5012930Z      [1m[94m|[0m
+2026-06-25T09:54:28.5013264Z [1m[94m 149[0m [1m[94m|[0m         client.init(
+2026-06-25T09:54:28.5013693Z      [1m[94m|[0m                [1m[91m^^^^[0m
+2026-06-25T09:54:28.5014061Z [1m[94m...[0m
+2026-06-25T09:54:28.5014416Z [1m[94m 163[0m [1m[94m|[0m             &max_unique_investors,
+2026-06-25T09:54:28.5015359Z      [1m[94m|[0m             [1m[94m---------------------[0m [1m[94munexpected argument #14 of type `&std::option::Option<u32>`[0m
+2026-06-25T09:54:28.5015951Z      [1m[94m|[0m
+2026-06-25T09:54:28.5016247Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5016620Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5017263Z      [1m[94m|[0m
+2026-06-25T09:54:28.5017573Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5017976Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5018354Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5018687Z      [1m[94m|[0m
+2026-06-25T09:54:28.5019059Z [1m[94m 162[0m [91m- [0m            &max_per_investor[91m,[0m
+2026-06-25T09:54:28.5019546Z [1m[94m 163[0m [91m-             &max_unique_investors[0m,
+2026-06-25T09:54:28.5020323Z [1m[94m 162[0m [92m+ [0m            &max_per_investor,
+2026-06-25T09:54:28.5020692Z      [1m[94m|[0m
+2026-06-25T09:54:28.5020835Z 
+2026-06-25T09:54:28.5105465Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5106191Z     [1m[94m--> [0mescrow/src/tests/properties.rs:323:12
+2026-06-25T09:54:28.5106606Z      [1m[94m|[0m
+2026-06-25T09:54:28.5107131Z [1m[94m 323[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5107554Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5108213Z [1m[94m...[0m
+2026-06-25T09:54:28.5108524Z [1m[94m 339[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5109371Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5109954Z      [1m[94m|[0m
+2026-06-25T09:54:28.5110266Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5110677Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5111039Z      [1m[94m|[0m
+2026-06-25T09:54:28.5111364Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5111768Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5112183Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5112558Z      [1m[94m|[0m
+2026-06-25T09:54:28.5112861Z [1m[94m 338[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5113210Z      [1m[94m|[0m
+2026-06-25T09:54:28.5113356Z 
+2026-06-25T09:54:28.5149332Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5149991Z     [1m[94m--> [0mescrow/src/tests/properties.rs:363:12
+2026-06-25T09:54:28.5150349Z      [1m[94m|[0m
+2026-06-25T09:54:28.5150661Z [1m[94m 363[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5151028Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5151371Z [1m[94m...[0m
+2026-06-25T09:54:28.5151663Z [1m[94m 379[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5152428Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5152904Z      [1m[94m|[0m
+2026-06-25T09:54:28.5153180Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5153535Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5153846Z      [1m[94m|[0m
+2026-06-25T09:54:28.5154144Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5154493Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5154932Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5155242Z      [1m[94m|[0m
+2026-06-25T09:54:28.5155496Z [1m[94m 378[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5155797Z      [1m[94m|[0m
+2026-06-25T09:54:28.5155912Z 
+2026-06-25T09:54:28.5195512Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5196193Z     [1m[94m--> [0mescrow/src/tests/properties.rs:401:12
+2026-06-25T09:54:28.5196574Z      [1m[94m|[0m
+2026-06-25T09:54:28.5197048Z [1m[94m 401[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5197436Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5197777Z [1m[94m...[0m
+2026-06-25T09:54:28.5198064Z [1m[94m 417[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5198827Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5199348Z      [1m[94m|[0m
+2026-06-25T09:54:28.5199640Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5200008Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5200338Z      [1m[94m|[0m
+2026-06-25T09:54:28.5200640Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5200999Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5201369Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5201957Z      [1m[94m|[0m
+2026-06-25T09:54:28.5202246Z [1m[94m 416[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5202564Z      [1m[94m|[0m
+2026-06-25T09:54:28.5202697Z 
+2026-06-25T09:54:28.5235171Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5236161Z     [1m[94m--> [0mescrow/src/tests/properties.rs:443:12
+2026-06-25T09:54:28.5236771Z      [1m[94m|[0m
+2026-06-25T09:54:28.5237542Z [1m[94m 443[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5238126Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5238863Z [1m[94m...[0m
+2026-06-25T09:54:28.5239357Z [1m[94m 459[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5240275Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5240977Z      [1m[94m|[0m
+2026-06-25T09:54:28.5241433Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5241977Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5242495Z      [1m[94m|[0m
+2026-06-25T09:54:28.5242975Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5243549Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5244107Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5244622Z      [1m[94m|[0m
+2026-06-25T09:54:28.5245093Z [1m[94m 458[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5245594Z      [1m[94m|[0m
+2026-06-25T09:54:28.5245941Z 
+2026-06-25T09:54:28.5273490Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5274620Z     [1m[94m--> [0mescrow/src/tests/properties.rs:483:12
+2026-06-25T09:54:28.5275345Z      [1m[94m|[0m
+2026-06-25T09:54:28.5275873Z [1m[94m 483[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5276495Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5277185Z [1m[94m...[0m
+2026-06-25T09:54:28.5277684Z [1m[94m 499[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5278798Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5279630Z      [1m[94m|[0m
+2026-06-25T09:54:28.5280105Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5280684Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5281248Z      [1m[94m|[0m
+2026-06-25T09:54:28.5281747Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5282378Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5282965Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5283519Z      [1m[94m|[0m
+2026-06-25T09:54:28.5284021Z [1m[94m 498[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5284739Z      [1m[94m|[0m
+2026-06-25T09:54:28.5285046Z 
+2026-06-25T09:54:28.5334931Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5335959Z     [1m[94m--> [0mescrow/src/tests/properties.rs:521:12
+2026-06-25T09:54:28.5336612Z      [1m[94m|[0m
+2026-06-25T09:54:28.5337246Z [1m[94m 521[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5337643Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5337974Z [1m[94m...[0m
+2026-06-25T09:54:28.5338267Z [1m[94m 537[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5339004Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5339526Z      [1m[94m|[0m
+2026-06-25T09:54:28.5339821Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5340181Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5340521Z      [1m[94m|[0m
+2026-06-25T09:54:28.5340846Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5341244Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5341626Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5342303Z      [1m[94m|[0m
+2026-06-25T09:54:28.5342599Z [1m[94m 536[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5342935Z      [1m[94m|[0m
+2026-06-25T09:54:28.5343071Z 
+2026-06-25T09:54:28.5369818Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5370497Z     [1m[94m--> [0mescrow/src/tests/properties.rs:557:12
+2026-06-25T09:54:28.5370893Z      [1m[94m|[0m
+2026-06-25T09:54:28.5371215Z [1m[94m 557[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5371608Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5372181Z [1m[94m...[0m
+2026-06-25T09:54:28.5372495Z [1m[94m 573[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5373233Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5373766Z      [1m[94m|[0m
+2026-06-25T09:54:28.5374074Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5374467Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5374823Z      [1m[94m|[0m
+2026-06-25T09:54:28.5375142Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5375539Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5375936Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5376282Z      [1m[94m|[0m
+2026-06-25T09:54:28.5376585Z [1m[94m 572[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5377109Z      [1m[94m|[0m
+2026-06-25T09:54:28.5377256Z 
+2026-06-25T09:54:28.5402535Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5403205Z     [1m[94m--> [0mescrow/src/tests/properties.rs:593:12
+2026-06-25T09:54:28.5403591Z      [1m[94m|[0m
+2026-06-25T09:54:28.5403909Z [1m[94m 593[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5404298Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5404623Z [1m[94m...[0m
+2026-06-25T09:54:28.5404922Z [1m[94m 609[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5405657Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5406200Z      [1m[94m|[0m
+2026-06-25T09:54:28.5406499Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5407072Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5407411Z      [1m[94m|[0m
+2026-06-25T09:54:28.5407729Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5408128Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5408504Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5408828Z      [1m[94m|[0m
+2026-06-25T09:54:28.5409113Z [1m[94m 608[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5409438Z      [1m[94m|[0m
+2026-06-25T09:54:28.5409578Z 
+2026-06-25T09:54:28.5436758Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5437527Z     [1m[94m--> [0mescrow/src/tests/properties.rs:635:12
+2026-06-25T09:54:28.5437918Z      [1m[94m|[0m
+2026-06-25T09:54:28.5438222Z [1m[94m 635[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5438620Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5438943Z [1m[94m...[0m
+2026-06-25T09:54:28.5439236Z [1m[94m 651[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5439953Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5440470Z      [1m[94m|[0m
+2026-06-25T09:54:28.5440781Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5441159Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5441505Z      [1m[94m|[0m
+2026-06-25T09:54:28.5441819Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5442204Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5442588Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5443181Z      [1m[94m|[0m
+2026-06-25T09:54:28.5443471Z [1m[94m 650[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5443793Z      [1m[94m|[0m
+2026-06-25T09:54:28.5443936Z 
+2026-06-25T09:54:28.5475055Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5475785Z     [1m[94m--> [0mescrow/src/tests/properties.rs:687:12
+2026-06-25T09:54:28.5476227Z      [1m[94m|[0m
+2026-06-25T09:54:28.5476618Z [1m[94m 687[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5477238Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5477873Z [1m[94m...[0m
+2026-06-25T09:54:28.5478234Z [1m[94m 703[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5479048Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5479665Z      [1m[94m|[0m
+2026-06-25T09:54:28.5480012Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5480441Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5480872Z      [1m[94m|[0m
+2026-06-25T09:54:28.5481235Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5481620Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5481998Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5482323Z      [1m[94m|[0m
+2026-06-25T09:54:28.5482606Z [1m[94m 702[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5482931Z      [1m[94m|[0m
+2026-06-25T09:54:28.5483067Z 
+2026-06-25T09:54:28.5511582Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5512234Z     [1m[94m--> [0mescrow/src/tests/properties.rs:727:12
+2026-06-25T09:54:28.5512624Z      [1m[94m|[0m
+2026-06-25T09:54:28.5512930Z [1m[94m 727[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5513319Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5513651Z [1m[94m...[0m
+2026-06-25T09:54:28.5513932Z [1m[94m 743[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5514689Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5515226Z      [1m[94m|[0m
+2026-06-25T09:54:28.5515520Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5515890Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5516227Z      [1m[94m|[0m
+2026-06-25T09:54:28.5516541Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5517140Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5517552Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5517881Z      [1m[94m|[0m
+2026-06-25T09:54:28.5518161Z [1m[94m 742[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5518469Z      [1m[94m|[0m
+2026-06-25T09:54:28.5518593Z 
+2026-06-25T09:54:28.5547427Z [1m[91merror[E0061][0m[1m: this method takes 15 arguments but 16 arguments were supplied[0m
+2026-06-25T09:54:28.5548159Z     [1m[94m--> [0mescrow/src/tests/properties.rs:781:12
+2026-06-25T09:54:28.5548624Z      [1m[94m|[0m
+2026-06-25T09:54:28.5548990Z [1m[94m 781[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.5549444Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.5549858Z [1m[94m...[0m
+2026-06-25T09:54:28.5550191Z [1m[94m 797[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.5550972Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94munexpected argument #16 of type `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.5551571Z      [1m[94m|[0m
+2026-06-25T09:54:28.5551968Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.5552338Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.5552697Z      [1m[94m|[0m
+2026-06-25T09:54:28.5552989Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.5553325Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.5553644Z [1m[96mhelp[0m: remove the extra argument
+2026-06-25T09:54:28.5554160Z      [1m[94m|[0m
+2026-06-25T09:54:28.5554428Z [1m[94m 796[0m [91m-         &None,[0m
+2026-06-25T09:54:28.5554729Z      [1m[94m|[0m
+2026-06-25T09:54:28.5554857Z 
+2026-06-25T09:54:28.6122317Z [1m[91merror[E0308][0m[1m: arguments to this method are incorrect[0m
+2026-06-25T09:54:28.6122858Z     [1m[94m--> [0mescrow/src/tests/settlement.rs:1772:12
+2026-06-25T09:54:28.6123191Z      [1m[94m|[0m
+2026-06-25T09:54:28.6123468Z [1m[94m1772[0m [1m[94m|[0m     client.init(
+2026-06-25T09:54:28.6123809Z      [1m[94m|[0m            [1m[91m^^^^[0m
+2026-06-25T09:54:28.6124384Z [1m[94m1773[0m [1m[94m|[0m         &admin_addr,
+2026-06-25T09:54:28.6124742Z [1m[94m1774[0m [1m[94m|[0m         &sme_addr,
+2026-06-25T09:54:28.6125482Z      [1m[94m|[0m         [1m[94m---------[0m [1m[94margument #2 of type `&soroban_sdk::String` is missing[0m
+2026-06-25T09:54:28.6125999Z [1m[94m1775[0m [1m[94m|[0m         &100_000i128,
+2026-06-25T09:54:28.6126487Z      [1m[94m|[0m         [1m[94m------------[0m [1m[94munexpected argument #3 of type `&i128`[0m
+2026-06-25T09:54:28.6127058Z [1m[94m...[0m
+2026-06-25T09:54:28.6127404Z [1m[94m1780[0m [1m[94m|[0m         &Address::generate(&env),
+2026-06-25T09:54:28.6128203Z      [1m[94m|[0m         [1m[94m------------------------[0m [1m[94mexpected `&std::option::Option<soroban_sdk::Address>`, found `&soroban_sdk::Address`[0m
+2026-06-25T09:54:28.6128824Z [1m[94m1781[0m [1m[94m|[0m         &None,
+2026-06-25T09:54:28.6129427Z      [1m[94m|[0m         [1m[94m-----[0m [1m[94mexpected `&soroban_sdk::Address`, found `&std::option::Option<_>`[0m
+2026-06-25T09:54:28.6129913Z      [1m[94m|[0m
+2026-06-25T09:54:28.6130161Z [1m[92mnote[0m: method defined here
+2026-06-25T09:54:28.6130480Z     [1m[94m--> [0mescrow/src/lib.rs:1039:12
+2026-06-25T09:54:28.6130765Z      [1m[94m|[0m
+2026-06-25T09:54:28.6131029Z [1m[94m1039[0m [1m[94m|[0m     pub fn init(
+2026-06-25T09:54:28.6131359Z      [1m[94m|[0m            [1m[92m^^^^[0m
+2026-06-25T09:54:28.6131669Z [1m[94m...[0m
+2026-06-25T09:54:28.6131953Z [1m[94m1042[0m [1m[94m|[0m         invoice_id: String,
+2026-06-25T09:54:28.6132329Z      [1m[94m|[0m         [1m[94m------------------[0m
+2026-06-25T09:54:28.6132655Z [1m[96mhelp[0m: did you mean
+2026-06-25T09:54:28.6132909Z      [1m[94m|[0m
+2026-06-25T09:54:28.6133187Z [1m[94m1772[0m [92m~ [0m    client.init[92m([0m
+2026-06-25T09:54:28.6133541Z [1m[94m1773[0m [92m+         &admin_addr,[0m
+2026-06-25T09:54:28.6133978Z [1m[94m1774[0m [92m+         /* &soroban_sdk::String */,[0m
+2026-06-25T09:54:28.6134422Z [1m[94m1775[0m [92m+         &sme_addr,[0m
+2026-06-25T09:54:28.6134825Z [1m[94m1776[0m [92m+         &TARGET,[0m
+2026-06-25T09:54:28.6135229Z [1m[94m1777[0m [92m+         &500i64,[0m
+2026-06-25T09:54:28.6135622Z [1m[94m1778[0m [92m+         &maturity,[0m
+2026-06-25T09:54:28.6136052Z [1m[94m1779[0m [92m+         &token_id,[0m
+2026-06-25T09:54:28.6137012Z [1m[94m1780[0m [92m+         &None,[0m
+2026-06-25T09:54:28.6137576Z [1m[94m1781[0m [92m+         &Address::generate(&env),[0m
+2026-06-25T09:54:28.6138090Z [1m[94m1782[0m [92m+         &None,[0m
+2026-06-25T09:54:28.6138449Z [1m[94m1783[0m [92m+         &None,[0m
+2026-06-25T09:54:28.6138786Z [1m[94m1784[0m [92m+         &None,[0m
+2026-06-25T09:54:28.6139151Z [1m[94m1785[0m [92m+         &None,[0m
+2026-06-25T09:54:28.6139550Z [1m[94m1786[0m [92m+         &None,[0m
+2026-06-25T09:54:28.6139952Z [1m[94m1787[0m [92m+         &None,[0m
+2026-06-25T09:54:28.6140349Z [1m[94m1788[0m [92m~     )[0m;
+2026-06-25T09:54:28.6140722Z      [1m[94m|[0m
+2026-06-25T09:54:28.6140883Z 
+2026-06-25T09:54:28.6142336Z [1m[91merror[E0061][0m[1m: this function takes 1 argument but 4 arguments were supplied[0m
+2026-06-25T09:54:28.6143008Z     [1m[94m--> [0mescrow/src/tests/settlement.rs:1791:5
+2026-06-25T09:54:28.6143397Z      [1m[94m|[0m
+2026-06-25T09:54:28.6143872Z [1m[94m1791[0m [1m[94m|[0m     install_stellar_asset_token(&env, &sac, &investor, TARGET);
+2026-06-25T09:54:28.6145070Z      [1m[94m|[0m     [1m[91m^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m       [1m[94m----[0m  [1m[94m---------[0m  [1m[94m------[0m [1m[94munexpected argument #4 of type `i128`[0m
+2026-06-25T09:54:28.6145901Z      [1m[94m|[0m                                       [1m[94m|[0m     [1m[94m|[0m
+2026-06-25T09:54:28.6146777Z      [1m[94m|[0m                                       [1m[94m|[0m     [1m[94munexpected argument #3 of type `&soroban_sdk::Address`[0m
+2026-06-25T09:54:28.6147939Z      [1m[94m|[0m                                       [1m[94munexpected argument #2 of type `&StellarAssetContract`[0m
+2026-06-25T09:54:28.6148475Z      [1m[94m|[0m
+2026-06-25T09:54:28.6148770Z [1m[92mnote[0m: function defined here
+2026-06-25T09:54:28.6149158Z     [1m[94m--> [0mescrow/src/tests.rs:108:8
+2026-06-25T09:54:28.6149509Z      [1m[94m|[0m
+2026-06-25T09:54:28.6150201Z [1m[94m 108[0m [1m[94m|[0m pub fn install_stellar_asset_token<'a>(env: &'a Env) -> StellarTestToken<'a> {
+2026-06-25T09:54:28.6150949Z      [1m[94m|[0m        [1m[92m^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+2026-06-25T09:54:28.6151449Z [1m[96mhelp[0m: remove the extra arguments
+2026-06-25T09:54:28.6151856Z      [1m[94m|[0m
+2026-06-25T09:54:28.6152425Z [1m[94m1791[0m [91m- [0m    install_stellar_asset_token(&env[91m, &sac, &investor, TARGET[0m);
+2026-06-25T09:54:28.6153163Z [1m[94m1791[0m [92m+ [0m    install_stellar_asset_token(&env);
+2026-06-25T09:54:28.6153640Z      [1m[94m|[0m
+2026-06-25T09:54:28.6153833Z 
+2026-06-25T09:54:29.2654404Z [1mSome errors have detailed explanations: E0061, E0106, E0308, E0599.[0m
+2026-06-25T09:54:29.2654903Z [1mFor more information about an error, try `rustc --explain E0061`.[0m
+2026-06-25T09:54:29.2720910Z [1m[33mwarning[0m: `liquifact_escrow` (lib test) generated 3 warnings
+2026-06-25T09:54:29.2721668Z [1m[91merror[0m: could not compile `liquifact_escrow` (lib test) due to 32 previous errors; 3 warnings emitted
+2026-06-25T09:54:29.2851809Z ##[error]Process completed with exit code 101.
+2026-06-25T09:54:29.2953823Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-06-25T09:54:29.2954761Z Post job cleanup.
+2026-06-25T09:54:29.3635780Z [command]/usr/bin/git version
+2026-06-25T09:54:29.3698187Z git version 2.54.0
+2026-06-25T09:54:29.3726201Z Temporarily overriding HOME='/home/runner/work/_temp/25401bb8-7284-43bf-8587-10a412bbc247' before making global git config changes
+2026-06-25T09:54:29.3727250Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-25T09:54:29.3730145Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T09:54:29.3760026Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-25T09:54:29.3787165Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-25T09:54:29.3964432Z fatal: No url found for submodule path 'Liquifact-contracts' in .gitmodules
+2026-06-25T09:54:29.3995296Z ##[warning]The process '/usr/bin/git' failed with exit code 128
+2026-06-25T09:54:29.4102207Z Cleaning up orphan processes
+2026-06-25T09:54:29.4328084Z ##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/ci_logs4.txt
+++ b/ci_logs4.txt
@@ -1,0 +1,1765 @@
+﻿2026-06-25T10:01:50.6267031Z Current runner version: '2.335.1'
+2026-06-25T10:01:50.6292472Z ##[group]Runner Image Provisioner
+2026-06-25T10:01:50.6293334Z Hosted Compute Agent
+2026-06-25T10:01:50.6294050Z Version: 20260611.554
+2026-06-25T10:01:50.6294752Z Commit: 5e0782fdc9014723d3be820dd114dd31555c2bd1
+2026-06-25T10:01:50.6295555Z Build Date: 2026-06-11T21:40:46Z
+2026-06-25T10:01:50.6296293Z Worker ID: {690f37c4-db3c-424c-ae95-e5c556bdfe12}
+2026-06-25T10:01:50.6297030Z Azure Region: westus3
+2026-06-25T10:01:50.6297680Z ##[endgroup]
+2026-06-25T10:01:50.6299164Z ##[group]Operating System
+2026-06-25T10:01:50.6299910Z Ubuntu
+2026-06-25T10:01:50.6300479Z 24.04.4
+2026-06-25T10:01:50.6301023Z LTS
+2026-06-25T10:01:50.6301791Z ##[endgroup]
+2026-06-25T10:01:50.6302404Z ##[group]Runner Image
+2026-06-25T10:01:50.6303019Z Image: ubuntu-24.04
+2026-06-25T10:01:50.6303675Z Version: 20260615.205.1
+2026-06-25T10:01:50.6304953Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260615.205/images/ubuntu/Ubuntu2404-Readme.md
+2026-06-25T10:01:50.6306601Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260615.205
+2026-06-25T10:01:50.6307569Z ##[endgroup]
+2026-06-25T10:01:50.6308820Z ##[group]GITHUB_TOKEN Permissions
+2026-06-25T10:01:50.6310763Z Contents: read
+2026-06-25T10:01:50.6311822Z Metadata: read
+2026-06-25T10:01:50.6312454Z Packages: read
+2026-06-25T10:01:50.6313090Z ##[endgroup]
+2026-06-25T10:01:50.6315577Z Secret source: None
+2026-06-25T10:01:50.6316336Z Prepare workflow directory
+2026-06-25T10:01:50.6654414Z Prepare all required actions
+2026-06-25T10:01:50.6692015Z Getting action download info
+2026-06-25T10:01:51.0625185Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2026-06-25T10:01:51.2429563Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+2026-06-25T10:01:51.5078107Z Download action repository 'Swatinem/rust-cache@v2' (SHA:e18b497796c12c097a38f9edb9d0641fb99eee32)
+2026-06-25T10:01:52.6232450Z Download action repository 'taiki-e/install-action@cargo-llvm-cov' (SHA:901c6c5742b8b5bab0a7cf0bf63286ad5e3120f3)
+2026-06-25T10:01:53.4194751Z Complete job name: fmt-build-test
+2026-06-25T10:01:53.4870963Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-06-25T10:01:53.4878992Z ##[group]Run actions/checkout@v4
+2026-06-25T10:01:53.4879426Z with:
+2026-06-25T10:01:53.4879684Z   repository: Liquifact/Liquifact-contracts
+2026-06-25T10:01:53.4882638Z   token: ***
+2026-06-25T10:01:53.4882873Z   ssh-strict: true
+2026-06-25T10:01:53.4883096Z   ssh-user: git
+2026-06-25T10:01:53.4883335Z   persist-credentials: true
+2026-06-25T10:01:53.4883589Z   clean: true
+2026-06-25T10:01:53.4883816Z   sparse-checkout-cone-mode: true
+2026-06-25T10:01:53.4884119Z   fetch-depth: 1
+2026-06-25T10:01:53.4884343Z   fetch-tags: false
+2026-06-25T10:01:53.4884581Z   show-progress: true
+2026-06-25T10:01:53.4884810Z   lfs: false
+2026-06-25T10:01:53.4885053Z   submodules: false
+2026-06-25T10:01:53.4885280Z   set-safe-directory: true
+2026-06-25T10:01:53.4885695Z ##[endgroup]
+2026-06-25T10:01:53.5926895Z Syncing repository: Liquifact/Liquifact-contracts
+2026-06-25T10:01:53.5928262Z ##[group]Getting Git version info
+2026-06-25T10:01:53.5928732Z Working directory is '/home/runner/work/Liquifact-contracts/Liquifact-contracts'
+2026-06-25T10:01:53.5929418Z [command]/usr/bin/git version
+2026-06-25T10:01:53.5967197Z git version 2.54.0
+2026-06-25T10:01:53.5995390Z ##[endgroup]
+2026-06-25T10:01:53.6012945Z Temporarily overriding HOME='/home/runner/work/_temp/a53658fa-390a-4d67-b852-0d7da08ce633' before making global git config changes
+2026-06-25T10:01:53.6014273Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-25T10:01:53.6019162Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T10:01:53.6070036Z Deleting the contents of '/home/runner/work/Liquifact-contracts/Liquifact-contracts'
+2026-06-25T10:01:53.6075254Z ##[group]Initializing the repository
+2026-06-25T10:01:53.6079969Z [command]/usr/bin/git init /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T10:01:53.6150833Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-06-25T10:01:53.6151733Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-06-25T10:01:53.6152366Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-06-25T10:01:53.6152960Z hint: call:
+2026-06-25T10:01:53.6153401Z hint:
+2026-06-25T10:01:53.6153768Z hint: 	git config --global init.defaultBranch <name>
+2026-06-25T10:01:53.6154108Z hint:
+2026-06-25T10:01:53.6154419Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-06-25T10:01:53.6154962Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-06-25T10:01:53.6155339Z hint:
+2026-06-25T10:01:53.6155566Z hint: 	git branch -m <name>
+2026-06-25T10:01:53.6155811Z hint:
+2026-06-25T10:01:53.6156145Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-06-25T10:01:53.6161106Z Initialized empty Git repository in /home/runner/work/Liquifact-contracts/Liquifact-contracts/.git/
+2026-06-25T10:01:53.6170289Z [command]/usr/bin/git remote add origin https://github.com/Liquifact/Liquifact-contracts
+2026-06-25T10:01:53.6207406Z ##[endgroup]
+2026-06-25T10:01:53.6208044Z ##[group]Disabling automatic garbage collection
+2026-06-25T10:01:53.6211558Z [command]/usr/bin/git config --local gc.auto 0
+2026-06-25T10:01:53.6246566Z ##[endgroup]
+2026-06-25T10:01:53.6246982Z ##[group]Setting up auth
+2026-06-25T10:01:53.6247426Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-25T10:01:53.6278482Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-25T10:01:53.6581248Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-06-25T10:01:53.6612062Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-06-25T10:01:53.6852654Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-06-25T10:01:53.6888193Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-06-25T10:01:53.7137686Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-06-25T10:01:53.7174637Z ##[endgroup]
+2026-06-25T10:01:53.7175339Z ##[group]Fetching the repository
+2026-06-25T10:01:53.7184202Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +0b9bae0b82919a91e0d8f6d44359c23fffd3ff68:refs/remotes/pull/427/merge
+2026-06-25T10:01:54.5060440Z From https://github.com/Liquifact/Liquifact-contracts
+2026-06-25T10:01:54.5061545Z  * [new ref]         0b9bae0b82919a91e0d8f6d44359c23fffd3ff68 -> pull/427/merge
+2026-06-25T10:01:54.5098795Z ##[endgroup]
+2026-06-25T10:01:54.5099415Z ##[group]Determining the checkout info
+2026-06-25T10:01:54.5103273Z ##[endgroup]
+2026-06-25T10:01:54.5110348Z [command]/usr/bin/git sparse-checkout disable
+2026-06-25T10:01:54.5160279Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-06-25T10:01:54.5189968Z ##[group]Checking out the ref
+2026-06-25T10:01:54.5195942Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/427/merge
+2026-06-25T10:01:54.5594096Z Note: switching to 'refs/remotes/pull/427/merge'.
+2026-06-25T10:01:54.5595143Z 
+2026-06-25T10:01:54.5595808Z You are in 'detached HEAD' state. You can look around, make experimental
+2026-06-25T10:01:54.5597065Z changes and commit them, and you can discard any commits you make in this
+2026-06-25T10:01:54.5597991Z state without impacting any branches by switching back to a branch.
+2026-06-25T10:01:54.5598481Z 
+2026-06-25T10:01:54.5598805Z If you want to create a new branch to retain commits you create, you may
+2026-06-25T10:01:54.5599568Z do so (now or later) by using -c with the switch command. Example:
+2026-06-25T10:01:54.5600009Z 
+2026-06-25T10:01:54.5600204Z   git switch -c <new-branch-name>
+2026-06-25T10:01:54.5600489Z 
+2026-06-25T10:01:54.5600664Z Or undo this operation with:
+2026-06-25T10:01:54.5600936Z 
+2026-06-25T10:01:54.5601090Z   git switch -
+2026-06-25T10:01:54.5601520Z 
+2026-06-25T10:01:54.5601900Z Turn off this advice by setting config variable advice.detachedHead to false
+2026-06-25T10:01:54.5602418Z 
+2026-06-25T10:01:54.5603036Z HEAD is now at 0b9bae0 Merge e6055be3a3a09643c229a27d66f25149c6f3470b into f3c49bc43a4afd486efc2e2beb59bd144adb5029
+2026-06-25T10:01:54.5612976Z ##[endgroup]
+2026-06-25T10:01:54.5655118Z [command]/usr/bin/git log -1 --format=%H
+2026-06-25T10:01:54.5680594Z 0b9bae0b82919a91e0d8f6d44359c23fffd3ff68
+2026-06-25T10:01:54.6017137Z ##[group]Run dtolnay/rust-toolchain@stable
+2026-06-25T10:01:54.6017460Z with:
+2026-06-25T10:01:54.6017715Z   components: rustfmt, clippy, llvm-tools-preview
+2026-06-25T10:01:54.6018026Z   toolchain: stable
+2026-06-25T10:01:54.6018247Z ##[endgroup]
+2026-06-25T10:01:54.6150490Z ##[group]Run : parse toolchain version
+2026-06-25T10:01:54.6150905Z [36;1m: parse toolchain version[0m
+2026-06-25T10:01:54.6151215Z [36;1mif [[ -z $toolchain ]]; then[0m
+2026-06-25T10:01:54.6152022Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+2026-06-25T10:01:54.6152588Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+2026-06-25T10:01:54.6152888Z [36;1m  exit 1[0m
+2026-06-25T10:01:54.6153248Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+2026-06-25T10:01:54.6153657Z [36;1m  if [[ Linux == macOS ]]; then[0m
+2026-06-25T10:01:54.6154714Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-06-25T10:01:54.6155620Z [36;1m  else[0m
+2026-06-25T10:01:54.6156042Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-06-25T10:01:54.6156508Z [36;1m  fi[0m
+2026-06-25T10:01:54.6156829Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+2026-06-25T10:01:54.6157371Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+2026-06-25T10:01:54.6158132Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+2026-06-25T10:01:54.6159006Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+2026-06-25T10:01:54.6159817Z [36;1melse[0m
+2026-06-25T10:01:54.6160225Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+2026-06-25T10:01:54.6160743Z [36;1mfi[0m
+2026-06-25T10:01:54.6293563Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:54.6293963Z env:
+2026-06-25T10:01:54.6294180Z   toolchain: stable
+2026-06-25T10:01:54.6294419Z ##[endgroup]
+2026-06-25T10:01:54.6442368Z ##[group]Run : construct rustup command line
+2026-06-25T10:01:54.6442743Z [36;1m: construct rustup command line[0m
+2026-06-25T10:01:54.6443211Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+2026-06-25T10:01:54.6443830Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+2026-06-25T10:01:54.6444307Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+2026-06-25T10:01:54.6474635Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:54.6475149Z env:
+2026-06-25T10:01:54.6475346Z   targets: 
+2026-06-25T10:01:54.6475598Z   components: rustfmt, clippy, llvm-tools-preview
+2026-06-25T10:01:54.6475903Z ##[endgroup]
+2026-06-25T10:01:54.6563939Z ##[group]Run : set $CARGO_HOME
+2026-06-25T10:01:54.6564240Z [36;1m: set $CARGO_HOME[0m
+2026-06-25T10:01:54.6564578Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+2026-06-25T10:01:54.6594169Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:54.6594629Z ##[endgroup]
+2026-06-25T10:01:54.6680636Z ##[group]Run : install rustup if needed
+2026-06-25T10:01:54.6680961Z [36;1m: install rustup if needed[0m
+2026-06-25T10:01:54.6681268Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+2026-06-25T10:01:54.6682384Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+2026-06-25T10:01:54.6683139Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+2026-06-25T10:01:54.6683438Z [36;1mfi[0m
+2026-06-25T10:01:54.6713430Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:54.6713772Z env:
+2026-06-25T10:01:54.6714176Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:54.6714441Z ##[endgroup]
+2026-06-25T10:01:54.6799752Z ##[group]Run rustup toolchain install stable --component rustfmt --component clippy --component llvm-tools-preview --profile minimal --no-self-update
+2026-06-25T10:01:54.6800770Z [36;1mrustup toolchain install stable --component rustfmt --component clippy --component llvm-tools-preview --profile minimal --no-self-update[0m
+2026-06-25T10:01:54.6830838Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:54.6831178Z env:
+2026-06-25T10:01:54.6831551Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:54.6831824Z   RUSTUP_PERMIT_COPY_RENAME: 1
+2026-06-25T10:01:54.6832073Z ##[endgroup]
+2026-06-25T10:01:54.8483319Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+2026-06-25T10:01:55.1904635Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T10:01:55.2142193Z info: component clippy is up to date
+2026-06-25T10:01:55.2142700Z info: component rustfmt is up to date
+2026-06-25T10:01:55.2150525Z info: downloading component llvm-tools
+2026-06-25T10:01:58.1263747Z 
+2026-06-25T10:01:58.1352216Z   stable-x86_64-unknown-linux-gnu updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.96.0 (ac68faa20 2026-05-25))
+2026-06-25T10:01:58.1353094Z 
+2026-06-25T10:01:58.1440002Z ##[group]Run rustup default stable
+2026-06-25T10:01:58.1440333Z [36;1mrustup default stable[0m
+2026-06-25T10:01:58.1472786Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:58.1473163Z env:
+2026-06-25T10:01:58.1473379Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:58.1473642Z ##[endgroup]
+2026-06-25T10:01:58.1581491Z info: using existing install for stable-x86_64-unknown-linux-gnu
+2026-06-25T10:01:58.1586922Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+2026-06-25T10:01:58.1587295Z 
+2026-06-25T10:01:58.1671041Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T10:01:58.1671882Z 
+2026-06-25T10:01:58.1706604Z ##[group]Run : create cachekey
+2026-06-25T10:01:58.1706915Z [36;1m: create cachekey[0m
+2026-06-25T10:01:58.1707437Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+2026-06-25T10:01:58.1708080Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+2026-06-25T10:01:58.1708608Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+2026-06-25T10:01:58.1739181Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:58.1739520Z env:
+2026-06-25T10:01:58.1739735Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:58.1739997Z ##[endgroup]
+2026-06-25T10:01:58.2136223Z ##[group]Run : disable incremental compilation
+2026-06-25T10:01:58.2136606Z [36;1m: disable incremental compilation[0m
+2026-06-25T10:01:58.2136974Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+2026-06-25T10:01:58.2137344Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+2026-06-25T10:01:58.2137649Z [36;1mfi[0m
+2026-06-25T10:01:58.2168595Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:58.2168946Z env:
+2026-06-25T10:01:58.2169206Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:58.2169478Z ##[endgroup]
+2026-06-25T10:01:58.2242234Z ##[group]Run : enable colors in Cargo output
+2026-06-25T10:01:58.2242581Z [36;1m: enable colors in Cargo output[0m
+2026-06-25T10:01:58.2242901Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+2026-06-25T10:01:58.2243250Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+2026-06-25T10:01:58.2243560Z [36;1mfi[0m
+2026-06-25T10:01:58.2273357Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:58.2273710Z env:
+2026-06-25T10:01:58.2273924Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:58.2274194Z   CARGO_INCREMENTAL: 0
+2026-06-25T10:01:58.2274418Z ##[endgroup]
+2026-06-25T10:01:58.2346435Z ##[group]Run : enable Cargo sparse registry
+2026-06-25T10:01:58.2346946Z [36;1m: enable Cargo sparse registry[0m
+2026-06-25T10:01:58.2347327Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+2026-06-25T10:01:58.2348043Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+2026-06-25T10:01:58.2348764Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+2026-06-25T10:01:58.2349330Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-06-25T10:01:58.2349868Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+2026-06-25T10:01:58.2350360Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+2026-06-25T10:01:58.2350918Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-06-25T10:01:58.2351683Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+2026-06-25T10:01:58.2352041Z [36;1m  fi[0m
+2026-06-25T10:01:58.2352247Z [36;1mfi[0m
+2026-06-25T10:01:58.2381483Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:58.2381837Z env:
+2026-06-25T10:01:58.2382054Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:58.2382321Z   CARGO_INCREMENTAL: 0
+2026-06-25T10:01:58.2382550Z   CARGO_TERM_COLOR: always
+2026-06-25T10:01:58.2382790Z ##[endgroup]
+2026-06-25T10:01:58.2745325Z ##[group]Run : work around spurious network errors in curl 8.0
+2026-06-25T10:01:58.2745782Z [36;1m: work around spurious network errors in curl 8.0[0m
+2026-06-25T10:01:58.2746360Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+2026-06-25T10:01:58.2747020Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+2026-06-25T10:01:58.2747487Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+2026-06-25T10:01:58.2747816Z [36;1mfi[0m
+2026-06-25T10:01:58.2779202Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:58.2779559Z env:
+2026-06-25T10:01:58.2779774Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:58.2780043Z   CARGO_INCREMENTAL: 0
+2026-06-25T10:01:58.2780276Z   CARGO_TERM_COLOR: always
+2026-06-25T10:01:58.2780513Z ##[endgroup]
+2026-06-25T10:01:58.2997346Z ##[group]Run rustc +stable --version --verbose
+2026-06-25T10:01:58.2997716Z [36;1mrustc +stable --version --verbose[0m
+2026-06-25T10:01:58.3027924Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T10:01:58.3028268Z env:
+2026-06-25T10:01:58.3028485Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:58.3028755Z   CARGO_INCREMENTAL: 0
+2026-06-25T10:01:58.3028995Z   CARGO_TERM_COLOR: always
+2026-06-25T10:01:58.3029408Z ##[endgroup]
+2026-06-25T10:01:58.3205190Z rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T10:01:58.3205606Z binary: rustc
+2026-06-25T10:01:58.3206013Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T10:01:58.3206501Z commit-date: 2026-05-25
+2026-06-25T10:01:58.3206756Z host: x86_64-unknown-linux-gnu
+2026-06-25T10:01:58.3207011Z release: 1.96.0
+2026-06-25T10:01:58.3207260Z LLVM version: 22.1.2
+2026-06-25T10:01:58.3335839Z ##[group]Run Swatinem/rust-cache@v2
+2026-06-25T10:01:58.3336143Z with:
+2026-06-25T10:01:58.3336649Z   prefix-key: v0-rust
+2026-06-25T10:01:58.3337019Z   add-job-id-key: true
+2026-06-25T10:01:58.3337375Z   add-rust-environment-hash-key: true
+2026-06-25T10:01:58.3337901Z   cache-targets: true
+2026-06-25T10:01:58.3338261Z   cache-all-crates: false
+2026-06-25T10:01:58.3338727Z   cache-workspace-crates: false
+2026-06-25T10:01:58.3339105Z   save-if: true
+2026-06-25T10:01:58.3339425Z   cache-provider: github
+2026-06-25T10:01:58.3339884Z   cache-bin: true
+2026-06-25T10:01:58.3340237Z   lookup-only: false
+2026-06-25T10:01:58.3340608Z   cmd-format: {0}
+2026-06-25T10:01:58.3340959Z env:
+2026-06-25T10:01:58.3341518Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:58.3342014Z   CARGO_INCREMENTAL: 0
+2026-06-25T10:01:58.3342375Z   CARGO_TERM_COLOR: always
+2026-06-25T10:01:58.3342721Z ##[endgroup]
+2026-06-25T10:01:58.6125472Z (node:2367) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+2026-06-25T10:01:58.6126216Z (Use `node --trace-deprecation ...` to show where the warning was created)
+2026-06-25T10:01:58.8342513Z ##[group]Cache Configuration
+2026-06-25T10:01:58.8362352Z Cache Provider:
+2026-06-25T10:01:58.8362712Z     github
+2026-06-25T10:01:58.8363034Z Workspaces:
+2026-06-25T10:01:58.8363519Z     /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T10:01:58.8364097Z Cache Paths:
+2026-06-25T10:01:58.8364417Z     /home/runner/.cargo/bin
+2026-06-25T10:01:58.8364823Z     /home/runner/.cargo/.crates.toml
+2026-06-25T10:01:58.8365299Z     /home/runner/.cargo/.crates2.json
+2026-06-25T10:01:58.8365750Z     /home/runner/.cargo/registry
+2026-06-25T10:01:58.8366161Z     /home/runner/.cargo/git
+2026-06-25T10:01:58.8366695Z     /home/runner/work/Liquifact-contracts/Liquifact-contracts/target
+2026-06-25T10:01:58.8367308Z Restore Key:
+2026-06-25T10:01:58.8367707Z     v0-rust-fmt-build-test-Linux-x64-4107bf91
+2026-06-25T10:01:58.8368188Z Cache Key:
+2026-06-25T10:01:58.8368601Z     v0-rust-fmt-build-test-Linux-x64-4107bf91-e1b782ec
+2026-06-25T10:01:58.8369112Z .. Prefix:
+2026-06-25T10:01:58.8369458Z   - v0-rust-fmt-build-test-Linux-x64
+2026-06-25T10:01:58.8369921Z .. Environment considered:
+2026-06-25T10:01:58.8370305Z   - Rust Versions:
+2026-06-25T10:01:58.8370835Z     - 1.96.0 x86_64-unknown-linux-gnu ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T10:01:58.8372152Z     - 1.96.0 x86_64-unknown-linux-gnu ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T10:01:58.8373554Z   - CARGO_HOME
+2026-06-25T10:01:58.8373906Z   - CARGO_INCREMENTAL
+2026-06-25T10:01:58.8374262Z   - CARGO_TERM_COLOR
+2026-06-25T10:01:58.8374617Z .. Lockfiles considered:
+2026-06-25T10:01:58.8375185Z   - /home/runner/work/Liquifact-contracts/Liquifact-contracts/Cargo.lock
+2026-06-25T10:01:58.8376055Z   - /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/Cargo.toml
+2026-06-25T10:01:58.8377048Z ##[endgroup]
+2026-06-25T10:01:58.8377250Z 
+2026-06-25T10:01:58.8377414Z ... Restoring cache ...
+2026-06-25T10:01:59.0557382Z No cache found.
+2026-06-25T10:01:59.0699163Z ##[group]Run cargo fmt -p liquifact_escrow -- --check
+2026-06-25T10:01:59.0699570Z [36;1mcargo fmt -p liquifact_escrow -- --check[0m
+2026-06-25T10:01:59.0733313Z shell: /usr/bin/bash -e {0}
+2026-06-25T10:01:59.0733571Z env:
+2026-06-25T10:01:59.0733780Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T10:01:59.0734055Z   CARGO_INCREMENTAL: 0
+2026-06-25T10:01:59.0734296Z   CARGO_TERM_COLOR: always
+2026-06-25T10:01:59.0734529Z   CACHE_ON_FAILURE: false
+2026-06-25T10:01:59.0734945Z ##[endgroup]
+2026-06-25T10:01:59.4908837Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:27:
+2026-06-25T10:01:59.4909689Z          &None,
+2026-06-25T10:01:59.4909990Z          &None,
+2026-06-25T10:01:59.4910290Z      );
+2026-06-25T10:01:59.4910642Z -let updated = client.update_maturity(&2000u64);
+2026-06-25T10:01:59.4911276Z +    let updated = client.update_maturity(&2000u64);
+2026-06-25T10:01:59.4912216Z      assert_eq!(updated.maturity, 2000u64);
+2026-06-25T10:01:59.4912747Z      assert_eq!(updated.status, 0);
+2026-06-25T10:01:59.4913139Z  }
+2026-06-25T10:01:59.4913759Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:56:
+2026-06-25T10:01:59.4914497Z          &None,
+2026-06-25T10:01:59.4914802Z          &None,
+2026-06-25T10:01:59.4915093Z      );
+2026-06-25T10:01:59.4915399Z -client.fund(&investor, &1_000i128);
+2026-06-25T10:01:59.4915827Z +    client.fund(&investor, &1_000i128);
+2026-06-25T10:01:59.4916254Z      client.update_maturity(&2000u64);
+2026-06-25T10:01:59.4916664Z  }
+2026-06-25T10:01:59.4916928Z  
+2026-06-25T10:01:59.4917512Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:86:
+2026-06-25T10:01:59.4918221Z          &None,
+2026-06-25T10:01:59.4918516Z          &None,
+2026-06-25T10:01:59.4918795Z      );
+2026-06-25T10:01:59.4919076Z -env.mock_auths(&[]);
+2026-06-25T10:01:59.4919419Z +    env.mock_auths(&[]);
+2026-06-25T10:01:59.4919796Z      client.update_maturity(&2000u64);
+2026-06-25T10:01:59.4920183Z  }
+2026-06-25T10:01:59.4920444Z  
+2026-06-25T10:01:59.4921022Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:113:
+2026-06-25T10:01:59.4921927Z          &None,
+2026-06-25T10:01:59.4922220Z          &None,
+2026-06-25T10:01:59.4922498Z      );
+2026-06-25T10:01:59.4922836Z -let pending = client.propose_admin(&new_admin);
+2026-06-25T10:01:59.4923357Z +    let pending = client.propose_admin(&new_admin);
+2026-06-25T10:01:59.4923836Z      assert_eq!(pending, new_admin);
+2026-06-25T10:01:59.4924172Z      assert_eq!(client.get_pending_admin(), Some(new_admin));
+2026-06-25T10:01:59.4924544Z      assert_eq!(client.get_escrow().admin, admin);
+2026-06-25T10:01:59.4925034Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:142:
+2026-06-25T10:01:59.4925474Z          &None,
+2026-06-25T10:01:59.4925666Z          &None,
+2026-06-25T10:01:59.4925846Z      );
+2026-06-25T10:01:59.4926052Z -client.propose_admin(&new_admin);
+2026-06-25T10:01:59.4926321Z +    client.propose_admin(&new_admin);
+2026-06-25T10:01:59.4926602Z      let updated = client.accept_admin();
+2026-06-25T10:01:59.4926893Z      assert_eq!(updated.admin, new_admin);
+2026-06-25T10:01:59.4927208Z      assert_eq!(client.get_escrow().admin, new_admin);
+2026-06-25T10:01:59.4927680Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:173:
+2026-06-25T10:01:59.4928115Z          &None,
+2026-06-25T10:01:59.4928311Z          &None,
+2026-06-25T10:01:59.4928497Z      );
+2026-06-25T10:01:59.4928733Z -let unchanged = client.transfer_admin(&new_admin);
+2026-06-25T10:01:59.4929085Z +    let unchanged = client.transfer_admin(&new_admin);
+2026-06-25T10:01:59.4929408Z      assert_eq!(unchanged.admin, admin);
+2026-06-25T10:01:59.4929733Z      assert_eq!(client.get_pending_admin(), Some(new_admin));
+2026-06-25T10:01:59.4930042Z  }
+2026-06-25T10:01:59.4930829Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:201:
+2026-06-25T10:01:59.4931465Z          &None,
+2026-06-25T10:01:59.4931728Z          &None,
+2026-06-25T10:01:59.4931914Z      );
+2026-06-25T10:01:59.4932118Z -client.propose_admin(&admin);
+2026-06-25T10:01:59.4932380Z +    client.propose_admin(&admin);
+2026-06-25T10:01:59.4932627Z  }
+2026-06-25T10:01:59.4932794Z  
+2026-06-25T10:01:59.4932969Z  #[test]
+2026-06-25T10:01:59.4933361Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:343:
+2026-06-25T10:01:59.4933978Z          &None,
+2026-06-25T10:01:59.4934175Z          &None,
+2026-06-25T10:01:59.4934361Z      );
+2026-06-25T10:01:59.4934573Z -let summary = client.get_escrow_summary();
+2026-06-25T10:01:59.4934883Z +    let summary = client.get_escrow_summary();
+2026-06-25T10:01:59.4935164Z  
+2026-06-25T10:01:59.4935393Z      assert_eq!(summary.escrow, client.get_escrow());
+2026-06-25T10:01:59.4935761Z      assert_eq!(summary.legal_hold, client.get_legal_hold());
+2026-06-25T10:01:59.4936269Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:377:
+2026-06-25T10:01:59.4936707Z          &None,
+2026-06-25T10:01:59.4936897Z          &None,
+2026-06-25T10:01:59.4937084Z      );
+2026-06-25T10:01:59.4937404Z -let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
+2026-06-25T10:01:59.4937927Z +    let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
+2026-06-25T10:01:59.4938326Z      assert_eq!(c.amount, 5000i128);
+2026-06-25T10:01:59.4938614Z      assert_eq!(c.asset, symbol_short!("USDC"));
+2026-06-25T10:01:59.4938974Z      assert_eq!(client.get_sme_collateral_commitment(), Some(c));
+2026-06-25T10:01:59.4939481Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:410:
+2026-06-25T10:01:59.4939916Z          &None,
+2026-06-25T10:01:59.4940102Z          &None,
+2026-06-25T10:01:59.4940283Z      );
+2026-06-25T10:01:59.4940572Z -client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
+2026-06-25T10:01:59.4941038Z +    client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
+2026-06-25T10:01:59.4941577Z  }
+2026-06-25T10:01:59.4941751Z  
+2026-06-25T10:01:59.4941930Z  #[test]
+2026-06-25T10:01:59.4942311Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:436:
+2026-06-25T10:01:59.4942741Z          &None,
+2026-06-25T10:01:59.4942929Z          &None,
+2026-06-25T10:01:59.4943112Z      );
+2026-06-25T10:01:59.4943297Z -env.mock_auths(&[]);
+2026-06-25T10:01:59.4943528Z +    env.mock_auths(&[]);
+2026-06-25T10:01:59.4943867Z      client.record_sme_collateral_commitment(&symbol_short!("XLM"), &100i128);
+2026-06-25T10:01:59.4944234Z  }
+2026-06-25T10:01:59.4944410Z  
+2026-06-25T10:01:59.4944772Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:463:
+2026-06-25T10:01:59.4945192Z          &None,
+2026-06-25T10:01:59.4945378Z          &None,
+2026-06-25T10:01:59.4945559Z      );
+2026-06-25T10:01:59.4945759Z -client.fund(&investor, &TARGET);
+2026-06-25T10:01:59.4946025Z +    client.fund(&investor, &TARGET);
+2026-06-25T10:01:59.4946292Z      client.set_legal_hold(&true);
+2026-06-25T10:01:59.4946557Z      assert!(client.get_legal_hold());
+2026-06-25T10:01:59.4946801Z  
+2026-06-25T10:01:59.4947150Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:517:
+2026-06-25T10:01:59.4947573Z          &None,
+2026-06-25T10:01:59.4947761Z          &None,
+2026-06-25T10:01:59.4947954Z      );
+2026-06-25T10:01:59.4948149Z -client.set_legal_hold(&true);
+2026-06-25T10:01:59.4948395Z +    client.set_legal_hold(&true);
+2026-06-25T10:01:59.4948650Z      client.fund(&investor, &1i128);
+2026-06-25T10:01:59.4948901Z  }
+2026-06-25T10:01:59.4949071Z  
+2026-06-25T10:01:59.4949413Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:560:
+2026-06-25T10:01:59.4949834Z          &None,
+2026-06-25T10:01:59.4950017Z          &None,
+2026-06-25T10:01:59.4950350Z      );
+2026-06-25T10:01:59.4950597Z -let updated = client.update_funding_target(&10_000i128);
+2026-06-25T10:01:59.4950968Z +    let updated = client.update_funding_target(&10_000i128);
+2026-06-25T10:01:59.4951493Z      assert_eq!(updated.funding_target, 10_000i128);
+2026-06-25T10:01:59.4951804Z      assert_eq!(updated.status, 0);
+2026-06-25T10:01:59.4952045Z  }
+2026-06-25T10:01:59.4952402Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:593:
+2026-06-25T10:01:59.4952953Z          &None,
+2026-06-25T10:01:59.4953143Z          &None,
+2026-06-25T10:01:59.4953414Z      );
+2026-06-25T10:01:59.4953633Z -env.mock_auths(&[]);
+2026-06-25T10:01:59.4953865Z +    env.mock_auths(&[]);
+2026-06-25T10:01:59.4954112Z      client.update_funding_target(&10_000i128);
+2026-06-25T10:01:59.4954407Z  }
+2026-06-25T10:01:59.4954574Z  
+2026-06-25T10:01:59.4954960Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:627:
+2026-06-25T10:01:59.4955397Z          &None,
+2026-06-25T10:01:59.4955587Z          &None,
+2026-06-25T10:01:59.4955772Z      );
+2026-06-25T10:01:59.4955965Z -client.fund(&investor, &5_000i128);
+2026-06-25T10:01:59.4956232Z +    client.fund(&investor, &5_000i128);
+2026-06-25T10:01:59.4956510Z      client.update_funding_target(&10_000i128);
+2026-06-25T10:01:59.4956774Z  }
+2026-06-25T10:01:59.4956943Z  
+2026-06-25T10:01:59.4957395Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:661:
+2026-06-25T10:01:59.4957840Z          &None,
+2026-06-25T10:01:59.4958028Z          &None,
+2026-06-25T10:01:59.4958224Z      );
+2026-06-25T10:01:59.4958422Z -client.fund(&investor, &4_000i128);
+2026-06-25T10:01:59.4958691Z +    client.fund(&investor, &4_000i128);
+2026-06-25T10:01:59.4958980Z      client.update_funding_target(&3_000i128);
+2026-06-25T10:01:59.4959247Z  }
+2026-06-25T10:01:59.4959419Z  
+2026-06-25T10:01:59.4959783Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:694:
+2026-06-25T10:01:59.4960223Z          &None,
+2026-06-25T10:01:59.4960414Z          &None,
+2026-06-25T10:01:59.4960600Z      );
+2026-06-25T10:01:59.4960803Z -client.update_funding_target(&0i128);
+2026-06-25T10:01:59.4961083Z +    client.update_funding_target(&0i128);
+2026-06-25T10:01:59.4961531Z  }
+2026-06-25T10:01:59.4961705Z  
+2026-06-25T10:01:59.4961975Z  // --- FundingTargetUpdated event and rejection coverage ---
+2026-06-25T10:01:59.4962492Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:733:
+2026-06-25T10:01:59.4962952Z          &None,
+2026-06-25T10:01:59.4963141Z          &None,
+2026-06-25T10:01:59.4963327Z      );
+2026-06-25T10:01:59.4963530Z -client.update_funding_target(&9_000i128);
+2026-06-25T10:01:59.4963818Z +    client.update_funding_target(&9_000i128);
+2026-06-25T10:01:59.4964083Z  
+2026-06-25T10:01:59.4964261Z      assert_eq!(
+2026-06-25T10:01:59.4964472Z          env.events().all(),
+2026-06-25T10:01:59.4964881Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:779:
+2026-06-25T10:01:59.4965304Z          &None,
+2026-06-25T10:01:59.4965485Z          &None,
+2026-06-25T10:01:59.4965667Z      );
+2026-06-25T10:01:59.4966183Z -client.fund(&investor, &5_000i128); // status → 1 (funded)
+2026-06-25T10:01:59.4966626Z +    client.fund(&investor, &5_000i128); // status → 1 (funded)
+2026-06-25T10:01:59.4967008Z      client.settle(); // status → 2 (settled)
+2026-06-25T10:01:59.4967312Z      client.update_funding_target(&6_000i128);
+2026-06-25T10:01:59.4967591Z  }
+2026-06-25T10:01:59.4967950Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:828:
+2026-06-25T10:01:59.4968382Z          &None,
+2026-06-25T10:01:59.4968569Z          &None,
+2026-06-25T10:01:59.4968754Z      );
+2026-06-25T10:01:59.4969040Z -client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
+2026-06-25T10:01:59.4969512Z +    client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
+2026-06-25T10:01:59.4970008Z  
+2026-06-25T10:01:59.4970310Z      // new_target == funded_amount: boundary — must not panic.
+2026-06-25T10:01:59.4970689Z      let updated = client.update_funding_target(&4_000i128);
+2026-06-25T10:01:59.4971186Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:867:
+2026-06-25T10:01:59.4971847Z          &None,
+2026-06-25T10:01:59.4972038Z          &None,
+2026-06-25T10:01:59.4972223Z      );
+2026-06-25T10:01:59.4972434Z -client.update_funding_target(&-1i128);
+2026-06-25T10:01:59.4972921Z +    client.update_funding_target(&-1i128);
+2026-06-25T10:01:59.4973182Z  }
+2026-06-25T10:01:59.4973508Z  // --- update_maturity: open-only, ledger time semantics, MaturityUpdatedEvent ---
+2026-06-25T10:01:59.4973890Z  
+2026-06-25T10:01:59.4974247Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:907:
+2026-06-25T10:01:59.4974670Z          &None,
+2026-06-25T10:01:59.4974861Z          &None,
+2026-06-25T10:01:59.4975065Z      );
+2026-06-25T10:01:59.4975264Z -client.update_maturity(&2000u64);
+2026-06-25T10:01:59.4975540Z +    client.update_maturity(&2000u64);
+2026-06-25T10:01:59.4975790Z  
+2026-06-25T10:01:59.4975965Z      assert_eq!(
+2026-06-25T10:01:59.4976174Z          env.events().all(),
+2026-06-25T10:01:59.4976592Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:953:
+2026-06-25T10:01:59.4977027Z          &None,
+2026-06-25T10:01:59.4977211Z          &None,
+2026-06-25T10:01:59.4977409Z      );
+2026-06-25T10:01:59.4977730Z -client.fund(&investor, &5_000i128); // status → 1 (funded)
+2026-06-25T10:01:59.4978162Z +    client.fund(&investor, &5_000i128); // status → 1 (funded)
+2026-06-25T10:01:59.4978482Z      client.update_maturity(&2000u64);
+2026-06-25T10:01:59.4978726Z  }
+2026-06-25T10:01:59.4978895Z  
+2026-06-25T10:01:59.4979251Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:989:
+2026-06-25T10:01:59.4979692Z          &None,
+2026-06-25T10:01:59.4979894Z          &None,
+2026-06-25T10:01:59.4980211Z      );
+2026-06-25T10:01:59.4980482Z -client.fund(&investor, &5_000i128); // status → 1
+2026-06-25T10:01:59.4980861Z +    client.fund(&investor, &5_000i128); // status → 1
+2026-06-25T10:01:59.4981204Z      client.settle(); // status → 2
+2026-06-25T10:01:59.4981689Z      client.update_maturity(&2000u64);
+2026-06-25T10:01:59.4981946Z  }
+2026-06-25T10:01:59.4982321Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:1036:
+2026-06-25T10:01:59.4982788Z          &None,
+2026-06-25T10:01:59.4982986Z          &None,
+2026-06-25T10:01:59.4983176Z      );
+2026-06-25T10:01:59.4983395Z -let updated = client.update_maturity(&0u64);
+2026-06-25T10:01:59.4983719Z +    let updated = client.update_maturity(&0u64);
+2026-06-25T10:01:59.4984028Z      assert_eq!(updated.maturity, 0u64);
+2026-06-25T10:01:59.4984310Z      assert_eq!(updated.status, 0);
+2026-06-25T10:01:59.4984563Z  }
+2026-06-25T10:01:59.4984943Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:1073:
+2026-06-25T10:01:59.4985388Z          &None,
+2026-06-25T10:01:59.4985581Z          &None,
+2026-06-25T10:01:59.4985769Z      );
+2026-06-25T10:01:59.4985971Z -client.fund(&investor, &5_000i128);
+2026-06-25T10:01:59.4986246Z +    client.fund(&investor, &5_000i128);
+2026-06-25T10:01:59.4986499Z  
+2026-06-25T10:01:59.4986794Z      // Advance ledger to exactly maturity — must succeed
+2026-06-25T10:01:59.4987147Z      env.ledger().with_mut(|l| l.timestamp = 5000);
+2026-06-25T10:01:59.4987628Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:1113:
+2026-06-25T10:01:59.4988060Z          &None,
+2026-06-25T10:01:59.4988250Z          &None,
+2026-06-25T10:01:59.4988439Z      );
+2026-06-25T10:01:59.4988638Z -client.fund(&investor, &5_000i128);
+2026-06-25T10:01:59.4988903Z +    client.fund(&investor, &5_000i128);
+2026-06-25T10:01:59.4989151Z  
+2026-06-25T10:01:59.4989913Z      // One second before maturity — must reject
+2026-06-25T10:01:59.4990242Z      env.ledger().with_mut(|l| l.timestamp = 4999);
+2026-06-25T10:01:59.4990708Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:1150:
+2026-06-25T10:01:59.4991134Z          &None,
+2026-06-25T10:01:59.4991536Z          &None,
+2026-06-25T10:01:59.4991729Z      );
+2026-06-25T10:01:59.4991927Z -client.update_maturity(&2000u64);
+2026-06-25T10:01:59.4992203Z +    client.update_maturity(&2000u64);
+2026-06-25T10:01:59.4992713Z      let updated = client.update_maturity(&3000u64);
+2026-06-25T10:01:59.4993030Z      assert_eq!(updated.maturity, 3000u64);
+2026-06-25T10:01:59.4993344Z      assert_eq!(client.get_escrow().maturity, 3000u64);
+2026-06-25T10:01:59.4993821Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:1327:
+2026-06-25T10:01:59.4994258Z          &None,
+2026-06-25T10:01:59.4994447Z          &None,
+2026-06-25T10:01:59.4994634Z      );
+2026-06-25T10:01:59.4994840Z -client.fund(&investor, &TARGET);
+2026-06-25T10:01:59.4995107Z +    client.fund(&investor, &TARGET);
+2026-06-25T10:01:59.4995364Z      client.settle();
+2026-06-25T10:01:59.4995604Z      token.stellar.mint(&escrow_id, &100i128);
+2026-06-25T10:01:59.4995892Z      env.mock_auths(&[]);
+2026-06-25T10:01:59.4996293Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:1524:
+2026-06-25T10:01:59.4996724Z          &None,
+2026-06-25T10:01:59.4996912Z          &None,
+2026-06-25T10:01:59.4997113Z      );
+2026-06-25T10:01:59.4997318Z -token.stellar.mint(&investor, &TARGET);
+2026-06-25T10:01:59.4997618Z +    token.stellar.mint(&investor, &TARGET);
+2026-06-25T10:01:59.4997908Z      token.stellar.approve(
+2026-06-25T10:01:59.4998142Z          &investor,
+2026-06-25T10:01:59.4998346Z          &escrow_id,
+2026-06-25T10:01:59.5004011Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:32:
+2026-06-25T10:01:59.5004830Z          &None,
+2026-06-25T10:01:59.5005125Z          &None,
+2026-06-25T10:01:59.5005412Z      );
+2026-06-25T10:01:59.5005705Z -// Verify initial state
+2026-06-25T10:01:59.5006073Z +    // Verify initial state
+2026-06-25T10:01:59.5006503Z      assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5007099Z      assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
+2026-06-25T10:01:59.5007619Z  
+2026-06-25T10:01:59.5008276Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:85:
+2026-06-25T10:01:59.5009074Z          &None,
+2026-06-25T10:01:59.5009385Z          &None,
+2026-06-25T10:01:59.5009675Z      );
+2026-06-25T10:01:59.5010291Z -// Add two investors — reaches the investor cap but NOT the funding target.
+2026-06-25T10:01:59.5011180Z +    // Add two investors — reaches the investor cap but NOT the funding target.
+2026-06-25T10:01:59.5017072Z      let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5017587Z      let inv2 = Address::generate(&env);
+2026-06-25T10:01:59.5018050Z      client.fund(&inv1, &50_000_000_000i128);
+2026-06-25T10:01:59.5018882Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:125:
+2026-06-25T10:01:59.5019673Z          &None,
+2026-06-25T10:01:59.5019966Z          &None,
+2026-06-25T10:01:59.5020248Z      );
+2026-06-25T10:01:59.5020570Z -let investor = Address::generate(&env);
+2026-06-25T10:01:59.5021031Z +    let investor = Address::generate(&env);
+2026-06-25T10:01:59.5021634Z  
+2026-06-25T10:01:59.5021931Z      // First fund should succeed
+2026-06-25T10:01:59.5022360Z      client.fund(&investor, &30_000_000_000i128);
+2026-06-25T10:01:59.5023172Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:168:
+2026-06-25T10:01:59.5023943Z          &None,
+2026-06-25T10:01:59.5024232Z          &None,
+2026-06-25T10:01:59.5024511Z      );
+2026-06-25T10:01:59.5024893Z -assert_eq!(client.get_max_unique_investors_cap(), None);
+2026-06-25T10:01:59.5025725Z +    assert_eq!(client.get_max_unique_investors_cap(), None);
+2026-06-25T10:01:59.5026224Z  
+2026-06-25T10:01:59.5026609Z      // Should be able to add many investors when no cap is set
+2026-06-25T10:01:59.5027107Z      for i in 0..5 {
+2026-06-25T10:01:59.5027804Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:208:
+2026-06-25T10:01:59.5028581Z          &None,
+2026-06-25T10:01:59.5028865Z          &None,
+2026-06-25T10:01:59.5029153Z      );
+2026-06-25T10:01:59.5029545Z -let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5029831Z +    let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5030113Z      client.fund(&inv1, &30_000_000_000i128);
+2026-06-25T10:01:59.5030463Z      assert_eq!(client.get_contribution(&inv1), 30_000_000_000i128);
+2026-06-25T10:01:59.5030793Z  
+2026-06-25T10:01:59.5031204Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:273:
+2026-06-25T10:01:59.5032197Z          &None,
+2026-06-25T10:01:59.5032520Z          &None,
+2026-06-25T10:01:59.5032809Z      );
+2026-06-25T10:01:59.5033191Z -client.fund(&Address::generate(&env), &(floor - 1));
+2026-06-25T10:01:59.5033781Z +    client.fund(&Address::generate(&env), &(floor - 1));
+2026-06-25T10:01:59.5034262Z  }
+2026-06-25T10:01:59.5034524Z  
+2026-06-25T10:01:59.5034787Z  #[test]
+2026-06-25T10:01:59.5035445Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:304:
+2026-06-25T10:01:59.5036211Z          &None,
+2026-06-25T10:01:59.5036511Z          &None,
+2026-06-25T10:01:59.5036768Z      );
+2026-06-25T10:01:59.5036964Z -client.fund(&inv, &floor);
+2026-06-25T10:01:59.5037204Z +    client.fund(&inv, &floor);
+2026-06-25T10:01:59.5037486Z      assert_eq!(client.get_contribution(&inv), floor);
+2026-06-25T10:01:59.5037815Z      assert_eq!(client.get_unique_funder_count(), 1);
+2026-06-25T10:01:59.5038095Z  }
+2026-06-25T10:01:59.5038496Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:338:
+2026-06-25T10:01:59.5038966Z          &None,
+2026-06-25T10:01:59.5039154Z          &None,
+2026-06-25T10:01:59.5039346Z      );
+2026-06-25T10:01:59.5039538Z -client.fund(&investor, &floor);
+2026-06-25T10:01:59.5039795Z +    client.fund(&investor, &floor);
+2026-06-25T10:01:59.5040070Z      client.fund(&investor, &(floor - 1));
+2026-06-25T10:01:59.5040327Z  }
+2026-06-25T10:01:59.5040497Z  
+2026-06-25T10:01:59.5040888Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:370:
+2026-06-25T10:01:59.5041567Z          &None,
+2026-06-25T10:01:59.5041756Z          &None,
+2026-06-25T10:01:59.5041937Z      );
+2026-06-25T10:01:59.5042129Z -client.fund(&inv, &30_000_000_000i128);
+2026-06-25T10:01:59.5042406Z +    client.fund(&inv, &30_000_000_000i128);
+2026-06-25T10:01:59.5042676Z      client.fund(&inv, &20_000_000_000i128);
+2026-06-25T10:01:59.5042970Z      assert_eq!(client.get_contribution(&inv), cap);
+2026-06-25T10:01:59.5043302Z      assert_eq!(client.get_unique_funder_count(), 1);
+2026-06-25T10:01:59.5043790Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:405:
+2026-06-25T10:01:59.5044242Z          &None,
+2026-06-25T10:01:59.5044426Z          &None,
+2026-06-25T10:01:59.5044605Z      );
+2026-06-25T10:01:59.5044794Z -client.fund(&inv, &30_000_000_000i128);
+2026-06-25T10:01:59.5045054Z +    client.fund(&inv, &30_000_000_000i128);
+2026-06-25T10:01:59.5045315Z      client.fund(&inv, &20_000_000_001i128);
+2026-06-25T10:01:59.5045562Z  }
+2026-06-25T10:01:59.5045734Z  
+2026-06-25T10:01:59.5046129Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:435:
+2026-06-25T10:01:59.5046597Z          &None,
+2026-06-25T10:01:59.5046787Z          &None,
+2026-06-25T10:01:59.5046973Z      );
+2026-06-25T10:01:59.5047228Z -client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5047621Z      client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5048175Z      client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5048555Z +    client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5048902Z      assert_eq!(client.get_unique_funder_count(), 3);
+2026-06-25T10:01:59.5049200Z  }
+2026-06-25T10:01:59.5049374Z  
+2026-06-25T10:01:59.5049788Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:468:
+2026-06-25T10:01:59.5050266Z          &None,
+2026-06-25T10:01:59.5050581Z          &None,
+2026-06-25T10:01:59.5050773Z      );
+2026-06-25T10:01:59.5051038Z -client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5051737Z      client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5052111Z      client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5052470Z +    client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5052844Z      client.fund(&Address::generate(&env), &1_000_000_000i128);
+2026-06-25T10:01:59.5053159Z  }
+2026-06-25T10:01:59.5053334Z  
+2026-06-25T10:01:59.5053727Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:501:
+2026-06-25T10:01:59.5054196Z          &None,
+2026-06-25T10:01:59.5054392Z          &None,
+2026-06-25T10:01:59.5054580Z      );
+2026-06-25T10:01:59.5054779Z -client.fund(&inv, &10_000_000_000i128);
+2026-06-25T10:01:59.5055089Z      client.fund(&inv, &10_000_000_000i128);
+2026-06-25T10:01:59.5055371Z +    client.fund(&inv, &10_000_000_000i128);
+2026-06-25T10:01:59.5055703Z      assert_eq!(client.get_contribution(&inv), 20_000_000_000i128);
+2026-06-25T10:01:59.5056071Z      assert_eq!(client.get_unique_funder_count(), 1);
+2026-06-25T10:01:59.5056364Z  }
+2026-06-25T10:01:59.5056753Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:628:
+2026-06-25T10:01:59.5057214Z          &None,
+2026-06-25T10:01:59.5057399Z          &None,
+2026-06-25T10:01:59.5057591Z      );
+2026-06-25T10:01:59.5057818Z -assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5058146Z +    assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5058423Z  
+2026-06-25T10:01:59.5058638Z      // First investor uses fund_with_commitment
+2026-06-25T10:01:59.5058946Z      let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5059419Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:673:
+2026-06-25T10:01:59.5059876Z          &None,
+2026-06-25T10:01:59.5060072Z          &None,
+2026-06-25T10:01:59.5060256Z      );
+2026-06-25T10:01:59.5060457Z -let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5060746Z +    let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5061020Z      let inv2 = Address::generate(&env);
+2026-06-25T10:01:59.5061466Z      client.fund(&inv1, &20_000_000_000i128);
+2026-06-25T10:01:59.5061780Z      client.fund(&inv2, &20_000_000_000i128);
+2026-06-25T10:01:59.5062263Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:711:
+2026-06-25T10:01:59.5062725Z          &None,
+2026-06-25T10:01:59.5062915Z          &None,
+2026-06-25T10:01:59.5063103Z      );
+2026-06-25T10:01:59.5063359Z -client.fund(&Address::generate(&env), &20_000_000_000i128);
+2026-06-25T10:01:59.5063737Z      client.fund(&Address::generate(&env), &20_000_000_000i128);
+2026-06-25T10:01:59.5064109Z +    client.fund(&Address::generate(&env), &20_000_000_000i128);
+2026-06-25T10:01:59.5064446Z      client.lower_max_unique_investors(&2u32);
+2026-06-25T10:01:59.5064724Z  
+2026-06-25T10:01:59.5064963Z      client.fund(&Address::generate(&env), &1_000_000_000i128);
+2026-06-25T10:01:59.5065486Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:744:
+2026-06-25T10:01:59.5065940Z          &None,
+2026-06-25T10:01:59.5066126Z          &None,
+2026-06-25T10:01:59.5066310Z      );
+2026-06-25T10:01:59.5066509Z -let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5066919Z +    let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5067197Z      let inv2 = Address::generate(&env);
+2026-06-25T10:01:59.5067465Z      client.fund(&inv1, &30_000_000_000i128);
+2026-06-25T10:01:59.5067735Z      client.fund(&inv2, &30_000_000_000i128);
+2026-06-25T10:01:59.5068191Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:782:
+2026-06-25T10:01:59.5068646Z          &None,
+2026-06-25T10:01:59.5068829Z          &None,
+2026-06-25T10:01:59.5069130Z      );
+2026-06-25T10:01:59.5069340Z -client.lower_max_unique_investors(&4u32);
+2026-06-25T10:01:59.5069638Z +    client.lower_max_unique_investors(&4u32);
+2026-06-25T10:01:59.5069909Z  }
+2026-06-25T10:01:59.5070081Z  
+2026-06-25T10:01:59.5070256Z  #[test]
+2026-06-25T10:01:59.5070638Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:812:
+2026-06-25T10:01:59.5071085Z          &None,
+2026-06-25T10:01:59.5071431Z          &None,
+2026-06-25T10:01:59.5071711Z      );
+2026-06-25T10:01:59.5071964Z -client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5072406Z      client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5072781Z      client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5073142Z +    client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5073469Z      client.lower_max_unique_investors(&2u32);
+2026-06-25T10:01:59.5073745Z  }
+2026-06-25T10:01:59.5073916Z  
+2026-06-25T10:01:59.5074305Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:845:
+2026-06-25T10:01:59.5074788Z          &None,
+2026-06-25T10:01:59.5074982Z          &None,
+2026-06-25T10:01:59.5075173Z      );
+2026-06-25T10:01:59.5075426Z -client.fund(&Address::generate(&env), &100_000_000_000i128);
+2026-06-25T10:01:59.5075815Z +    client.fund(&Address::generate(&env), &100_000_000_000i128);
+2026-06-25T10:01:59.5076192Z      assert_eq!(client.get_escrow().status, 1);
+2026-06-25T10:01:59.5076506Z      client.lower_max_unique_investors(&2u32);
+2026-06-25T10:01:59.5076772Z  }
+2026-06-25T10:01:59.5077179Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:877:
+2026-06-25T10:01:59.5077638Z          &None,
+2026-06-25T10:01:59.5077828Z          &None,
+2026-06-25T10:01:59.5078012Z      );
+2026-06-25T10:01:59.5078221Z -client.lower_max_unique_investors(&10u32);
+2026-06-25T10:01:59.5078527Z +    client.lower_max_unique_investors(&10u32);
+2026-06-25T10:01:59.5078792Z  }
+2026-06-25T10:01:59.5078965Z  
+2026-06-25T10:01:59.5079141Z  #[test]
+2026-06-25T10:01:59.5079535Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:906:
+2026-06-25T10:01:59.5080000Z          &None,
+2026-06-25T10:01:59.5080186Z          &None,
+2026-06-25T10:01:59.5080372Z      );
+2026-06-25T10:01:59.5080683Z -client.lower_max_unique_investors(&3u32);
+2026-06-25T10:01:59.5081534Z +    client.lower_max_unique_investors(&3u32);
+2026-06-25T10:01:59.5096485Z      assert!(
+2026-06-25T10:01:59.5096905Z          env.auths().iter().any(|(addr, _)| *addr == admin),
+2026-06-25T10:01:59.5097431Z          "admin auth was not recorded for lower_max_unique_investors"
+2026-06-25T10:01:59.5098014Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:940:
+2026-06-25T10:01:59.5098513Z          &None,
+2026-06-25T10:01:59.5098722Z          &None,
+2026-06-25T10:01:59.5098939Z      );
+2026-06-25T10:01:59.5099139Z -env.mock_auths(&[]);
+2026-06-25T10:01:59.5099370Z +    env.mock_auths(&[]);
+2026-06-25T10:01:59.5099633Z      client.lower_max_unique_investors(&3u32);
+2026-06-25T10:01:59.5099910Z  }
+2026-06-25T10:01:59.5100079Z  
+2026-06-25T10:01:59.5100494Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/cap_validation.rs:973:
+2026-06-25T10:01:59.5100984Z          &None,
+2026-06-25T10:01:59.5101174Z          &None,
+2026-06-25T10:01:59.5101744Z      );
+2026-06-25T10:01:59.5102026Z -client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5102417Z +    client.fund(&Address::generate(&env), &10_000_000_000i128);
+2026-06-25T10:01:59.5102762Z      client.lower_max_unique_investors(&3u32);
+2026-06-25T10:01:59.5103028Z  
+2026-06-25T10:01:59.5103200Z      assert_eq!(
+2026-06-25T10:01:59.5149805Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/external_calls.rs:229:
+2026-06-25T10:01:59.5150767Z          &None,
+2026-06-25T10:01:59.5150968Z          &None,
+2026-06-25T10:01:59.5151156Z      );
+2026-06-25T10:01:59.5151596Z -// Mint tokens into the contract to simulate on-chain custody
+2026-06-25T10:01:59.5152004Z +    // Mint tokens into the contract to simulate on-chain custody
+2026-06-25T10:01:59.5152395Z      token.stellar.mint(&client.address, &fund_amount);
+2026-06-25T10:01:59.5152713Z      client.fund(investor, &fund_amount);
+2026-06-25T10:01:59.5152998Z      client.cancel_funding();
+2026-06-25T10:01:59.5153459Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/external_calls.rs:309:
+2026-06-25T10:01:59.5153943Z          &None,
+2026-06-25T10:01:59.5154135Z          &None,
+2026-06-25T10:01:59.5154332Z      );
+2026-06-25T10:01:59.5154569Z -// Mint 1001 into contract: 500 for A, 500 for B, 1 dust
+2026-06-25T10:01:59.5154912Z +    // Mint 1001 into contract: 500 for A, 500 for B, 1 dust
+2026-06-25T10:01:59.5155253Z      token.stellar.mint(&client.address, &1_001i128);
+2026-06-25T10:01:59.5155569Z      client.fund(&investor_a, &500i128);
+2026-06-25T10:01:59.5155843Z      client.fund(&investor_b, &500i128);
+2026-06-25T10:01:59.5156303Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/external_calls.rs:356:
+2026-06-25T10:01:59.5156761Z          &None,
+2026-06-25T10:01:59.5156941Z          &None,
+2026-06-25T10:01:59.5157119Z      );
+2026-06-25T10:01:59.5157351Z -token.stellar.mint(&client.address, &1_001i128);
+2026-06-25T10:01:59.5157686Z +    token.stellar.mint(&client.address, &1_001i128);
+2026-06-25T10:01:59.5158023Z      client.fund(&investor_a, &500i128);
+2026-06-25T10:01:59.5158277Z      client.fund(&investor_b, &500i128);
+2026-06-25T10:01:59.5158533Z      client.cancel_funding();
+2026-06-25T10:01:59.5158968Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/external_calls.rs:394:
+2026-06-25T10:01:59.5159420Z          &None,
+2026-06-25T10:01:59.5159602Z          &None,
+2026-06-25T10:01:59.5159787Z      );
+2026-06-25T10:01:59.5159971Z -client.cancel_funding();
+2026-06-25T10:01:59.5160204Z +    client.cancel_funding();
+2026-06-25T10:01:59.5160433Z  
+2026-06-25T10:01:59.5160623Z      // Stray airdrop of 50 tokens
+2026-06-25T10:01:59.5160906Z      token.stellar.mint(&client.address, &50i128);
+2026-06-25T10:01:59.5161609Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/external_calls.rs:434:
+2026-06-25T10:01:59.5162094Z          &None,
+2026-06-25T10:01:59.5162294Z          &None,
+2026-06-25T10:01:59.5162481Z      );
+2026-06-25T10:01:59.5162709Z -token.stellar.mint(&client.address, &900i128);
+2026-06-25T10:01:59.5163039Z +    token.stellar.mint(&client.address, &900i128);
+2026-06-25T10:01:59.5163340Z      client.fund(&inv_a, &300i128);
+2026-06-25T10:01:59.5163593Z      client.fund(&inv_b, &300i128);
+2026-06-25T10:01:59.5163831Z      client.fund(&inv_c, &300i128);
+2026-06-25T10:01:59.5512304Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:46:
+2026-06-25T10:01:59.5513113Z          &None,
+2026-06-25T10:01:59.5513416Z          &None,
+2026-06-25T10:01:59.5513699Z      );
+2026-06-25T10:01:59.5514030Z -let funded = client.fund(&investor, &TARGET);
+2026-06-25T10:01:59.5514613Z +    let funded = client.fund(&investor, &TARGET);
+2026-06-25T10:01:59.5515109Z      assert_eq!(funded.funded_amount, TARGET);
+2026-06-25T10:01:59.5515553Z      assert_eq!(funded.status, 1);
+2026-06-25T10:01:59.5516380Z      let settled = client.settle();
+2026-06-25T10:01:59.5517098Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:76:
+2026-06-25T10:01:59.5517814Z          &None,
+2026-06-25T10:01:59.5518108Z          &None,
+2026-06-25T10:01:59.5518398Z      );
+2026-06-25T10:01:59.5518645Z -let partial = client.fund(&investor, &(TARGET / 2));
+2026-06-25T10:01:59.5519018Z +    let partial = client.fund(&investor, &(TARGET / 2));
+2026-06-25T10:01:59.5519351Z      assert_eq!(partial.status, 0);
+2026-06-25T10:01:59.5519815Z      assert_eq!(partial.funded_amount, TARGET / 2);
+2026-06-25T10:01:59.5520151Z      let full = client.fund(&investor, &(TARGET / 2));
+2026-06-25T10:01:59.5520634Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:141:
+2026-06-25T10:01:59.5521091Z          &None,
+2026-06-25T10:01:59.5521430Z          &None,
+2026-06-25T10:01:59.5521623Z      );
+2026-06-25T10:01:59.5521836Z -client.fund(&investor, &(30_000_000_000i128));
+2026-06-25T10:01:59.5522163Z +    client.fund(&investor, &(30_000_000_000i128));
+2026-06-25T10:01:59.5522503Z      let contribution = client.get_contribution(&investor);
+2026-06-25T10:01:59.5522844Z      assert_eq!(contribution, 30_000_000_000i128);
+2026-06-25T10:01:59.5523121Z  }
+2026-06-25T10:01:59.5523490Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:180:
+2026-06-25T10:01:59.5523929Z          &None,
+2026-06-25T10:01:59.5524118Z          &None,
+2026-06-25T10:01:59.5524302Z      );
+2026-06-25T10:01:59.5524522Z -client.fund(&investor, &(20_000_000_000i128));
+2026-06-25T10:01:59.5524827Z +    client.fund(&investor, &(20_000_000_000i128));
+2026-06-25T10:01:59.5525126Z      client.fund(&investor, &(30_000_000_000i128));
+2026-06-25T10:01:59.5525506Z      assert_eq!(client.get_contribution(&investor), 50_000_000_000i128);
+2026-06-25T10:01:59.5525855Z  }
+2026-06-25T10:01:59.5526232Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:210:
+2026-06-25T10:01:59.5526676Z          &None,
+2026-06-25T10:01:59.5526862Z          &None,
+2026-06-25T10:01:59.5527049Z      );
+2026-06-25T10:01:59.5527303Z -client.fund(&investor_a, &(i128::MAX - 1));
+2026-06-25T10:01:59.5527611Z +    client.fund(&investor_a, &(i128::MAX - 1));
+2026-06-25T10:01:59.5527901Z      client.fund(&investor_b, &2i128);
+2026-06-25T10:01:59.5528152Z  }
+2026-06-25T10:01:59.5528323Z  
+2026-06-25T10:01:59.5528687Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:237:
+2026-06-25T10:01:59.5529132Z          &None,
+2026-06-25T10:01:59.5529325Z          &None,
+2026-06-25T10:01:59.5529509Z      );
+2026-06-25T10:01:59.5529716Z -client.fund(&investor, &(i128::MAX - 1));
+2026-06-25T10:01:59.5530011Z +    client.fund(&investor, &(i128::MAX - 1));
+2026-06-25T10:01:59.5530300Z      let before = client.get_escrow();
+2026-06-25T10:01:59.5530547Z  
+2026-06-25T10:01:59.5530850Z      let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+2026-06-25T10:01:59.5531562Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:276:
+2026-06-25T10:01:59.5532016Z          &None,
+2026-06-25T10:01:59.5532206Z          &None,
+2026-06-25T10:01:59.5532391Z      );
+2026-06-25T10:01:59.5532603Z -client.fund(&investor_a, &(i128::MAX - 1));
+2026-06-25T10:01:59.5532910Z +    client.fund(&investor_a, &(i128::MAX - 1));
+2026-06-25T10:01:59.5533250Z      client.fund_with_commitment(&investor_b, &2i128, &0u64);
+2026-06-25T10:01:59.5533559Z  }
+2026-06-25T10:01:59.5533738Z  
+2026-06-25T10:01:59.5534095Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:304:
+2026-06-25T10:01:59.5534522Z          &None,
+2026-06-25T10:01:59.5534707Z          &None,
+2026-06-25T10:01:59.5534890Z      );
+2026-06-25T10:01:59.5535092Z -client.fund(&investor_a, &(i128::MAX - 1));
+2026-06-25T10:01:59.5535383Z +    client.fund(&investor_a, &(i128::MAX - 1));
+2026-06-25T10:01:59.5535665Z      let before = client.get_escrow();
+2026-06-25T10:01:59.5536113Z  
+2026-06-25T10:01:59.5536403Z      let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+2026-06-25T10:01:59.5536940Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:346:
+2026-06-25T10:01:59.5537369Z          &None,
+2026-06-25T10:01:59.5537558Z          &None,
+2026-06-25T10:01:59.5537742Z      );
+2026-06-25T10:01:59.5537939Z -client.fund(&investor, &500i128);
+2026-06-25T10:01:59.5538209Z +    client.fund(&investor, &500i128);
+2026-06-25T10:01:59.5538573Z  
+2026-06-25T10:01:59.5538780Z      env.as_contract(&contract_id, || {
+2026-06-25T10:01:59.5539052Z          assert_eq!(
+2026-06-25T10:01:59.5539464Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:400:
+2026-06-25T10:01:59.5539913Z          &None,
+2026-06-25T10:01:59.5540112Z          &None,
+2026-06-25T10:01:59.5540307Z      );
+2026-06-25T10:01:59.5540514Z -env.as_contract(&contract_id, || {
+2026-06-25T10:01:59.5540799Z +    env.as_contract(&contract_id, || {
+2026-06-25T10:01:59.5541190Z          // Force the contribution near i128::MAX while keeping funded_amount small.
+2026-06-25T10:01:59.5541831Z          // `fund` must still trap on contribution overflow even if funded_amount would not.
+2026-06-25T10:01:59.5542255Z          env.storage().persistent().set(
+2026-06-25T10:01:59.5542720Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:446:
+2026-06-25T10:01:59.5543174Z          &None,
+2026-06-25T10:01:59.5543379Z          &None,
+2026-06-25T10:01:59.5543570Z      );
+2026-06-25T10:01:59.5543771Z -env.as_contract(&contract_id, || {
+2026-06-25T10:01:59.5544045Z +    env.as_contract(&contract_id, || {
+2026-06-25T10:01:59.5544316Z          env.storage().persistent().set(
+2026-06-25T10:01:59.5544638Z              &DataKey::InvestorContribution(investor.clone()),
+2026-06-25T10:01:59.5544957Z              &(i128::MAX - 1),
+2026-06-25T10:01:59.5545374Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:494:
+2026-06-25T10:01:59.5545809Z          &None,
+2026-06-25T10:01:59.5546001Z          &None,
+2026-06-25T10:01:59.5546186Z      );
+2026-06-25T10:01:59.5546391Z -client.fund(&inv_a, &(20_000_000_000i128));
+2026-06-25T10:01:59.5546685Z +    client.fund(&inv_a, &(20_000_000_000i128));
+2026-06-25T10:01:59.5546982Z      client.fund(&inv_b, &(50_000_000_000i128));
+2026-06-25T10:01:59.5547260Z      client.fund(&inv_c, &(30_000_000_000i128));
+2026-06-25T10:01:59.5547612Z      assert_eq!(client.get_contribution(&inv_a), 20_000_000_000i128);
+2026-06-25T10:01:59.5548128Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:531:
+2026-06-25T10:01:59.5548566Z          &None,
+2026-06-25T10:01:59.5548754Z          &None,
+2026-06-25T10:01:59.5548940Z      );
+2026-06-25T10:01:59.5549140Z -client.fund(&inv_a, &(20_000_000_000i128));
+2026-06-25T10:01:59.5549418Z +    client.fund(&inv_a, &(20_000_000_000i128));
+2026-06-25T10:01:59.5549702Z      client.fund(&inv_b, &(50_000_000_000i128));
+2026-06-25T10:01:59.5549982Z      client.fund(&inv_c, &(30_000_000_000i128));
+2026-06-25T10:01:59.5550271Z      let sum = client.get_contribution(&inv_a)
+2026-06-25T10:01:59.5550719Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:563:
+2026-06-25T10:01:59.5551153Z          &None,
+2026-06-25T10:01:59.5551488Z          &None,
+2026-06-25T10:01:59.5551780Z      );
+2026-06-25T10:01:59.5552008Z -client.fund(&investor, &(10_000_000_000i128));
+2026-06-25T10:01:59.5552328Z +    client.fund(&investor, &(10_000_000_000i128));
+2026-06-25T10:01:59.5552606Z  }
+2026-06-25T10:01:59.5552786Z  
+2026-06-25T10:01:59.5552978Z  #[test]
+2026-06-25T10:01:59.5553343Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:589:
+2026-06-25T10:01:59.5553770Z          &None,
+2026-06-25T10:01:59.5553954Z          &None,
+2026-06-25T10:01:59.5554138Z      );
+2026-06-25T10:01:59.5554499Z -client.fund(&investor, &TARGET);
+2026-06-25T10:01:59.5554772Z +    client.fund(&investor, &TARGET);
+2026-06-25T10:01:59.5555021Z  }
+2026-06-25T10:01:59.5555198Z  
+2026-06-25T10:01:59.5555373Z  #[test]
+2026-06-25T10:01:59.5555731Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:615:
+2026-06-25T10:01:59.5556164Z          &None,
+2026-06-25T10:01:59.5556351Z          &None,
+2026-06-25T10:01:59.5556540Z      );
+2026-06-25T10:01:59.5556749Z -client.fund(&investor, &(150_000_000_000i128));
+2026-06-25T10:01:59.5557180Z +    client.fund(&investor, &(150_000_000_000i128));
+2026-06-25T10:01:59.5557494Z      assert_eq!(client.get_escrow().status, 1);
+2026-06-25T10:01:59.5557771Z  }
+2026-06-25T10:01:59.5557945Z  
+2026-06-25T10:01:59.5558298Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:642:
+2026-06-25T10:01:59.5558727Z          &None,
+2026-06-25T10:01:59.5558915Z          &None,
+2026-06-25T10:01:59.5559102Z      );
+2026-06-25T10:01:59.5559309Z -client.fund(&investor, &(TARGET / 2));
+2026-06-25T10:01:59.5559590Z      client.fund(&investor, &(TARGET / 2));
+2026-06-25T10:01:59.5559874Z +    client.fund(&investor, &(TARGET / 2));
+2026-06-25T10:01:59.5560155Z      assert_eq!(client.get_escrow().status, 1);
+2026-06-25T10:01:59.5560422Z  }
+2026-06-25T10:01:59.5560598Z  
+2026-06-25T10:01:59.5560953Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:674:
+2026-06-25T10:01:59.5561543Z          &None,
+2026-06-25T10:01:59.5561741Z          &None,
+2026-06-25T10:01:59.5561927Z      );
+2026-06-25T10:01:59.5562170Z -assert_eq!(client.get_funding_close_snapshot(), None);
+2026-06-25T10:01:59.5562545Z +    assert_eq!(client.get_funding_close_snapshot(), None);
+2026-06-25T10:01:59.5562890Z      client.fund(&inv, &(TARGET + 50_000_000_000i128));
+2026-06-25T10:01:59.5563263Z      let snap = client.get_funding_close_snapshot().expect("snapshot");
+2026-06-25T10:01:59.5563683Z      assert_eq!(snap.total_principal, TARGET + 50_000_000_000i128);
+2026-06-25T10:01:59.5564183Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:711:
+2026-06-25T10:01:59.5564616Z          &None,
+2026-06-25T10:01:59.5564803Z          &None,
+2026-06-25T10:01:59.5564986Z      );
+2026-06-25T10:01:59.5565182Z -client.fund(&a, &(TARGET / 2));
+2026-06-25T10:01:59.5565442Z +    client.fund(&a, &(TARGET / 2));
+2026-06-25T10:01:59.5565748Z      assert_eq!(client.get_funding_close_snapshot(), None);
+2026-06-25T10:01:59.5566062Z      client.fund(&b, &(TARGET / 2));
+2026-06-25T10:01:59.5566350Z      let s1 = client.get_funding_close_snapshot().unwrap();
+2026-06-25T10:01:59.5566835Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:748:
+2026-06-25T10:01:59.5567269Z          &None,
+2026-06-25T10:01:59.5567468Z          &None,
+2026-06-25T10:01:59.5567657Z      );
+2026-06-25T10:01:59.5567858Z -client.fund(&a, &(20_000_000_000i128));
+2026-06-25T10:01:59.5568138Z +    client.fund(&a, &(20_000_000_000i128));
+2026-06-25T10:01:59.5568416Z      client.fund(&b, &(80_000_000_000i128));
+2026-06-25T10:01:59.5568737Z      let snap = client.get_funding_close_snapshot().unwrap();
+2026-06-25T10:01:59.5569080Z      assert_eq!(snap.total_principal, TARGET);
+2026-06-25T10:01:59.5569536Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:793:
+2026-06-25T10:01:59.5569969Z          &None,
+2026-06-25T10:01:59.5570159Z          &None,
+2026-06-25T10:01:59.5570356Z      );
+2026-06-25T10:01:59.5570611Z -client.fund_with_commitment(&inv, &5_000i128, &200u64);
+2026-06-25T10:01:59.5570978Z +    client.fund_with_commitment(&inv, &5_000i128, &200u64);
+2026-06-25T10:01:59.5571460Z      assert_eq!(client.get_investor_yield_bps(&inv), 900);
+2026-06-25T10:01:59.5571845Z      assert_eq!(client.get_investor_claim_not_before(&inv), 200);
+2026-06-25T10:01:59.5572182Z      client.fund(&inv, &5_000i128);
+2026-06-25T10:01:59.5572751Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:834:
+2026-06-25T10:01:59.5573203Z          &None,
+2026-06-25T10:01:59.5573400Z          &None,
+2026-06-25T10:01:59.5573592Z      );
+2026-06-25T10:01:59.5573851Z -client.fund_with_commitment(&i_short, &10_000i128, &40u64);
+2026-06-25T10:01:59.5574241Z +    client.fund_with_commitment(&i_short, &10_000i128, &40u64);
+2026-06-25T10:01:59.5574625Z      assert_eq!(client.get_investor_yield_bps(&i_short), 800);
+2026-06-25T10:01:59.5575004Z      client.fund_with_commitment(&i_long, &10_000i128, &50u64);
+2026-06-25T10:01:59.5575499Z      assert_eq!(client.get_investor_yield_bps(&i_long), 850);
+2026-06-25T10:01:59.5575992Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:873:
+2026-06-25T10:01:59.5576461Z          &None,
+2026-06-25T10:01:59.5576653Z          &None,
+2026-06-25T10:01:59.5576838Z      );
+2026-06-25T10:01:59.5577074Z -client.fund_with_commitment(&inv, &5_000i128, &10u64);
+2026-06-25T10:01:59.5577439Z      client.fund_with_commitment(&inv, &5_000i128, &10u64);
+2026-06-25T10:01:59.5577796Z +    client.fund_with_commitment(&inv, &5_000i128, &10u64);
+2026-06-25T10:01:59.5578087Z  }
+2026-06-25T10:01:59.5578267Z  
+2026-06-25T10:01:59.5578444Z  #[test]
+2026-06-25T10:01:59.5578833Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:905:
+2026-06-25T10:01:59.5579272Z          &None,
+2026-06-25T10:01:59.5579460Z          &None,
+2026-06-25T10:01:59.5579648Z      );
+2026-06-25T10:01:59.5579850Z -client.fund(&inv, &5_000i128);
+2026-06-25T10:01:59.5580100Z +    client.fund(&inv, &5_000i128);
+2026-06-25T10:01:59.5580400Z      client.fund_with_commitment(&inv, &5_000i128, &10u64);
+2026-06-25T10:01:59.5580690Z  }
+2026-06-25T10:01:59.5580874Z  
+2026-06-25T10:01:59.5581232Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:946:
+2026-06-25T10:01:59.5581791Z          &None,
+2026-06-25T10:01:59.5581987Z          &None,
+2026-06-25T10:01:59.5582175Z      );
+2026-06-25T10:01:59.5582392Z -let inv_base = Address::generate(&env);
+2026-06-25T10:01:59.5582686Z +    let inv_base = Address::generate(&env);
+2026-06-25T10:01:59.5582986Z      let inv_tier1 = Address::generate(&env);
+2026-06-25T10:01:59.5583281Z      let inv_tier2 = Address::generate(&env);
+2026-06-25T10:01:59.5583568Z      let inv_mid = Address::generate(&env);
+2026-06-25T10:01:59.5584036Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1004:
+2026-06-25T10:01:59.5584494Z          &None,
+2026-06-25T10:01:59.5584686Z          &None,
+2026-06-25T10:01:59.5584874Z      );
+2026-06-25T10:01:59.5585081Z -let inv = Address::generate(&env);
+2026-06-25T10:01:59.5585360Z +    let inv = Address::generate(&env);
+2026-06-25T10:01:59.5585611Z  
+2026-06-25T10:01:59.5585951Z      // 1. Tiered fund: committed_lock_secs=150 >= tier.min_lock_secs=100 => yield 900, lock 100.
+2026-06-25T10:01:59.5586416Z      client.fund_with_commitment(&inv, &1_000i128, &150u64);
+2026-06-25T10:01:59.5586919Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1079:
+2026-06-25T10:01:59.5587362Z          &None,
+2026-06-25T10:01:59.5587555Z          &None,
+2026-06-25T10:01:59.5587753Z      );
+2026-06-25T10:01:59.5587959Z -let inv = Address::generate(&env);
+2026-06-25T10:01:59.5588222Z +    let inv = Address::generate(&env);
+2026-06-25T10:01:59.5588541Z      // fund_with_commitment even with no tiers configured
+2026-06-25T10:01:59.5588896Z      client.fund_with_commitment(&inv, &1_000i128, &150u64);
+2026-06-25T10:01:59.5589194Z  
+2026-06-25T10:01:59.5589557Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1139:
+2026-06-25T10:01:59.5589992Z          &None,
+2026-06-25T10:01:59.5590178Z          &None,
+2026-06-25T10:01:59.5590363Z      );
+2026-06-25T10:01:59.5590559Z -let inv = Address::generate(&env);
+2026-06-25T10:01:59.5590814Z +    let inv = Address::generate(&env);
+2026-06-25T10:01:59.5591410Z      // Committing 150 secs (between 100 and 200) -> matches the 100 sec tier.
+2026-06-25T10:01:59.5591991Z      client.fund_with_commitment(&inv, &1_000i128, &150u64);
+2026-06-25T10:01:59.5592287Z  
+2026-06-25T10:01:59.5592655Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1195:
+2026-06-25T10:01:59.5593094Z          &None,
+2026-06-25T10:01:59.5593278Z          &None,
+2026-06-25T10:01:59.5593471Z      );
+2026-06-25T10:01:59.5593704Z -client.fund_with_commitment(&inv, &5_000i128, &0u64);
+2026-06-25T10:01:59.5594177Z +    client.fund_with_commitment(&inv, &5_000i128, &0u64);
+2026-06-25T10:01:59.5594584Z      assert_eq!(client.get_investor_yield_bps(&inv), 800);
+2026-06-25T10:01:59.5595153Z      assert_eq!(client.get_investor_claim_not_before(&inv), 0);
+2026-06-25T10:01:59.5595645Z  }
+2026-06-25T10:01:59.5596237Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1230:
+2026-06-25T10:01:59.5596841Z          &None,
+2026-06-25T10:01:59.5597035Z          &None,
+2026-06-25T10:01:59.5597233Z      );
+2026-06-25T10:01:59.5597477Z -client.fund_with_commitment(&investor, &100i128, &5u64);
+2026-06-25T10:01:59.5597855Z +    client.fund_with_commitment(&investor, &100i128, &5u64);
+2026-06-25T10:01:59.5598158Z  
+2026-06-25T10:01:59.5598453Z      assert_eq!(client.get_investor_claim_not_before(&investor), u64::MAX);
+2026-06-25T10:01:59.5598814Z  }
+2026-06-25T10:01:59.5599181Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1266:
+2026-06-25T10:01:59.5599623Z          &None,
+2026-06-25T10:01:59.5599808Z          &None,
+2026-06-25T10:01:59.5599991Z      );
+2026-06-25T10:01:59.5600228Z -client.fund_with_commitment(&investor, &100i128, &6u64);
+2026-06-25T10:01:59.5600594Z +    client.fund_with_commitment(&investor, &100i128, &6u64);
+2026-06-25T10:01:59.5600897Z  }
+2026-06-25T10:01:59.5601076Z  
+2026-06-25T10:01:59.5601250Z  #[test]
+2026-06-25T10:01:59.5601775Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1299:
+2026-06-25T10:01:59.5602221Z          &None,
+2026-06-25T10:01:59.5602441Z          &None,
+2026-06-25T10:01:59.5602631Z      );
+2026-06-25T10:01:59.5602939Z -let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+2026-06-25T10:01:59.5603427Z +    let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+2026-06-25T10:01:59.5603878Z          client.fund_with_commitment(&investor, &100i128, &6u64);
+2026-06-25T10:01:59.5604192Z      }));
+2026-06-25T10:01:59.5604402Z      assert!(overflowed.is_err());
+2026-06-25T10:01:59.5604837Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1409:
+2026-06-25T10:01:59.5605276Z          &None,
+2026-06-25T10:01:59.5605464Z          &None,
+2026-06-25T10:01:59.5605650Z      );
+2026-06-25T10:01:59.5605849Z -let escrow = client.fund(&inv, &t);
+2026-06-25T10:01:59.5606119Z +    let escrow = client.fund(&inv, &t);
+2026-06-25T10:01:59.5606394Z      assert_eq!(escrow.funded_amount, t);
+2026-06-25T10:01:59.5606671Z      assert_eq!(escrow.status, 1);
+2026-06-25T10:01:59.5606978Z      let snap = client.get_funding_close_snapshot().unwrap();
+2026-06-25T10:01:59.5607467Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1444:
+2026-06-25T10:01:59.5607901Z          &None,
+2026-06-25T10:01:59.5608091Z          &None,
+2026-06-25T10:01:59.5608282Z      );
+2026-06-25T10:01:59.5608475Z -let seq = env.ledger().sequence();
+2026-06-25T10:01:59.5608740Z +    let seq = env.ledger().sequence();
+2026-06-25T10:01:59.5609003Z      client.fund(&inv, &1_000i128);
+2026-06-25T10:01:59.5609299Z      let snap = client.get_funding_close_snapshot().unwrap();
+2026-06-25T10:01:59.5609647Z      assert_eq!(snap.closed_at_ledger_sequence, seq);
+2026-06-25T10:01:59.5610128Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1477:
+2026-06-25T10:01:59.5610558Z          &None,
+2026-06-25T10:01:59.5610743Z          &None,
+2026-06-25T10:01:59.5611084Z      );
+2026-06-25T10:01:59.5611368Z -assert_eq!(
+2026-06-25T10:01:59.5611569Z +    assert_eq!(
+2026-06-25T10:01:59.5611796Z          client.get_funding_close_snapshot(),
+2026-06-25T10:01:59.5612067Z          None,
+2026-06-25T10:01:59.5612305Z          "snapshot must be absent before any funding"
+2026-06-25T10:01:59.5612782Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1512:
+2026-06-25T10:01:59.5613247Z          &None,
+2026-06-25T10:01:59.5613563Z          &None,
+2026-06-25T10:01:59.5613751Z      );
+2026-06-25T10:01:59.5614199Z -// Partial fund — snapshot still absent.
+2026-06-25T10:01:59.5614543Z +    // Partial fund — snapshot still absent.
+2026-06-25T10:01:59.5614834Z      client.fund(&inv, &(TARGET / 2));
+2026-06-25T10:01:59.5615093Z      assert_eq!(
+2026-06-25T10:01:59.5615317Z          client.get_funding_close_snapshot(),
+2026-06-25T10:01:59.5615777Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1558:
+2026-06-25T10:01:59.5616234Z          &None,
+2026-06-25T10:01:59.5616428Z          &None,
+2026-06-25T10:01:59.5616621Z      );
+2026-06-25T10:01:59.5616904Z -// Fund exactly to target — snapshot is written here.
+2026-06-25T10:01:59.5617299Z +    // Fund exactly to target — snapshot is written here.
+2026-06-25T10:01:59.5617614Z      client.fund(&inv, &TARGET);
+2026-06-25T10:01:59.5617876Z      let snap_at_close = client
+2026-06-25T10:01:59.5618136Z          .get_funding_close_snapshot()
+2026-06-25T10:01:59.5618592Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1598:
+2026-06-25T10:01:59.5619034Z          &None,
+2026-06-25T10:01:59.5619224Z          &None,
+2026-06-25T10:01:59.5619409Z      );
+2026-06-25T10:01:59.5619636Z -assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5619971Z +    assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5620255Z  }
+2026-06-25T10:01:59.5620432Z  
+2026-06-25T10:01:59.5620608Z  #[test]
+2026-06-25T10:01:59.5620984Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1624:
+2026-06-25T10:01:59.5621608Z          &None,
+2026-06-25T10:01:59.5621798Z          &None,
+2026-06-25T10:01:59.5621985Z      );
+2026-06-25T10:01:59.5622205Z -assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5622602Z +    assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5622912Z      client.fund(&investor, &(TARGET / 2));
+2026-06-25T10:01:59.5623228Z      assert_eq!(client.get_unique_funder_count(), 1);
+2026-06-25T10:01:59.5623523Z      client.fund(&investor, &(TARGET / 2));
+2026-06-25T10:01:59.5623976Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1656:
+2026-06-25T10:01:59.5624421Z          &None,
+2026-06-25T10:01:59.5624614Z          &None,
+2026-06-25T10:01:59.5624798Z      );
+2026-06-25T10:01:59.5625022Z -assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5625350Z +    assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5625622Z  
+2026-06-25T10:01:59.5625819Z      client.fund(&inv_a, &(TARGET / 3));
+2026-06-25T10:01:59.5626111Z      assert_eq!(client.get_unique_funder_count(), 1);
+2026-06-25T10:01:59.5626577Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1703:
+2026-06-25T10:01:59.5627018Z          &None,
+2026-06-25T10:01:59.5627208Z          &None,
+2026-06-25T10:01:59.5627391Z      );
+2026-06-25T10:01:59.5627605Z -assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5627922Z +    assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5628194Z  
+2026-06-25T10:01:59.5628403Z      // First investor uses fund_with_commitment
+2026-06-25T10:01:59.5628758Z      client.fund_with_commitment(&inv_a, &(TARGET / 2), &200u64);
+2026-06-25T10:01:59.5629261Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1736:
+2026-06-25T10:01:59.5629702Z          &None,
+2026-06-25T10:01:59.5630058Z          &None,
+2026-06-25T10:01:59.5630249Z      );
+2026-06-25T10:01:59.5630508Z -// Should be able to add many investors when no cap is set
+2026-06-25T10:01:59.5630903Z +    // Should be able to add many investors when no cap is set
+2026-06-25T10:01:59.5631223Z      for i in 0..10 {
+2026-06-25T10:01:59.5631580Z          let investor = Address::generate(&env);
+2026-06-25T10:01:59.5631885Z          client.fund(&investor, &(TARGET / 20));
+2026-06-25T10:01:59.5632351Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1767:
+2026-06-25T10:01:59.5632939Z          &None,
+2026-06-25T10:01:59.5633138Z          &None,
+2026-06-25T10:01:59.5633326Z      );
+2026-06-25T10:01:59.5633598Z -assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
+2026-06-25T10:01:59.5634011Z +    assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
+2026-06-25T10:01:59.5634332Z  
+2026-06-25T10:01:59.5634532Z      // Add 3 investors - should succeed
+2026-06-25T10:01:59.5634819Z      let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5635259Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1811:
+2026-06-25T10:01:59.5635709Z          &None,
+2026-06-25T10:01:59.5635908Z          &None,
+2026-06-25T10:01:59.5636107Z      );
+2026-06-25T10:01:59.5636309Z -// Add 2 investors
+2026-06-25T10:01:59.5636527Z +    // Add 2 investors
+2026-06-25T10:01:59.5636768Z      let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5637054Z      let inv2 = Address::generate(&env);
+2026-06-25T10:01:59.5637318Z      client.fund(&inv1, &(TARGET / 4));
+2026-06-25T10:01:59.5637772Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1856:
+2026-06-25T10:01:59.5638226Z          &None,
+2026-06-25T10:01:59.5638420Z          &None,
+2026-06-25T10:01:59.5638608Z      );
+2026-06-25T10:01:59.5638802Z -// First investor succeeds
+2026-06-25T10:01:59.5639047Z +    // First investor succeeds
+2026-06-25T10:01:59.5639319Z      let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5639644Z      client.fund_with_commitment(&inv1, &(TARGET / 2), &200u64);
+2026-06-25T10:01:59.5639961Z  
+2026-06-25T10:01:59.5640334Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1889:
+2026-06-25T10:01:59.5640782Z          &None,
+2026-06-25T10:01:59.5640973Z          &None,
+2026-06-25T10:01:59.5641157Z      );
+2026-06-25T10:01:59.5641492Z -// First fund should succeed
+2026-06-25T10:01:59.5641753Z +    // First fund should succeed
+2026-06-25T10:01:59.5642020Z      client.fund(&investor, &(TARGET / 3));
+2026-06-25T10:01:59.5642339Z      assert_eq!(client.get_unique_funder_count(), 1);
+2026-06-25T10:01:59.5642627Z  
+2026-06-25T10:01:59.5642993Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:1926:
+2026-06-25T10:01:59.5643430Z          &None,
+2026-06-25T10:01:59.5643617Z          &None,
+2026-06-25T10:01:59.5643802Z      );
+2026-06-25T10:01:59.5644033Z -assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5644364Z +    assert_eq!(client.get_unique_funder_count(), 0);
+2026-06-25T10:01:59.5644694Z      assert_eq!(client.get_contribution(&investor), 0);
+2026-06-25T10:01:59.5644981Z  
+2026-06-25T10:01:59.5645224Z      // First non-zero contribution should increment count
+2026-06-25T10:01:59.5645713Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2010:
+2026-06-25T10:01:59.5646149Z          &None,
+2026-06-25T10:01:59.5646340Z          &None,
+2026-06-25T10:01:59.5646529Z      );
+2026-06-25T10:01:59.5646745Z -// Add exactly 5 investors - should all succeed
+2026-06-25T10:01:59.5647066Z +    // Add exactly 5 investors - should all succeed
+2026-06-25T10:01:59.5647354Z      for i in 0..5 {
+2026-06-25T10:01:59.5647591Z          let investor = Address::generate(&env);
+2026-06-25T10:01:59.5647886Z          client.fund(&investor, &(TARGET / 10));
+2026-06-25T10:01:59.5648532Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2048:
+2026-06-25T10:01:59.5649001Z          &None,
+2026-06-25T10:01:59.5649202Z          &None,
+2026-06-25T10:01:59.5649391Z      );
+2026-06-25T10:01:59.5649585Z -// Add exactly 5 investors
+2026-06-25T10:01:59.5649827Z +    // Add exactly 5 investors
+2026-06-25T10:01:59.5650073Z      for _i in 0..5 {
+2026-06-25T10:01:59.5650315Z          let investor = Address::generate(&env);
+2026-06-25T10:01:59.5650609Z          client.fund(&investor, &(TARGET / 10));
+2026-06-25T10:01:59.5651199Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2082:
+2026-06-25T10:01:59.5651757Z          &None,
+2026-06-25T10:01:59.5651946Z          &None,
+2026-06-25T10:01:59.5652133Z      );
+2026-06-25T10:01:59.5652341Z -// Should respect both cap and floor
+2026-06-25T10:01:59.5652618Z +    // Should respect both cap and floor
+2026-06-25T10:01:59.5652900Z      let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5653175Z      let inv2 = Address::generate(&env);
+2026-06-25T10:01:59.5653436Z      let inv3 = Address::generate(&env);
+2026-06-25T10:01:59.5653874Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2124:
+2026-06-25T10:01:59.5654316Z          &None,
+2026-06-25T10:01:59.5654513Z          &None,
+2026-06-25T10:01:59.5654699Z      );
+2026-06-25T10:01:59.5654893Z -// First investor can fund large amount
+2026-06-25T10:01:59.5655168Z +    // First investor can fund large amount
+2026-06-25T10:01:59.5655454Z      let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5655714Z      client.fund(&inv1, &(TARGET * 5));
+2026-06-25T10:01:59.5655960Z  
+2026-06-25T10:01:59.5656319Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2161:
+2026-06-25T10:01:59.5656749Z          &None,
+2026-06-25T10:01:59.5656933Z          &None,
+2026-06-25T10:01:59.5657114Z      );
+2026-06-25T10:01:59.5657298Z -// Add first investor
+2026-06-25T10:01:59.5657522Z +    // Add first investor
+2026-06-25T10:01:59.5657764Z      let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5658028Z      client.fund(&inv1, &(TARGET / 2));
+2026-06-25T10:01:59.5658271Z  
+2026-06-25T10:01:59.5658638Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2201:
+2026-06-25T10:01:59.5659077Z          &None,
+2026-06-25T10:01:59.5659260Z          &None,
+2026-06-25T10:01:59.5659445Z      );
+2026-06-25T10:01:59.5659627Z -(token, treasury)
+2026-06-25T10:01:59.5659851Z +    (token, treasury)
+2026-06-25T10:01:59.5660072Z  }
+2026-06-25T10:01:59.5660150Z  
+2026-06-25T10:01:59.5660236Z  #[test]
+2026-06-25T10:01:59.5660515Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2471:
+2026-06-25T10:01:59.5660599Z          &None,
+2026-06-25T10:01:59.5660684Z          &None,
+2026-06-25T10:01:59.5660761Z      );
+2026-06-25T10:01:59.5660946Z -// Set ledger timestamp to a known value so claim_nb is deterministic.
+2026-06-25T10:01:59.5661132Z +    // Set ledger timestamp to a known value so claim_nb is deterministic.
+2026-06-25T10:01:59.5661385Z      env.ledger().with_mut(|l| l.timestamp = 1_000_000u64);
+2026-06-25T10:01:59.5661465Z  
+2026-06-25T10:01:59.5661788Z      // First deposit: tier at 100 s → effective yield = 950 bps, lock until 1_000_100.
+2026-06-25T10:01:59.5662074Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2538:
+2026-06-25T10:01:59.5662162Z          &None,
+2026-06-25T10:01:59.5662246Z          &None,
+2026-06-25T10:01:59.5662336Z      );
+2026-06-25T10:01:59.5662578Z -env.ledger().with_mut(|l| l.timestamp = 2_000_000u64);
+2026-06-25T10:01:59.5662783Z +    env.ledger().with_mut(|l| l.timestamp = 2_000_000u64);
+2026-06-25T10:01:59.5662900Z  
+2026-06-25T10:01:59.5663332Z      // First deposit: 200 s commitment → top tier (1100 bps), lock until 2_000_200.
+2026-06-25T10:01:59.5663561Z      client.fund_with_commitment(&inv, &5_000i128, &200u64);
+2026-06-25T10:01:59.5663995Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2600:
+2026-06-25T10:01:59.5664084Z          &None,
+2026-06-25T10:01:59.5664162Z          &None,
+2026-06-25T10:01:59.5664245Z      );
+2026-06-25T10:01:59.5664413Z -// Zero lock → base yield only, no claim gate.
+2026-06-25T10:01:59.5664571Z +    // Zero lock → base yield only, no claim gate.
+2026-06-25T10:01:59.5664710Z      client.fund_with_commitment(&inv, &4_000i128, &0u64);
+2026-06-25T10:01:59.5664793Z      assert_eq!(
+2026-06-25T10:01:59.5665028Z          client.get_investor_yield_bps(&inv),
+2026-06-25T10:01:59.5665297Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2659:
+2026-06-25T10:01:59.5665385Z          &None,
+2026-06-25T10:01:59.5665466Z          &None,
+2026-06-25T10:01:59.5665550Z      );
+2026-06-25T10:01:59.5665686Z -client.fund_with_commitment(&inv, &3_000i128, &0u64);
+2026-06-25T10:01:59.5665814Z +    client.fund_with_commitment(&inv, &3_000i128, &0u64);
+2026-06-25T10:01:59.5665923Z      // Second call must trap.
+2026-06-25T10:01:59.5666025Z      assert_contract_error(
+2026-06-25T10:01:59.5666185Z          client.try_fund_with_commitment(&inv, &3_000i128, &0u64),
+2026-06-25T10:01:59.5666448Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2704:
+2026-06-25T10:01:59.5666534Z          &None,
+2026-06-25T10:01:59.5666611Z          &None,
+2026-06-25T10:01:59.5666696Z      );
+2026-06-25T10:01:59.5666897Z -// First leg via fund() → establishes base-yield position.
+2026-06-25T10:01:59.5667108Z +    // First leg via fund() → establishes base-yield position.
+2026-06-25T10:01:59.5667212Z      client.fund(&inv, &3_000i128);
+2026-06-25T10:01:59.5667437Z      // Attempt to re-select tier via fund_with_commitment → must panic.
+2026-06-25T10:01:59.5667536Z      assert_contract_error(
+2026-06-25T10:01:59.5667811Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2750:
+2026-06-25T10:01:59.5667898Z          &None,
+2026-06-25T10:01:59.5667984Z          &None,
+2026-06-25T10:01:59.5668070Z      );
+2026-06-25T10:01:59.5668165Z -client.fund(&inv, &5_000i128);
+2026-06-25T10:01:59.5668266Z +    client.fund(&inv, &5_000i128);
+2026-06-25T10:01:59.5668348Z      assert_eq!(
+2026-06-25T10:01:59.5668464Z          client.get_investor_yield_bps(&inv),
+2026-06-25T10:01:59.5668550Z          800,
+2026-06-25T10:01:59.5668820Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2906:
+2026-06-25T10:01:59.5668916Z          &None,
+2026-06-25T10:01:59.5668994Z          &None,
+2026-06-25T10:01:59.5669078Z      );
+2026-06-25T10:01:59.5669271Z -let escrow = client.fund_with_commitment(&investor, &1_000i128, &9999u64);
+2026-06-25T10:01:59.5669467Z +    let escrow = client.fund_with_commitment(&investor, &1_000i128, &9999u64);
+2026-06-25T10:01:59.5669566Z      assert_eq!(escrow.status, 0);
+2026-06-25T10:01:59.5669755Z      assert_eq!(client.get_investor_claim_not_before(&investor), 10999u64);
+2026-06-25T10:01:59.5669843Z  }
+2026-06-25T10:01:59.5670109Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:2988:
+2026-06-25T10:01:59.5670198Z              &None,
+2026-06-25T10:01:59.5670277Z              &None,
+2026-06-25T10:01:59.5670363Z              &None,
+2026-06-25T10:01:59.5670442Z -        &None,
+2026-06-25T10:01:59.5670529Z -    );
+2026-06-25T10:01:59.5670604Z -}
+2026-06-25T10:01:59.5670693Z +            &None,
+2026-06-25T10:01:59.5670773Z +        );
+2026-06-25T10:01:59.5670861Z +    }
+2026-06-25T10:01:59.5670937Z  
+2026-06-25T10:01:59.5671036Z      // Create 5 investors
+2026-06-25T10:01:59.5671168Z      let mut investors = SorobanVec::new(&env);
+2026-06-25T10:01:59.5671557Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:3060:
+2026-06-25T10:01:59.5671642Z          &None,
+2026-06-25T10:01:59.5671723Z          &None,
+2026-06-25T10:01:59.5671808Z      );
+2026-06-25T10:01:59.5671919Z -let mut entries = SorobanVec::new(&env);
+2026-06-25T10:01:59.5672172Z +    let mut entries = SorobanVec::new(&env);
+2026-06-25T10:01:59.5672337Z      entries.push_back((inv1.clone(), 25_000i128)); // Within cap
+2026-06-25T10:01:59.5672503Z      entries.push_back((inv2.clone(), 35_000i128)); // Exceeds cap
+2026-06-25T10:01:59.5672586Z  
+2026-06-25T10:01:59.5672857Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:3096:
+2026-06-25T10:01:59.5672942Z          &None,
+2026-06-25T10:01:59.5673021Z          &None,
+2026-06-25T10:01:59.5673227Z      );
+2026-06-25T10:01:59.5673332Z -let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5673443Z +    let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5673541Z      let inv2 = Address::generate(&env);
+2026-06-25T10:01:59.5673645Z      let inv3 = Address::generate(&env);
+2026-06-25T10:01:59.5673721Z  
+2026-06-25T10:01:59.5673998Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:3157:
+2026-06-25T10:01:59.5674081Z          &None,
+2026-06-25T10:01:59.5674164Z          &None,
+2026-06-25T10:01:59.5674248Z      );
+2026-06-25T10:01:59.5674353Z -let mut entries = SorobanVec::new(&env);
+2026-06-25T10:01:59.5674468Z +    let mut entries = SorobanVec::new(&env);
+2026-06-25T10:01:59.5674635Z      entries.push_back((inv.clone(), 30_000i128)); // First entry: 30k
+2026-06-25T10:01:59.5674851Z      entries.push_back((inv.clone(), 25_000i128)); // Second entry: 30k + 25k = 55k > cap
+2026-06-25T10:01:59.5674930Z  
+2026-06-25T10:01:59.5675204Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:3234:
+2026-06-25T10:01:59.5675292Z          &None,
+2026-06-25T10:01:59.5675371Z          &None,
+2026-06-25T10:01:59.5675450Z      );
+2026-06-25T10:01:59.5675550Z -// Create exactly MAX_FUND_BATCH entries
+2026-06-25T10:01:59.5675663Z +    // Create exactly MAX_FUND_BATCH entries
+2026-06-25T10:01:59.5675768Z      let mut entries = SorobanVec::new(&env);
+2026-06-25T10:01:59.5675867Z      for _ in 0..MAX_FUND_BATCH {
+2026-06-25T10:01:59.5675975Z          let inv = Address::generate(&env);
+2026-06-25T10:01:59.5676246Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/funding.rs:3277:
+2026-06-25T10:01:59.5676326Z          &None,
+2026-06-25T10:01:59.5676412Z          &None,
+2026-06-25T10:01:59.5676495Z      );
+2026-06-25T10:01:59.5676591Z -let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5676696Z +    let inv1 = Address::generate(&env);
+2026-06-25T10:01:59.5676790Z      let inv2 = Address::generate(&env);
+2026-06-25T10:01:59.5676878Z  
+2026-06-25T10:01:59.5676980Z      let mut entries = SorobanVec::new(&env);
+2026-06-25T10:01:59.5677248Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:28:
+2026-06-25T10:01:59.5677329Z          &None,
+2026-06-25T10:01:59.5677413Z          &None,
+2026-06-25T10:01:59.5677490Z      );
+2026-06-25T10:01:59.5677647Z -assert_eq!(escrow.invoice_id, symbol_short!("INV001"));
+2026-06-25T10:01:59.5677802Z +    assert_eq!(escrow.invoice_id, symbol_short!("INV001"));
+2026-06-25T10:01:59.5677903Z      assert_eq!(escrow.admin, admin);
+2026-06-25T10:01:59.5678006Z      assert_eq!(escrow.sme_address, sme);
+2026-06-25T10:01:59.5678106Z      assert_eq!(escrow.amount, TARGET);
+2026-06-25T10:01:59.5678363Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:61:
+2026-06-25T10:01:59.5678443Z          &None,
+2026-06-25T10:01:59.5678528Z          &None,
+2026-06-25T10:01:59.5678604Z      );
+2026-06-25T10:01:59.5678711Z -let got = client.get_escrow();
+2026-06-25T10:01:59.5678815Z +    let got = client.get_escrow();
+2026-06-25T10:01:59.5678908Z      assert_eq!(got, escrow);
+2026-06-25T10:01:59.5678990Z  }
+2026-06-25T10:01:59.5679065Z  
+2026-06-25T10:01:59.5679320Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:87:
+2026-06-25T10:01:59.5679397Z          &None,
+2026-06-25T10:01:59.5679481Z          &None,
+2026-06-25T10:01:59.5679557Z      );
+2026-06-25T10:01:59.5679742Z -assert!(
+2026-06-25T10:01:59.5679825Z +    assert!(
+2026-06-25T10:01:59.5679965Z          env.auths().iter().any(|(addr, _)| *addr == admin),
+2026-06-25T10:01:59.5680078Z          "admin auth was not recorded for init"
+2026-06-25T10:01:59.5680163Z      );
+2026-06-25T10:01:59.5680428Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:139:
+2026-06-25T10:01:59.5680512Z              &None,
+2026-06-25T10:01:59.5680597Z              &None,
+2026-06-25T10:01:59.5680765Z              &None,
+2026-06-25T10:01:59.5680848Z -        &None,
+2026-06-25T10:01:59.5680926Z -    );
+2026-06-25T10:01:59.5681008Z -}));
+2026-06-25T10:01:59.5681086Z +            &None,
+2026-06-25T10:01:59.5681174Z +        );
+2026-06-25T10:01:59.5681252Z +    }));
+2026-06-25T10:01:59.5681546Z      assert!(result.is_err(), "Expected panic without auth");
+2026-06-25T10:01:59.5681631Z  }
+2026-06-25T10:01:59.5681709Z  
+2026-06-25T10:01:59.5681984Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:396:
+2026-06-25T10:01:59.5682061Z  
+2026-06-25T10:01:59.5682154Z      client.init(
+2026-06-25T10:01:59.5682370Z          &admin, &s, &sme, &1000i128, &500i64, &0u64, &t, &None, &tr, &None, &None, &None, &None,
+2026-06-25T10:01:59.5682462Z -        &None, &None,
+2026-06-25T10:01:59.5682540Z -        &None,
+2026-06-25T10:01:59.5682637Z +        &None, &None, &None,
+2026-06-25T10:01:59.5682713Z      );
+2026-06-25T10:01:59.5682798Z  }
+2026-06-25T10:01:59.5682874Z  
+2026-06-25T10:01:59.5683145Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:429:
+2026-06-25T10:01:59.5683228Z          &None,
+2026-06-25T10:01:59.5683304Z          &None,
+2026-06-25T10:01:59.5683387Z      );
+2026-06-25T10:01:59.5683514Z -assert_eq!(client.get_registry_ref(), Some(reg));
+2026-06-25T10:01:59.5683647Z +    assert_eq!(client.get_registry_ref(), Some(reg));
+2026-06-25T10:01:59.5683767Z      assert_eq!(client.get_funding_token(), token);
+2026-06-25T10:01:59.5683896Z      assert_eq!(client.get_treasury(), treasury);
+2026-06-25T10:01:59.5683971Z  }
+2026-06-25T10:01:59.5684229Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:463:
+2026-06-25T10:01:59.5684324Z          &None,
+2026-06-25T10:01:59.5684401Z          &None,
+2026-06-25T10:01:59.5684483Z      );
+2026-06-25T10:01:59.5684629Z -assert_eq!(client.get_min_contribution_floor(), 1_000i128);
+2026-06-25T10:01:59.5684785Z +    assert_eq!(client.get_min_contribution_floor(), 1_000i128);
+2026-06-25T10:01:59.5684867Z  }
+2026-06-25T10:01:59.5684951Z  
+2026-06-25T10:01:59.5685094Z  /// Floor defaults to 0 when `min_contribution` is `None`.
+2026-06-25T10:01:59.5685354Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:493:
+2026-06-25T10:01:59.5685431Z          &None,
+2026-06-25T10:01:59.5685531Z          &None,
+2026-06-25T10:01:59.5685615Z      );
+2026-06-25T10:01:59.5685754Z -assert_eq!(client.get_min_contribution_floor(), 0i128);
+2026-06-25T10:01:59.5685897Z +    assert_eq!(client.get_min_contribution_floor(), 0i128);
+2026-06-25T10:01:59.5685972Z  }
+2026-06-25T10:01:59.5686056Z  
+2026-06-25T10:01:59.5686373Z  /// `min_contribution = Some(0)` is rejected — the value must be positive when supplied.
+2026-06-25T10:01:59.5686636Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:583:
+2026-06-25T10:01:59.5686716Z          &None,
+2026-06-25T10:01:59.5686804Z          &None,
+2026-06-25T10:01:59.5686883Z      );
+2026-06-25T10:01:59.5687039Z -assert_eq!(client.get_min_contribution_floor(), 5_000i128);
+2026-06-25T10:01:59.5687192Z +    assert_eq!(client.get_min_contribution_floor(), 5_000i128);
+2026-06-25T10:01:59.5687269Z  }
+2026-06-25T10:01:59.5687351Z  
+2026-06-25T10:01:59.5687430Z  #[test]
+2026-06-25T10:01:59.5687684Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:626:
+2026-06-25T10:01:59.5687761Z          &None,
+2026-06-25T10:01:59.5687845Z          &None,
+2026-06-25T10:01:59.5688065Z      );
+2026-06-25T10:01:59.5688192Z -assert_eq!(client.get_funding_token(), token);
+2026-06-25T10:01:59.5688307Z +    assert_eq!(client.get_funding_token(), token);
+2026-06-25T10:01:59.5688395Z  }
+2026-06-25T10:01:59.5688477Z  
+2026-06-25T10:01:59.5688557Z  #[test]
+2026-06-25T10:01:59.5688810Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:652:
+2026-06-25T10:01:59.5688888Z          &None,
+2026-06-25T10:01:59.5688972Z          &None,
+2026-06-25T10:01:59.5689162Z      );
+2026-06-25T10:01:59.5689282Z -assert_eq!(client.get_treasury(), treasury);
+2026-06-25T10:01:59.5689394Z +    assert_eq!(client.get_treasury(), treasury);
+2026-06-25T10:01:59.5689480Z  }
+2026-06-25T10:01:59.5689554Z  
+2026-06-25T10:01:59.5689638Z  #[test]
+2026-06-25T10:01:59.5705624Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:689:
+2026-06-25T10:01:59.5705796Z          &None,
+2026-06-25T10:01:59.5705928Z          &None,
+2026-06-25T10:01:59.5706018Z      );
+2026-06-25T10:01:59.5706166Z -assert_eq!(client.get_registry_ref(), None);
+2026-06-25T10:01:59.5706298Z +    assert_eq!(client.get_registry_ref(), None);
+2026-06-25T10:01:59.5706384Z  }
+2026-06-25T10:01:59.5706459Z  
+2026-06-25T10:01:59.5706547Z  #[test]
+2026-06-25T10:01:59.5706845Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:724:
+2026-06-25T10:01:59.5706928Z          &None,
+2026-06-25T10:01:59.5707011Z          &None,
+2026-06-25T10:01:59.5707095Z      );
+2026-06-25T10:01:59.5707183Z -assert_eq!(
+2026-06-25T10:01:59.5707265Z +    assert_eq!(
+2026-06-25T10:01:59.5707363Z          env.events().all(),
+2026-06-25T10:01:59.5707485Z          std::vec![EscrowInitialized {
+2026-06-25T10:01:59.5707606Z              name: symbol_short!("escrow_ii"),
+2026-06-25T10:01:59.5707866Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:769:
+2026-06-25T10:01:59.5707952Z          &None,
+2026-06-25T10:01:59.5708034Z          &None,
+2026-06-25T10:01:59.5708113Z      );
+2026-06-25T10:01:59.5708197Z -assert_eq!(
+2026-06-25T10:01:59.5708275Z +    assert_eq!(
+2026-06-25T10:01:59.5708372Z          env.events().all(),
+2026-06-25T10:01:59.5708473Z          std::vec![EscrowInitialized {
+2026-06-25T10:01:59.5708580Z              name: symbol_short!("escrow_ii"),
+2026-06-25T10:01:59.5708832Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:811:
+2026-06-25T10:01:59.5708922Z              &None,
+2026-06-25T10:01:59.5709003Z              &None,
+2026-06-25T10:01:59.5709086Z              &None,
+2026-06-25T10:01:59.5709170Z -        &None,
+2026-06-25T10:01:59.5709246Z -    );
+2026-06-25T10:01:59.5709327Z -}));
+2026-06-25T10:01:59.5709404Z +            &None,
+2026-06-25T10:01:59.5709484Z +        );
+2026-06-25T10:01:59.5709561Z +    }));
+2026-06-25T10:01:59.5709670Z      result.map(|_| ()).map_err(|_| ())
+2026-06-25T10:01:59.5709745Z  }
+2026-06-25T10:01:59.5709827Z  
+2026-06-25T10:01:59.5710105Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:1071:
+2026-06-25T10:01:59.5710186Z          &None,
+2026-06-25T10:01:59.5710260Z          &None,
+2026-06-25T10:01:59.5710348Z      );
+2026-06-25T10:01:59.5710494Z -assert_eq!(client.get_distributed_principal(), 0i128);
+2026-06-25T10:01:59.5710644Z +    assert_eq!(client.get_distributed_principal(), 0i128);
+2026-06-25T10:01:59.5710720Z  
+2026-06-25T10:01:59.5710855Z      token.stellar.mint(&client.address, &500i128);
+2026-06-25T10:01:59.5710954Z      client.fund(&investor, &500i128);
+2026-06-25T10:01:59.5711408Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:58:
+2026-06-25T10:01:59.5711496Z          &None,
+2026-06-25T10:01:59.5711573Z          &None,
+2026-06-25T10:01:59.5711658Z      );
+2026-06-25T10:01:59.5711973Z -// We will not fund or settle — just exercise legal hold at multiple points.
+2026-06-25T10:01:59.5712446Z +    // We will not fund or settle — just exercise legal hold at multiple points.
+2026-06-25T10:01:59.5712643Z      // The contract id is derived from the deploy_and_init sequence, so we
+2026-06-25T10:01:59.5712742Z      // capture it for auth mock setup.
+2026-06-25T10:01:59.5712822Z  
+2026-06-25T10:01:59.5713125Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:164:
+2026-06-25T10:01:59.5713211Z          &None,
+2026-06-25T10:01:59.5713291Z          &None,
+2026-06-25T10:01:59.5713377Z      );
+2026-06-25T10:01:59.5713487Z -let initial_escrow = client.get_escrow();
+2026-06-25T10:01:59.5713734Z +    let initial_escrow = client.get_escrow();
+2026-06-25T10:01:59.5713818Z      assert_eq!(
+2026-06-25T10:01:59.5713924Z          initial_escrow.status, 0,
+2026-06-25T10:01:59.5714034Z          "Escrow should start in Open status"
+2026-06-25T10:01:59.5714315Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:393:
+2026-06-25T10:01:59.5714400Z          &None,
+2026-06-25T10:01:59.5714476Z          &None,
+2026-06-25T10:01:59.5714562Z      );
+2026-06-25T10:01:59.5714680Z -let investor_base = Address::generate(&env);
+2026-06-25T10:01:59.5714809Z +    let investor_base = Address::generate(&env);
+2026-06-25T10:01:59.5714933Z      let investor_tier1 = Address::generate(&env);
+2026-06-25T10:01:59.5715052Z      let investor_tier2 = Address::generate(&env);
+2026-06-25T10:01:59.5715166Z      let investor_tier3 = Address::generate(&env);
+2026-06-25T10:01:59.5715437Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:519:
+2026-06-25T10:01:59.5715522Z          &None,
+2026-06-25T10:01:59.5715596Z          &None,
+2026-06-25T10:01:59.5715676Z      );
+2026-06-25T10:01:59.5715930Z -let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+2026-06-25T10:01:59.5716180Z +    let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+2026-06-25T10:01:59.5716319Z      assert_eq!(commitment.asset, symbol_short!("USDC"));
+2026-06-25T10:01:59.5716432Z      assert_eq!(commitment.amount, 5_000i128);
+2026-06-25T10:01:59.5716589Z      assert!(client.get_sme_collateral_commitment().is_some());
+2026-06-25T10:01:59.5716867Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:750:
+2026-06-25T10:01:59.5716951Z          &None,
+2026-06-25T10:01:59.5717026Z          &None,
+2026-06-25T10:01:59.5717103Z      );
+2026-06-25T10:01:59.5717217Z -// Initial funding succeeds while hold is off.
+2026-06-25T10:01:59.5717341Z +    // Initial funding succeeds while hold is off.
+2026-06-25T10:01:59.5717469Z      let open_state = client.fund(&investor, &4_000i128);
+2026-06-25T10:01:59.5717574Z      assert_eq!(open_state.status, 0);
+2026-06-25T10:01:59.5717654Z  
+2026-06-25T10:01:59.5717929Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:873:
+2026-06-25T10:01:59.5718011Z          &None,
+2026-06-25T10:01:59.5718087Z          &None,
+2026-06-25T10:01:59.5718171Z      );
+2026-06-25T10:01:59.5718301Z -let investor = soroban_sdk::Address::generate(env);
+2026-06-25T10:01:59.5718438Z +    let investor = soroban_sdk::Address::generate(env);
+2026-06-25T10:01:59.5718536Z      client.fund(&investor, &target);
+2026-06-25T10:01:59.5718615Z  
+2026-06-25T10:01:59.5718820Z      // Mint the funded amount into the escrow contract so withdraw() can send it.
+2026-06-25T10:01:59.5719101Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:989:
+2026-06-25T10:01:59.5719184Z          &None,
+2026-06-25T10:01:59.5719258Z          &None,
+2026-06-25T10:01:59.5719337Z      );
+2026-06-25T10:01:59.5719480Z -// No funding — status is 0.
+2026-06-25T10:01:59.5719615Z +    // No funding — status is 0.
+2026-06-25T10:01:59.5719758Z      client.withdraw(); // must panic: WithdrawalNotFunded
+2026-06-25T10:01:59.5719841Z  }
+2026-06-25T10:01:59.5719915Z  
+2026-06-25T10:01:59.5720332Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:1031:
+2026-06-25T10:01:59.5720413Z          &None,
+2026-06-25T10:01:59.5720500Z          &None,
+2026-06-25T10:01:59.5720579Z      );
+2026-06-25T10:01:59.5720713Z -let investor = soroban_sdk::Address::generate(&env);
+2026-06-25T10:01:59.5720850Z +    let investor = soroban_sdk::Address::generate(&env);
+2026-06-25T10:01:59.5720944Z      client.fund(&investor, &target);
+2026-06-25T10:01:59.5721023Z  
+2026-06-25T10:01:59.5721194Z      // Mint only half — contract balance < funded_amount.
+2026-06-25T10:01:59.5721848Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/legal_hold.rs:53:
+2026-06-25T10:01:59.5721923Z          &None,
+2026-06-25T10:01:59.5722003Z          &None,
+2026-06-25T10:01:59.5722076Z      );
+2026-06-25T10:01:59.5722164Z -(token, treasury)
+2026-06-25T10:01:59.5722253Z +    (token, treasury)
+2026-06-25T10:01:59.5722326Z  }
+2026-06-25T10:01:59.5722402Z  
+2026-06-25T10:01:59.5722590Z  /// Initialise an open escrow with a configured legal-hold clear delay.
+2026-06-25T10:01:59.5722871Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/legal_hold.rs:85:
+2026-06-25T10:01:59.5722947Z          &None,
+2026-06-25T10:01:59.5723027Z          &None,
+2026-06-25T10:01:59.5723097Z      );
+2026-06-25T10:01:59.5723188Z -(token, treasury)
+2026-06-25T10:01:59.5723268Z +    (token, treasury)
+2026-06-25T10:01:59.5723346Z  }
+2026-06-25T10:01:59.5723421Z  
+2026-06-25T10:01:59.5723618Z  /// Initialise with a real SAC token, fund to target, and mint `TARGET` tokens
+2026-06-25T10:01:59.5723907Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/legal_hold.rs:121:
+2026-06-25T10:01:59.5723980Z          &None,
+2026-06-25T10:01:59.5724062Z          &None,
+2026-06-25T10:01:59.5724138Z      );
+2026-06-25T10:01:59.5724244Z -client.fund(investor, &TARGET);
+2026-06-25T10:01:59.5724340Z +    client.fund(investor, &TARGET);
+2026-06-25T10:01:59.5724442Z      sac_admin.mint(&escrow_id, &TARGET);
+2026-06-25T10:01:59.5724534Z      (client, escrow_id)
+2026-06-25T10:01:59.5724616Z  }
+2026-06-25T10:01:59.5724892Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/legal_hold.rs:171:
+2026-06-25T10:01:59.5724967Z          &None,
+2026-06-25T10:01:59.5725048Z          &None,
+2026-06-25T10:01:59.5725122Z      );
+2026-06-25T10:01:59.5725215Z -client.fund(investor, &TARGET);
+2026-06-25T10:01:59.5725306Z +    client.fund(investor, &TARGET);
+2026-06-25T10:01:59.5725397Z      client.settle();
+2026-06-25T10:01:59.5725497Z      (client, escrow_id, token, treasury)
+2026-06-25T10:01:59.5725574Z  }
+2026-06-25T10:01:59.5823311Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/settlement.rs:1797:
+2026-06-25T10:01:59.5823567Z          "settled_at must equal the ledger timestamp when settle() succeeds with maturity gate"
+2026-06-25T10:01:59.5823654Z      );
+2026-06-25T10:01:59.5823728Z  }
+2026-06-25T10:01:59.5823806Z -
+2026-06-25T10:01:59.5823879Z  
+2026-06-25T10:01:59.5980599Z ##[error]Process completed with exit code 1.
+2026-06-25T10:01:59.6115434Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-06-25T10:01:59.6115615Z Post job cleanup.
+2026-06-25T10:01:59.6967051Z [command]/usr/bin/git version
+2026-06-25T10:01:59.7004272Z git version 2.54.0
+2026-06-25T10:01:59.7039867Z Temporarily overriding HOME='/home/runner/work/_temp/b3b285e1-2f63-48a5-bdf0-05ac3304e3be' before making global git config changes
+2026-06-25T10:01:59.7040288Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-25T10:01:59.7045502Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T10:01:59.7082655Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-25T10:01:59.7117091Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-25T10:01:59.7345709Z fatal: No url found for submodule path 'Liquifact-contracts' in .gitmodules
+2026-06-25T10:01:59.7384126Z ##[warning]The process '/usr/bin/git' failed with exit code 128
+2026-06-25T10:01:59.7490871Z Cleaning up orphan processes
+2026-06-25T10:01:59.7761085Z ##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/ci_main.txt
+++ b/ci_main.txt
@@ -1,0 +1,460 @@
+﻿2026-06-25T03:40:00.2296481Z Current runner version: '2.335.1'
+2026-06-25T03:40:00.2322684Z ##[group]Runner Image Provisioner
+2026-06-25T03:40:00.2323637Z Hosted Compute Agent
+2026-06-25T03:40:00.2324272Z Version: 20260611.554
+2026-06-25T03:40:00.2324907Z Commit: 5e0782fdc9014723d3be820dd114dd31555c2bd1
+2026-06-25T03:40:00.2325731Z Build Date: 2026-06-11T21:40:46Z
+2026-06-25T03:40:00.2326454Z Worker ID: {fe555bbb-6400-4cef-95d2-068a1d9dc635}
+2026-06-25T03:40:00.2327222Z Azure Region: westcentralus
+2026-06-25T03:40:00.2327853Z ##[endgroup]
+2026-06-25T03:40:00.2329337Z ##[group]Operating System
+2026-06-25T03:40:00.2330065Z Ubuntu
+2026-06-25T03:40:00.2330636Z 24.04.4
+2026-06-25T03:40:00.2331138Z LTS
+2026-06-25T03:40:00.2331767Z ##[endgroup]
+2026-06-25T03:40:00.2332543Z ##[group]Runner Image
+2026-06-25T03:40:00.2333533Z Image: ubuntu-24.04
+2026-06-25T03:40:00.2334190Z Version: 20260615.205.1
+2026-06-25T03:40:00.2335508Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260615.205/images/ubuntu/Ubuntu2404-Readme.md
+2026-06-25T03:40:00.2337034Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260615.205
+2026-06-25T03:40:00.2338048Z ##[endgroup]
+2026-06-25T03:40:00.2339355Z ##[group]GITHUB_TOKEN Permissions
+2026-06-25T03:40:00.2341496Z Contents: read
+2026-06-25T03:40:00.2342662Z Metadata: read
+2026-06-25T03:40:00.2343266Z Packages: read
+2026-06-25T03:40:00.2343957Z ##[endgroup]
+2026-06-25T03:40:00.2346198Z Secret source: Actions
+2026-06-25T03:40:00.2347058Z Prepare workflow directory
+2026-06-25T03:40:00.2706734Z Prepare all required actions
+2026-06-25T03:40:00.2764035Z Getting action download info
+2026-06-25T03:40:00.6422435Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2026-06-25T03:40:00.7478580Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+2026-06-25T03:40:00.9833196Z Download action repository 'Swatinem/rust-cache@v2' (SHA:e18b497796c12c097a38f9edb9d0641fb99eee32)
+2026-06-25T03:40:02.0054574Z Download action repository 'taiki-e/install-action@cargo-llvm-cov' (SHA:901c6c5742b8b5bab0a7cf0bf63286ad5e3120f3)
+2026-06-25T03:40:02.8925531Z Complete job name: fmt-build-test
+2026-06-25T03:40:02.9876441Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-06-25T03:40:02.9888016Z ##[group]Run actions/checkout@v4
+2026-06-25T03:40:02.9889231Z with:
+2026-06-25T03:40:02.9890082Z   repository: Liquifact/Liquifact-contracts
+2026-06-25T03:40:02.9900427Z   token: ***
+2026-06-25T03:40:02.9901233Z   ssh-strict: true
+2026-06-25T03:40:02.9902176Z   ssh-user: git
+2026-06-25T03:40:02.9903008Z   persist-credentials: true
+2026-06-25T03:40:02.9903921Z   clean: true
+2026-06-25T03:40:02.9904749Z   sparse-checkout-cone-mode: true
+2026-06-25T03:40:02.9905845Z   fetch-depth: 1
+2026-06-25T03:40:02.9906653Z   fetch-tags: false
+2026-06-25T03:40:02.9907492Z   show-progress: true
+2026-06-25T03:40:02.9908337Z   lfs: false
+2026-06-25T03:40:02.9909126Z   submodules: false
+2026-06-25T03:40:02.9909967Z   set-safe-directory: true
+2026-06-25T03:40:02.9911153Z ##[endgroup]
+2026-06-25T03:40:03.0925095Z Syncing repository: Liquifact/Liquifact-contracts
+2026-06-25T03:40:03.0928610Z ##[group]Getting Git version info
+2026-06-25T03:40:03.0930315Z Working directory is '/home/runner/work/Liquifact-contracts/Liquifact-contracts'
+2026-06-25T03:40:03.0932954Z [command]/usr/bin/git version
+2026-06-25T03:40:03.0998385Z git version 2.54.0
+2026-06-25T03:40:03.1022217Z ##[endgroup]
+2026-06-25T03:40:03.1038669Z Temporarily overriding HOME='/home/runner/work/_temp/3625da43-85c7-48a8-a6c6-4b27f319c2fe' before making global git config changes
+2026-06-25T03:40:03.1043900Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-25T03:40:03.1048353Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T03:40:03.1099395Z Deleting the contents of '/home/runner/work/Liquifact-contracts/Liquifact-contracts'
+2026-06-25T03:40:03.1104186Z ##[group]Initializing the repository
+2026-06-25T03:40:03.1109540Z [command]/usr/bin/git init /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T03:40:03.1224573Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-06-25T03:40:03.1227450Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-06-25T03:40:03.1299444Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-06-25T03:40:03.1301153Z hint: call:
+2026-06-25T03:40:03.1302157Z hint:
+2026-06-25T03:40:03.1303112Z hint: 	git config --global init.defaultBranch <name>
+2026-06-25T03:40:03.1304266Z hint:
+2026-06-25T03:40:03.1305331Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-06-25T03:40:03.1307152Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-06-25T03:40:03.1308593Z hint:
+2026-06-25T03:40:03.1309909Z hint: 	git branch -m <name>
+2026-06-25T03:40:03.1311312Z hint:
+2026-06-25T03:40:03.1313658Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-06-25T03:40:03.1315999Z Initialized empty Git repository in /home/runner/work/Liquifact-contracts/Liquifact-contracts/.git/
+2026-06-25T03:40:03.1319608Z [command]/usr/bin/git remote add origin https://github.com/Liquifact/Liquifact-contracts
+2026-06-25T03:40:03.1324030Z ##[endgroup]
+2026-06-25T03:40:03.1325472Z ##[group]Disabling automatic garbage collection
+2026-06-25T03:40:03.1327293Z [command]/usr/bin/git config --local gc.auto 0
+2026-06-25T03:40:03.1331158Z ##[endgroup]
+2026-06-25T03:40:03.1332892Z ##[group]Setting up auth
+2026-06-25T03:40:03.1335792Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-25T03:40:03.1371343Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-25T03:40:03.1749753Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-06-25T03:40:03.1781561Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-06-25T03:40:03.2011768Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-06-25T03:40:03.2050451Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-06-25T03:40:03.2280305Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-06-25T03:40:03.2316336Z ##[endgroup]
+2026-06-25T03:40:03.2317814Z ##[group]Fetching the repository
+2026-06-25T03:40:03.2326029Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f3c49bc43a4afd486efc2e2beb59bd144adb5029:refs/remotes/origin/main
+2026-06-25T03:40:04.1902937Z From https://github.com/Liquifact/Liquifact-contracts
+2026-06-25T03:40:04.1905404Z  * [new ref]         f3c49bc43a4afd486efc2e2beb59bd144adb5029 -> origin/main
+2026-06-25T03:40:04.1939038Z ##[endgroup]
+2026-06-25T03:40:04.1939828Z ##[group]Determining the checkout info
+2026-06-25T03:40:04.1941581Z ##[endgroup]
+2026-06-25T03:40:04.1947170Z [command]/usr/bin/git sparse-checkout disable
+2026-06-25T03:40:04.1995055Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-06-25T03:40:04.2022899Z ##[group]Checking out the ref
+2026-06-25T03:40:04.2027457Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2026-06-25T03:40:04.2420646Z Switched to a new branch 'main'
+2026-06-25T03:40:04.2422416Z branch 'main' set up to track 'origin/main'.
+2026-06-25T03:40:04.2429668Z ##[endgroup]
+2026-06-25T03:40:04.2473687Z [command]/usr/bin/git log -1 --format=%H
+2026-06-25T03:40:04.2496659Z f3c49bc43a4afd486efc2e2beb59bd144adb5029
+2026-06-25T03:40:04.2840189Z ##[group]Run dtolnay/rust-toolchain@stable
+2026-06-25T03:40:04.2840633Z with:
+2026-06-25T03:40:04.2840936Z   components: rustfmt, clippy, llvm-tools-preview
+2026-06-25T03:40:04.2841302Z   toolchain: stable
+2026-06-25T03:40:04.2841568Z ##[endgroup]
+2026-06-25T03:40:04.2966157Z ##[group]Run : parse toolchain version
+2026-06-25T03:40:04.2966618Z [36;1m: parse toolchain version[0m
+2026-06-25T03:40:04.2966961Z [36;1mif [[ -z $toolchain ]]; then[0m
+2026-06-25T03:40:04.2967581Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+2026-06-25T03:40:04.2968224Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+2026-06-25T03:40:04.2968575Z [36;1m  exit 1[0m
+2026-06-25T03:40:04.2968991Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+2026-06-25T03:40:04.2969465Z [36;1m  if [[ Linux == macOS ]]; then[0m
+2026-06-25T03:40:04.2970096Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-06-25T03:40:04.2970664Z [36;1m  else[0m
+2026-06-25T03:40:04.2971128Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-06-25T03:40:04.2971642Z [36;1m  fi[0m
+2026-06-25T03:40:04.2972466Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+2026-06-25T03:40:04.2973102Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+2026-06-25T03:40:04.2973629Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+2026-06-25T03:40:04.2974218Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+2026-06-25T03:40:04.2974786Z [36;1melse[0m
+2026-06-25T03:40:04.2975084Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+2026-06-25T03:40:04.2975439Z [36;1mfi[0m
+2026-06-25T03:40:04.3172281Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:04.3172765Z env:
+2026-06-25T03:40:04.3173043Z   toolchain: stable
+2026-06-25T03:40:04.3173337Z ##[endgroup]
+2026-06-25T03:40:04.3321384Z ##[group]Run : construct rustup command line
+2026-06-25T03:40:04.3321790Z [36;1m: construct rustup command line[0m
+2026-06-25T03:40:04.3322834Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+2026-06-25T03:40:04.3323559Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+2026-06-25T03:40:04.3324108Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+2026-06-25T03:40:04.3353497Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:04.3353928Z env:
+2026-06-25T03:40:04.3354164Z   targets: 
+2026-06-25T03:40:04.3354463Z   components: rustfmt, clippy, llvm-tools-preview
+2026-06-25T03:40:04.3354817Z ##[endgroup]
+2026-06-25T03:40:04.3439515Z ##[group]Run : set $CARGO_HOME
+2026-06-25T03:40:04.3439852Z [36;1m: set $CARGO_HOME[0m
+2026-06-25T03:40:04.3440231Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+2026-06-25T03:40:04.3467896Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:04.3468304Z ##[endgroup]
+2026-06-25T03:40:04.3550574Z ##[group]Run : install rustup if needed
+2026-06-25T03:40:04.3550946Z [36;1m: install rustup if needed[0m
+2026-06-25T03:40:04.3551302Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+2026-06-25T03:40:04.3552415Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+2026-06-25T03:40:04.3553216Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+2026-06-25T03:40:04.3553736Z [36;1mfi[0m
+2026-06-25T03:40:04.3581290Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:04.3581689Z env:
+2026-06-25T03:40:04.3582410Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:04.3582739Z ##[endgroup]
+2026-06-25T03:40:04.3665439Z ##[group]Run rustup toolchain install stable --component rustfmt --component clippy --component llvm-tools-preview --profile minimal --no-self-update
+2026-06-25T03:40:04.3666550Z [36;1mrustup toolchain install stable --component rustfmt --component clippy --component llvm-tools-preview --profile minimal --no-self-update[0m
+2026-06-25T03:40:04.3694592Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:04.3694992Z env:
+2026-06-25T03:40:04.3695251Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:04.3695572Z   RUSTUP_PERMIT_COPY_RENAME: 1
+2026-06-25T03:40:04.3695859Z ##[endgroup]
+2026-06-25T03:40:07.5268860Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+2026-06-25T03:40:07.8337278Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T03:40:07.8465458Z info: component clippy is up to date
+2026-06-25T03:40:07.8466243Z info: component rustfmt is up to date
+2026-06-25T03:40:07.8476022Z info: downloading component llvm-tools
+2026-06-25T03:40:11.0726954Z 
+2026-06-25T03:40:11.0812784Z   stable-x86_64-unknown-linux-gnu updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.96.0 (ac68faa20 2026-05-25))
+2026-06-25T03:40:11.0813576Z 
+2026-06-25T03:40:11.0881425Z ##[group]Run rustup default stable
+2026-06-25T03:40:11.0881740Z [36;1mrustup default stable[0m
+2026-06-25T03:40:11.0913094Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:11.0913450Z env:
+2026-06-25T03:40:11.0913683Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:11.0913946Z ##[endgroup]
+2026-06-25T03:40:11.1021166Z info: using existing install for stable-x86_64-unknown-linux-gnu
+2026-06-25T03:40:11.1028365Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+2026-06-25T03:40:11.1028795Z 
+2026-06-25T03:40:11.1113750Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T03:40:11.1114301Z 
+2026-06-25T03:40:11.1175852Z ##[group]Run : create cachekey
+2026-06-25T03:40:11.1176356Z [36;1m: create cachekey[0m
+2026-06-25T03:40:11.1177292Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+2026-06-25T03:40:11.1178494Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+2026-06-25T03:40:11.1179258Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+2026-06-25T03:40:11.1210265Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:11.1210617Z env:
+2026-06-25T03:40:11.1210827Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:11.1211086Z ##[endgroup]
+2026-06-25T03:40:11.2619398Z ##[group]Run : disable incremental compilation
+2026-06-25T03:40:11.2619818Z [36;1m: disable incremental compilation[0m
+2026-06-25T03:40:11.2620155Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+2026-06-25T03:40:11.2620508Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+2026-06-25T03:40:11.2620803Z [36;1mfi[0m
+2026-06-25T03:40:11.2651527Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:11.2652242Z env:
+2026-06-25T03:40:11.2652472Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:11.2652732Z ##[endgroup]
+2026-06-25T03:40:11.2723541Z ##[group]Run : enable colors in Cargo output
+2026-06-25T03:40:11.2723875Z [36;1m: enable colors in Cargo output[0m
+2026-06-25T03:40:11.2724186Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+2026-06-25T03:40:11.2724525Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+2026-06-25T03:40:11.2724823Z [36;1mfi[0m
+2026-06-25T03:40:11.2754032Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:11.2754373Z env:
+2026-06-25T03:40:11.2754747Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:11.2755019Z   CARGO_INCREMENTAL: 0
+2026-06-25T03:40:11.2755238Z ##[endgroup]
+2026-06-25T03:40:11.2824962Z ##[group]Run : enable Cargo sparse registry
+2026-06-25T03:40:11.2825480Z [36;1m: enable Cargo sparse registry[0m
+2026-06-25T03:40:11.2825856Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+2026-06-25T03:40:11.2826560Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+2026-06-25T03:40:11.2827286Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+2026-06-25T03:40:11.2827850Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-06-25T03:40:11.2828391Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+2026-06-25T03:40:11.2828899Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+2026-06-25T03:40:11.2829483Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-06-25T03:40:11.2830009Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+2026-06-25T03:40:11.2830362Z [36;1m  fi[0m
+2026-06-25T03:40:11.2830561Z [36;1mfi[0m
+2026-06-25T03:40:11.2859687Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:11.2860035Z env:
+2026-06-25T03:40:11.2860243Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:11.2860512Z   CARGO_INCREMENTAL: 0
+2026-06-25T03:40:11.2860739Z   CARGO_TERM_COLOR: always
+2026-06-25T03:40:11.2860964Z ##[endgroup]
+2026-06-25T03:40:11.3239075Z ##[group]Run : work around spurious network errors in curl 8.0
+2026-06-25T03:40:11.3239530Z [36;1m: work around spurious network errors in curl 8.0[0m
+2026-06-25T03:40:11.3240091Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+2026-06-25T03:40:11.3240738Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+2026-06-25T03:40:11.3241217Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+2026-06-25T03:40:11.3241533Z [36;1mfi[0m
+2026-06-25T03:40:11.3272498Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:11.3272848Z env:
+2026-06-25T03:40:11.3273050Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:11.3273305Z   CARGO_INCREMENTAL: 0
+2026-06-25T03:40:11.3273527Z   CARGO_TERM_COLOR: always
+2026-06-25T03:40:11.3273752Z ##[endgroup]
+2026-06-25T03:40:11.3490829Z ##[group]Run rustc +stable --version --verbose
+2026-06-25T03:40:11.3491189Z [36;1mrustc +stable --version --verbose[0m
+2026-06-25T03:40:11.3521645Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-25T03:40:11.3522268Z env:
+2026-06-25T03:40:11.3522487Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:11.3522749Z   CARGO_INCREMENTAL: 0
+2026-06-25T03:40:11.3522982Z   CARGO_TERM_COLOR: always
+2026-06-25T03:40:11.3523207Z ##[endgroup]
+2026-06-25T03:40:11.3696253Z rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-25T03:40:11.3697075Z binary: rustc
+2026-06-25T03:40:11.3697684Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T03:40:11.3698372Z commit-date: 2026-05-25
+2026-06-25T03:40:11.3698921Z host: x86_64-unknown-linux-gnu
+2026-06-25T03:40:11.3699342Z release: 1.96.0
+2026-06-25T03:40:11.3699601Z LLVM version: 22.1.2
+2026-06-25T03:40:11.3825620Z ##[group]Run Swatinem/rust-cache@v2
+2026-06-25T03:40:11.3825930Z with:
+2026-06-25T03:40:11.3826134Z   prefix-key: v0-rust
+2026-06-25T03:40:11.3826371Z   add-job-id-key: true
+2026-06-25T03:40:11.3826617Z   add-rust-environment-hash-key: true
+2026-06-25T03:40:11.3826893Z   cache-targets: true
+2026-06-25T03:40:11.3827113Z   cache-all-crates: false
+2026-06-25T03:40:11.3827353Z   cache-workspace-crates: false
+2026-06-25T03:40:11.3827596Z   save-if: true
+2026-06-25T03:40:11.3827806Z   cache-provider: github
+2026-06-25T03:40:11.3828033Z   cache-bin: true
+2026-06-25T03:40:11.3828244Z   lookup-only: false
+2026-06-25T03:40:11.3828649Z   cmd-format: {0}
+2026-06-25T03:40:11.3828846Z env:
+2026-06-25T03:40:11.3829043Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:11.3829302Z   CARGO_INCREMENTAL: 0
+2026-06-25T03:40:11.3829525Z   CARGO_TERM_COLOR: always
+2026-06-25T03:40:11.3829749Z ##[endgroup]
+2026-06-25T03:40:11.6961538Z (node:2433) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+2026-06-25T03:40:11.6963474Z (Use `node --trace-deprecation ...` to show where the warning was created)
+2026-06-25T03:40:15.8135105Z ##[group]Cache Configuration
+2026-06-25T03:40:15.8135998Z Cache Provider:
+2026-06-25T03:40:15.8136548Z     github
+2026-06-25T03:40:15.8137055Z Workspaces:
+2026-06-25T03:40:15.8137719Z     /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T03:40:15.8138483Z Cache Paths:
+2026-06-25T03:40:15.8139017Z     /home/runner/.cargo/bin
+2026-06-25T03:40:15.8139640Z     /home/runner/.cargo/.crates.toml
+2026-06-25T03:40:15.8140270Z     /home/runner/.cargo/.crates2.json
+2026-06-25T03:40:15.8140878Z     /home/runner/.cargo/registry
+2026-06-25T03:40:15.8141461Z     /home/runner/.cargo/git
+2026-06-25T03:40:15.8142664Z     /home/runner/work/Liquifact-contracts/Liquifact-contracts/target
+2026-06-25T03:40:15.8143361Z Restore Key:
+2026-06-25T03:40:15.8143777Z     v0-rust-fmt-build-test-Linux-x64-4107bf91
+2026-06-25T03:40:15.8144308Z Cache Key:
+2026-06-25T03:40:15.8144759Z     v0-rust-fmt-build-test-Linux-x64-4107bf91-e1b782ec
+2026-06-25T03:40:15.8145317Z .. Prefix:
+2026-06-25T03:40:15.8145693Z   - v0-rust-fmt-build-test-Linux-x64
+2026-06-25T03:40:15.8146194Z .. Environment considered:
+2026-06-25T03:40:15.8146597Z   - Rust Versions:
+2026-06-25T03:40:15.8147169Z     - 1.96.0 x86_64-unknown-linux-gnu ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T03:40:15.8148025Z     - 1.96.0 x86_64-unknown-linux-gnu ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-25T03:40:15.8148667Z   - CARGO_HOME
+2026-06-25T03:40:15.8149006Z   - CARGO_INCREMENTAL
+2026-06-25T03:40:15.8149387Z   - CARGO_TERM_COLOR
+2026-06-25T03:40:15.8149758Z .. Lockfiles considered:
+2026-06-25T03:40:15.8150351Z   - /home/runner/work/Liquifact-contracts/Liquifact-contracts/Cargo.lock
+2026-06-25T03:40:15.8151424Z   - /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/Cargo.toml
+2026-06-25T03:40:15.8152690Z ##[endgroup]
+2026-06-25T03:40:15.8152894Z 
+2026-06-25T03:40:15.8153054Z ... Restoring cache ...
+2026-06-25T03:40:16.0323653Z No cache found.
+2026-06-25T03:40:16.0447536Z ##[group]Run cargo fmt -p liquifact_escrow -- --check
+2026-06-25T03:40:16.0448268Z [36;1mcargo fmt -p liquifact_escrow -- --check[0m
+2026-06-25T03:40:16.0480289Z shell: /usr/bin/bash -e {0}
+2026-06-25T03:40:16.0480539Z env:
+2026-06-25T03:40:16.0480738Z   CARGO_HOME: /home/runner/.cargo
+2026-06-25T03:40:16.0481003Z   CARGO_INCREMENTAL: 0
+2026-06-25T03:40:16.0481227Z   CARGO_TERM_COLOR: always
+2026-06-25T03:40:16.0481460Z   CACHE_ON_FAILURE: false
+2026-06-25T03:40:16.0481679Z ##[endgroup]
+2026-06-25T03:40:19.5050588Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/lib.rs:2201:
+2026-06-25T03:40:19.5051767Z          let n = entries.len();
+2026-06-25T03:40:19.5052676Z  
+2026-06-25T03:40:19.5059096Z          ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
+2026-06-25T03:40:19.5059484Z -        ensure(
+2026-06-25T03:40:19.5059714Z -            &env,
+2026-06-25T03:40:19.5059952Z -            n <= MAX_FUND_BATCH,
+2026-06-25T03:40:19.5060333Z -            EscrowError::FundingBatchTooLarge,
+2026-06-25T03:40:19.5060647Z -        );
+2026-06-25T03:40:19.5060977Z +        ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
+2026-06-25T03:40:19.5061382Z  
+2026-06-25T03:40:19.5061630Z          let mut escrow = Self::get_escrow(env.clone());
+2026-06-25T03:40:19.5062392Z  
+2026-06-25T03:40:19.5310027Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:777:
+2026-06-25T03:40:19.5310957Z  fn test_update_funding_target_fails_when_withdrawn() {
+2026-06-25T03:40:19.5312151Z      let env = Env::default();
+2026-06-25T03:40:19.5312618Z      env.mock_all_auths();
+2026-06-25T03:40:19.5313044Z -    let (client, _escrow_id, _sme) =
+2026-06-25T03:40:19.5313624Z -        init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+2026-06-25T03:40:19.5314458Z +    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+2026-06-25T03:40:19.5315554Z      client.withdraw(); // status → 3 (withdrawn)
+2026-06-25T03:40:19.5316164Z      client.update_funding_target(&6_000i128);
+2026-06-25T03:40:19.5316647Z  }
+2026-06-25T03:40:19.5317334Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/admin.rs:984:
+2026-06-25T03:40:19.5318256Z  fn test_update_maturity_fails_when_withdrawn() {
+2026-06-25T03:40:19.5318817Z      let env = Env::default();
+2026-06-25T03:40:19.5319240Z      env.mock_all_auths();
+2026-06-25T03:40:19.5319656Z -    let (client, _escrow_id, _sme) =
+2026-06-25T03:40:19.5320230Z -        init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+2026-06-25T03:40:19.5321095Z +    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+2026-06-25T03:40:19.5322182Z      client.withdraw(); // status → 3
+2026-06-25T03:40:19.5322677Z      client.update_maturity(&2000u64);
+2026-06-25T03:40:19.5323119Z  }
+2026-06-25T03:40:19.6332450Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/init.rs:581:
+2026-06-25T03:40:19.6333538Z  fn test_get_treasury_before_init_fails_with_typed_error() {
+2026-06-25T03:40:19.6334206Z      let env = Env::default();
+2026-06-25T03:40:19.6334724Z      let client = deploy(&env);
+2026-06-25T03:40:19.6335165Z -    assert_contract_error(
+2026-06-25T03:40:19.6335594Z -        client.try_get_treasury(),
+2026-06-25T03:40:19.6336112Z -        EscrowError::TreasuryNotSet,
+2026-06-25T03:40:19.6336568Z -    );
+2026-06-25T03:40:19.6337151Z +    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
+2026-06-25T03:40:19.6337884Z  }
+2026-06-25T03:40:19.6338177Z  
+2026-06-25T03:40:19.6338476Z  #[test]
+2026-06-25T03:40:19.6386203Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:890:
+2026-06-25T03:40:19.6387128Z      env.mock_all_auths();
+2026-06-25T03:40:19.6387539Z  
+2026-06-25T03:40:19.6387872Z      let target = 50_000_000i128;
+2026-06-25T03:40:19.6388340Z -    let (client, escrow_id, token, sme) =
+2026-06-25T03:40:19.6389396Z -        setup_withdraw_with_token(&env, target, "WD_BAL001");
+2026-06-25T03:40:19.6390291Z +    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
+2026-06-25T03:40:19.6391106Z  
+2026-06-25T03:40:19.6391444Z      let sme_before = token.balance(&sme);
+2026-06-25T03:40:19.6392279Z      let contract_before = token.balance(&escrow_id);
+2026-06-25T03:40:19.6393250Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:898:
+2026-06-25T03:40:19.6394498Z -    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
+2026-06-25T03:40:19.6395327Z +    assert_eq!(
+2026-06-25T03:40:19.6395699Z +        contract_before, target,
+2026-06-25T03:40:19.6396254Z +        "escrow must hold exactly funded_amount before withdraw"
+2026-06-25T03:40:19.6396988Z +    );
+2026-06-25T03:40:19.6397299Z  
+2026-06-25T03:40:19.6397615Z      client.withdraw();
+2026-06-25T03:40:19.6397987Z  
+2026-06-25T03:40:19.6398714Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:911:
+2026-06-25T03:40:19.6399604Z          contract_after, 0,
+2026-06-25T03:40:19.6400141Z          "escrow contract balance must be zero after disbursement"
+2026-06-25T03:40:19.6400744Z      );
+2026-06-25T03:40:19.6401322Z -    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
+2026-06-25T03:40:19.6402384Z +    assert_eq!(
+2026-06-25T03:40:19.6402879Z +        client.get_escrow().status,
+2026-06-25T03:40:19.6403565Z +        3u32,
+2026-06-25T03:40:19.6403949Z +        "status must be 3 after withdraw"
+2026-06-25T03:40:19.6404407Z +    );
+2026-06-25T03:40:19.6404707Z  }
+2026-06-25T03:40:19.6405002Z  
+2026-06-25T03:40:19.6405483Z  /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
+2026-06-25T03:40:19.6406533Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:921:
+2026-06-25T03:40:19.6407420Z      env.mock_all_auths();
+2026-06-25T03:40:19.6407817Z  
+2026-06-25T03:40:19.6408141Z      let target = 20_000_000i128;
+2026-06-25T03:40:19.6408615Z -    let (client, _escrow_id, _token, _sme) =
+2026-06-25T03:40:19.6409215Z -        setup_withdraw_with_token(&env, target, "WD_DP001");
+2026-06-25T03:40:19.6410071Z +    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
+2026-06-25T03:40:19.6410817Z  
+2026-06-25T03:40:19.6411132Z      client.withdraw();
+2026-06-25T03:40:19.6411505Z  
+2026-06-25T03:40:19.6412468Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:1058:
+2026-06-25T03:40:19.6413388Z      env.mock_all_auths();
+2026-06-25T03:40:19.6413770Z  
+2026-06-25T03:40:19.6414092Z      let target = 5_000_000i128;
+2026-06-25T03:40:19.6414548Z -    let (client, escrow_id, _token, sme) =
+2026-06-25T03:40:19.6415147Z -        setup_withdraw_with_token(&env, target, "WD_EV001");
+2026-06-25T03:40:19.6415985Z +    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
+2026-06-25T03:40:19.6416714Z  
+2026-06-25T03:40:19.6417033Z      client.withdraw();
+2026-06-25T03:40:19.6417402Z  
+2026-06-25T03:40:19.6418131Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/integration.rs:1074:
+2026-06-25T03:40:19.6419127Z      .to_xdr(&env, &escrow_id);
+2026-06-25T03:40:19.6419569Z  
+2026-06-25T03:40:19.6420046Z      let all_events = env.events().all().filter_by_contract(&escrow_id);
+2026-06-25T03:40:19.6420684Z -    let found = all_events
+2026-06-25T03:40:19.6421089Z -        .events()
+2026-06-25T03:40:19.6421438Z -        .iter()
+2026-06-25T03:40:19.6421807Z -        .any(|e| *e == expected_xdr);
+2026-06-25T03:40:19.6422935Z -    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
+2026-06-25T03:40:19.6423872Z +    let found = all_events.events().iter().any(|e| *e == expected_xdr);
+2026-06-25T03:40:19.6424483Z +    assert!(
+2026-06-25T03:40:19.6424805Z +        found,
+2026-06-25T03:40:19.6425583Z +        "SmeWithdrew event with correct recipient and amount must be emitted"
+2026-06-25T03:40:19.6426274Z +    );
+2026-06-25T03:40:19.6426576Z  }
+2026-06-25T03:40:19.6426912Z  
+2026-06-25T03:40:19.6722991Z Diff in /home/runner/work/Liquifact-contracts/Liquifact-contracts/escrow/src/tests/settlement.rs:45:
+2026-06-25T03:40:19.6724159Z  /// actually transfer them.  Returns `(client, sme, sac_admin_client)`.
+2026-06-25T03:40:19.6724833Z  fn setup_funded_with_token<'a>(
+2026-06-25T03:40:19.6725256Z      env: &'a Env,
+2026-06-25T03:40:19.6725906Z -) -> (super::LiquifactEscrowClient<'a>, Address, StellarAssetClient<'a>) {
+2026-06-25T03:40:19.6726608Z +) -> (
+2026-06-25T03:40:19.6726992Z +    super::LiquifactEscrowClient<'a>,
+2026-06-25T03:40:19.6727472Z +    Address,
+2026-06-25T03:40:19.6727844Z +    StellarAssetClient<'a>,
+2026-06-25T03:40:19.6728266Z +) {
+2026-06-25T03:40:19.6728809Z      let sac = env.register_stellar_asset_contract_v2(Address::generate(env));
+2026-06-25T03:40:19.6729515Z      let token_id = sac.address();
+2026-06-25T03:40:19.6730091Z      let sac_admin = StellarAssetClient::new(env, &token_id);
+2026-06-25T03:40:19.7226918Z ##[error]Process completed with exit code 1.
+2026-06-25T03:40:19.7383981Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-06-25T03:40:19.7385704Z Post job cleanup.
+2026-06-25T03:40:19.8216988Z [command]/usr/bin/git version
+2026-06-25T03:40:19.8254551Z git version 2.54.0
+2026-06-25T03:40:19.8293850Z Temporarily overriding HOME='/home/runner/work/_temp/76f73d27-fd7a-4a1a-a125-312b33576101' before making global git config changes
+2026-06-25T03:40:19.8295942Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-25T03:40:19.8300433Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/Liquifact-contracts/Liquifact-contracts
+2026-06-25T03:40:19.8336411Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-25T03:40:19.8367535Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-25T03:40:19.8582644Z fatal: No url found for submodule path 'Liquifact-contracts' in .gitmodules
+2026-06-25T03:40:19.8622458Z ##[warning]The process '/usr/bin/git' failed with exit code 128
+2026-06-25T03:40:19.8721676Z Cleaning up orphan processes
+2026-06-25T03:40:19.8989100Z ##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/docs/escrow-data-model.md
+++ b/docs/escrow-data-model.md
@@ -53,8 +53,11 @@ with `unwrap_or(0)`.
 | `FundingCloseSnapshot` | `FundingCloseSnapshot` | `fund_impl` on first transition to `status == 1` | Immutable once written |
 | `SmeCollateralPledge` | `SmeCollateralCommitment` | `record_sme_collateral_commitment` | Record-only; replaceable by SME |
 | `MaxUniqueInvestorsCap` | `u32` | `init` (when `max_unique_investors` arg is `Some`) | Absent means unlimited |
+| `MaxPerInvestorCap` | `i128` | `init` (when `max_per_investor` arg is `Some`) | Absent means unlimited |
 | `PrimaryAttestationHash` | `BytesN<32>` | `bind_primary_attestation_hash` | Single-set; panics on second call |
 | `AttestationAppendLog` | `Vec<BytesN<32>>` | `append_attestation_digest` | Bounded by `MAX_ATTESTATION_APPEND_ENTRIES` (32) |
+| `SettledAt` | `u64` | `settle` on status 1→2 transition | Write-once; `None` before settlement; legacy-safe |
+| `FundingDeadline` | `u64` | `init` (when `funding_deadline` arg is `Some`) | Ledger timestamp; new funds rejected after this |
 
 ### Per-address investor keys in persistent storage
 

--- a/docs/escrow-ledger-time.md
+++ b/docs/escrow-ledger-time.md
@@ -62,6 +62,44 @@ investor is never time-gated and may claim immediately after settlement.
 The `recorded_at` field is set to `env.ledger().timestamp()` for
 indexing only. It does not gate any operations.
 
+### 4. Settlement Timestamp — `SettledAt` and `get_settled_at`
+
+When `settle()` transitions an escrow from status 1 (funded) to status 2 (settled), 
+the contract captures the ledger timestamp for audit and accounting:
+
+```rust
+let now = env.ledger().timestamp();
+env.storage().instance().set(&DataKey::SettledAt, &now);
+```
+
+**Write-once policy:** this key is set exactly once per escrow, because `settle()` can only be 
+called from status 1. The stored timestamp never changes once settlement occurs.
+
+#### Reading the settlement timestamp
+
+The view function `get_settled_at(env: Env) -> Option<u64>` retrieves the settlement timestamp:
+
+```rust
+pub fn get_settled_at(env: Env) -> Option<u64> {
+    env.storage().instance().get(&DataKey::SettledAt)
+}
+```
+
+| Escrow state | Return value | Interpretation |
+|--------------|--------------|----------------|
+| Not yet settled (status 0 or 1) | `None` | Settlement has not occurred |
+| Settled (status 2, 3, or 4 after settlement) | `Some(timestamp)` | Ledger timestamp when `settle()` was called |
+| Legacy instance (deployed before this feature) | `None` | Additive-key policy — no migration required |
+
+**Use cases:**
+- Claim accounting: determine settlement timestamp for investor payouts
+- Dispute resolution: authoritative on-chain record of settlement moment
+- Reporting: calculate time-to-settlement, track settlement patterns
+- Event pruning safety: settlement timestamp persists even if `EscrowSettled` event is pruned
+
+**Note:** The `EscrowSettled` event also includes `settled_at_ledger_timestamp`, but the storage 
+key provides a permanent, query-friendly view that survives network event retention policies.
+
 ---
 
 ## `claim_investor_payout` — Idempotency
@@ -268,5 +306,8 @@ ledger timestamp (seconds since Unix epoch, inclusive).
 - **Idempotency is not trustless skipping:** the early return in
   `claim_investor_payout` only fires after `investor.require_auth()`;
   it cannot be exploited to skip the auth check.
+- **Settlement timestamp write-once:** `DataKey::SettledAt` is only written inside `settle()` at
+  the status 1→2 transition. There is no path to overwrite or delete the key after it is set.
+  `get_settled_at` is a pure read — it performs no mutation and has no auth requirement.
 - **Token economics:** time-based yield calculations are out of scope.
   See `escrow/src/external_calls.rs` for token transfer assumptions.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -492,6 +492,12 @@ pub enum DataKey {
     DistributedPrincipal,
     /// Optional funding deadline (ledger timestamp); after it passes, new funds are rejected.
     FundingDeadline,
+    /// Ledger timestamp (seconds since Unix epoch) recorded exactly once when `status` transitions
+    /// from 1 → 2 inside [`LiquifactEscrow::settle`].
+    ///
+    /// **Write-once:** written by `settle` only; the getter returns [`None`] on legacy instances
+    /// where this key was never written (ADR-007 additive-key policy).
+    SettledAt,
 }
 
 // --- Data types ---
@@ -1668,6 +1674,19 @@ impl LiquifactEscrow {
         env.storage().instance().get(&DataKey::FundingCloseSnapshot)
     }
 
+    /// Returns the ledger timestamp (seconds since Unix epoch) at which [`LiquifactEscrow::settle`]
+    /// transitioned status from 1 → 2, or [`None`] if the escrow has not yet been settled.
+    ///
+    /// **Additive-key policy (ADR-007):** legacy escrow instances that were settled before this key
+    /// was introduced will return [`None`] because [`DataKey::SettledAt`] was never written.
+    ///
+    /// # Returns
+    /// - `Some(timestamp)` — the ledger timestamp at the moment `settle()` was called.
+    /// - `None` — escrow is not yet settled, or is a legacy instance predating this key.
+    pub fn get_settled_at(env: Env) -> Option<u64> {
+        env.storage().instance().get(&DataKey::SettledAt)
+    }
+
     /// Effective yield (bps) for this investor after their **first** deposit; later [`LiquifactEscrow::fund`]
     /// calls add principal at this rate. Defaults to [`InvoiceEscrow::yield_bps`] when unset (legacy positions).
     ///
@@ -2499,6 +2518,10 @@ impl LiquifactEscrow {
         }
 
         escrow.status = 2;
+
+        // Write-once settlement timestamp (ADR-007 additive-key policy).
+        // settle() is only reachable from status 1, so this key is set exactly once per escrow.
+        env.storage().instance().set(&DataKey::SettledAt, &now);
 
         env.storage().instance().set(&DataKey::Escrow, &escrow);
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -351,7 +351,7 @@ pub enum EscrowError {
     /// Computing the legal-hold clear ready-at timestamp would overflow.
     LegalHoldClearDelayOverflow = 152,
     /// Funding deadline has passed, new deposits are rejected.
-    FundingDeadlinePassed = 164,
+    FundingDeadlinePassed = 153,
 
     /// A legal hold blocks rotating the beneficiary (SME) address.
     LegalHoldBlocksBeneficiaryRotation = 160,

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2220,11 +2220,7 @@ impl LiquifactEscrow {
         let n = entries.len();
 
         ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
-        ensure(
-            &env,
-            n <= MAX_FUND_BATCH,
-            EscrowError::FundingBatchTooLarge,
-        );
+        ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
 
         let mut escrow = Self::get_escrow(env.clone());
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1687,6 +1687,30 @@ impl LiquifactEscrow {
         env.storage().instance().get(&DataKey::SettledAt)
     }
 
+    /// Returns `true` if the escrow can be settled now, `false` otherwise.
+    ///
+    /// Checks:
+    /// - Status must be 1 (funded)
+    /// - No legal hold active
+    /// - If `maturity > 0`, ledger timestamp must be `>= maturity`
+    ///
+    /// # Panics
+    /// Panics with [`EscrowError::EscrowNotInitialized`] if `init` has not been called.
+    pub fn is_settleable(env: Env) -> bool {
+        if Self::legal_hold_active(&env) {
+            return false;
+        }
+        let escrow = Self::get_escrow(env.clone());
+        if escrow.status != 1 {
+            return false;
+        }
+        if escrow.maturity > 0 {
+            let now = env.ledger().timestamp();
+            return now >= escrow.maturity;
+        }
+        true
+    }
+
     /// Effective yield (bps) for this investor after their **first** deposit; later [`LiquifactEscrow::fund`]
     /// calls add principal at this rate. Defaults to [`InvoiceEscrow::yield_bps`] when unset (legacy positions).
     ///

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1053,6 +1053,7 @@ impl LiquifactEscrow {
         max_per_investor: Option<i128>,
         legal_hold_clear_delay: Option<u64>,
         funding_deadline: Option<u64>,
+        allowlist_active: Option<bool>,
     ) -> InvoiceEscrow {
         admin.require_auth();
 
@@ -1151,6 +1152,14 @@ impl LiquifactEscrow {
             env.storage()
                 .instance()
                 .set(&DataKey::LegalHoldClearDelay, &delay);
+        }
+
+        if let Some(active) = allowlist_active {
+            if active {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::AllowlistActive, &true);
+            }
         }
 
         EscrowInitialized {

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -1,4 +1,4 @@
-use super::{
+﻿use super::{
     AllowlistEnabledChanged, DataKey, InvestorAllowlistChanged, LiquifactEscrow,
     LiquifactEscrowClient,
 };
@@ -239,7 +239,7 @@ fn test_fund_allowed_when_allowlist_disabled() {
     let client = deploy(&env);
     init(&env, &client);
     let investor = Address::generate(&env);
-    // Allowlist off — anyone can fund.
+    // Allowlist off ÔÇö anyone can fund.
     let escrow = client.fund(&investor, &5_000i128);
     assert_eq!(escrow.funded_amount, 5_000i128);
 }
@@ -251,7 +251,7 @@ fn test_fund_with_commitment_allowed_when_allowlist_disabled() {
     let client = deploy(&env);
     init(&env, &client);
     let investor = Address::generate(&env);
-    // Allowlist off — anyone can fund with commitment.
+    // Allowlist off ÔÇö anyone can fund with commitment.
     let escrow = client.fund_with_commitment(&investor, &5_000i128, &0u64);
     assert_eq!(escrow.funded_amount, 5_000i128);
 }
@@ -323,7 +323,7 @@ fn test_fund_allowed_after_disable_even_without_entry() {
     client.set_allowlist_active(&true);
     client.set_allowlist_active(&false);
 
-    // Gate is off — investor not in list but can still fund.
+    // Gate is off ÔÇö investor not in list but can still fund.
     let escrow = client.fund(&investor, &3_000i128);
     assert_eq!(escrow.funded_amount, 3_000i128);
 }
@@ -341,7 +341,7 @@ fn test_entries_persist_across_disable_reenable() {
     client.set_allowlist_active(&false);
     // Entry still there even while disabled.
     assert!(client.is_investor_allowlisted(&investor));
-    // Re-enable — investor can still fund without re-adding.
+    // Re-enable ÔÇö investor can still fund without re-adding.
     client.set_allowlist_active(&true);
     let escrow = client.fund(&investor, &2_000i128);
     assert_eq!(escrow.funded_amount, 2_000i128);

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -31,6 +31,7 @@ fn init(env: &Env, client: &LiquifactEscrowClient) -> (Address, Address) {
         &None,
         &None,
         &None,
+        &None,
     );
     (admin, sme)
 }

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -134,6 +134,7 @@ pub fn default_init(client: &LiquifactEscrowClient<'_>, env: &Env, admin: &Addre
         &None,
         &None,
         &None, // No funding deadline
+        &None, // No allowlist
     );
 }
 

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -26,6 +26,7 @@ fn test_update_maturity_success() {
         &None,
         &None,
         &None,
+        &None,
     );
     let updated = client.update_maturity(&2000u64);
     assert_eq!(updated.maturity, 2000u64);
@@ -48,6 +49,7 @@ fn test_update_maturity_wrong_state() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -85,6 +87,7 @@ fn test_update_maturity_unauthorized() {
         &None,
         &None,
         &None,
+        &None,
     );
     env.mock_auths(&[]);
     client.update_maturity(&2000u64);
@@ -105,6 +108,7 @@ fn test_propose_admin_sets_pending_without_changing_admin() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -134,6 +138,7 @@ fn test_accept_admin_promotes_pending_and_clears_pending() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -173,6 +178,7 @@ fn test_transfer_admin_deprecated_shim_only_proposes() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let unchanged = client.transfer_admin(&new_admin);
@@ -195,6 +201,7 @@ fn test_transfer_admin_same_address_panics() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -343,6 +350,7 @@ fn test_read_model_summary_includes_optional_admin_fields() {
         &Some(10_000i128),
         &None,
         &None,
+        &None,
     );
 
     let summary = client.get_escrow_summary();
@@ -371,6 +379,7 @@ fn test_record_collateral_stored_and_does_not_block_settle() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -411,6 +420,7 @@ fn test_collateral_zero_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
 }
@@ -430,6 +440,7 @@ fn test_collateral_requires_sme_auth() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -457,6 +468,7 @@ fn test_legal_hold_blocks_settle_withdraw_claim_and_fund() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -518,6 +530,7 @@ fn test_legal_hold_blocks_new_funds_when_open() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_legal_hold(&true);
     client.fund(&investor, &1i128);
@@ -529,7 +542,7 @@ fn test_legal_hold_blocks_new_funds_when_open() {
 #[test]
 fn test_get_legal_hold_defaults_false_on_fresh_deploy() {
     let env = Env::default();
-    // No init, no set_legal_hold ÔÇô DataKey::LegalHold is absent from storage.
+    // No init, no set_legal_hold ├ö├ç├┤ DataKey::LegalHold is absent from storage.
     let client = deploy(&env);
     assert!(!client.get_legal_hold());
 }
@@ -554,6 +567,7 @@ fn test_update_funding_target_by_admin_succeeds() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -588,6 +602,7 @@ fn test_update_funding_target_by_non_admin_panics() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -630,6 +645,7 @@ fn test_update_funding_target_fails_when_funded() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &5_000i128);
     client.update_funding_target(&10_000i128);
@@ -657,6 +673,7 @@ fn test_update_funding_target_below_funded_panics() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -697,6 +714,7 @@ fn test_update_funding_target_zero_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.update_funding_target(&0i128);
 }
@@ -729,6 +747,7 @@ fn test_update_funding_target_event_fields() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -783,9 +802,10 @@ fn test_update_funding_target_fails_when_settled() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128); // status ÔåÆ 1 (funded)
-    client.settle(); // status ÔåÆ 2 (settled)
+    client.fund(&investor, &5_000i128); // status ├ö├Ñ├å 1 (funded)
+    client.settle(); // status ├ö├Ñ├å 2 (settled)
     client.update_funding_target(&6_000i128);
 }
 
@@ -797,7 +817,7 @@ fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
-    client.withdraw(); // status ÔåÆ 3 (withdrawn)
+    client.withdraw(); // status ├ö├Ñ├å 3 (withdrawn)
     client.update_funding_target(&6_000i128);
 }
 
@@ -832,10 +852,11 @@ fn test_update_funding_target_equal_to_funded_amount_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
 
-    // new_target == funded_amount: boundary ÔÇö must not panic.
+    // new_target == funded_amount: boundary ├ö├ç├Â must not panic.
     let updated = client.update_funding_target(&4_000i128);
     assert_eq!(updated.funding_target, 4_000i128);
     assert_eq!(updated.funded_amount, 4_000i128);
@@ -864,6 +885,7 @@ fn test_update_funding_target_negative_panics() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -904,6 +926,7 @@ fn test_update_maturity_event_fields() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -958,8 +981,9 @@ fn test_update_maturity_fails_when_funded() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128); // status ÔåÆ 1 (funded)
+    client.fund(&investor, &5_000i128); // status ├ö├Ñ├å 1 (funded)
     client.update_maturity(&2000u64);
 }
 
@@ -994,9 +1018,10 @@ fn test_update_maturity_fails_when_settled() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128); // status ÔåÆ 1
-    client.settle(); // status ÔåÆ 2
+    client.fund(&investor, &5_000i128); // status ├ö├Ñ├å 1
+    client.settle(); // status ├ö├Ñ├å 2
     client.update_maturity(&2000u64);
 }
 
@@ -1008,11 +1033,11 @@ fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
-    client.withdraw(); // status ÔåÆ 3
+    client.withdraw(); // status ├ö├Ñ├å 3
     client.update_maturity(&2000u64);
 }
 
-/// Setting maturity to zero is valid ÔÇö it means no maturity gate.
+/// Setting maturity to zero is valid ├ö├ç├Â it means no maturity gate.
 /// The contract must accept zero as new_maturity in Open state.
 #[test]
 fn test_update_maturity_to_zero_succeeds() {
@@ -1041,6 +1066,7 @@ fn test_update_maturity_to_zero_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
     let updated = client.update_maturity(&0u64);
     assert_eq!(updated.maturity, 0u64);
@@ -1048,7 +1074,7 @@ fn test_update_maturity_to_zero_succeeds() {
 }
 
 /// Ledger time semantics: `settle` uses `env.ledger().timestamp()`
-/// (validator-observed seconds). Settle must pass exactly at maturity ÔÇö
+/// (validator-observed seconds). Settle must pass exactly at maturity ├ö├ç├Â
 /// confirming the boundary is `now >= maturity` (inclusive).
 #[test]
 fn test_settle_passes_exactly_at_maturity_ledger_time() {
@@ -1078,16 +1104,17 @@ fn test_settle_passes_exactly_at_maturity_ledger_time() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &5_000i128);
 
-    // Advance ledger to exactly maturity ÔÇö must succeed
+    // Advance ledger to exactly maturity ├ö├ç├Â must succeed
     env.ledger().with_mut(|l| l.timestamp = 5000);
     let settled = client.settle();
     assert_eq!(settled.status, 2);
 }
 
-/// Ledger time semantics: settle must panic one second before maturity ÔÇö
+/// Ledger time semantics: settle must panic one second before maturity ├ö├ç├Â
 /// confirming the `>=` boundary strictly excludes values below maturity.
 #[test]
 #[should_panic]
@@ -1118,16 +1145,17 @@ fn test_settle_fails_one_second_before_maturity() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &5_000i128);
 
-    // One second before maturity ÔÇö must reject
+    // One second before maturity ├ö├ç├Â must reject
     env.ledger().with_mut(|l| l.timestamp = 4999);
     client.settle();
 }
 
 /// A second `update_maturity` call in the same Open state must overwrite
-/// the previous value correctly ÔÇö storage is atomic per call.
+/// the previous value correctly ├ö├ç├Â storage is atomic per call.
 #[test]
 fn test_update_maturity_twice_overwrites() {
     let env = Env::default();
@@ -1155,6 +1183,7 @@ fn test_update_maturity_twice_overwrites() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.update_maturity(&2000u64);
@@ -1163,11 +1192,11 @@ fn test_update_maturity_twice_overwrites() {
     assert_eq!(client.get_escrow().maturity, 3000u64);
 }
 
-// ÔöÇÔöÇ Authorization guard ordering audit (issue #265) ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+// ├ö├Â├ç├ö├Â├ç Authorization guard ordering audit (issue #265) ├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç
 //
 // Negative tests: each guarded entrypoint must trap when `require_auth` fails
 // (Soroban host aborts the transaction). Canonical ordering is documented in
-// `docs/escrow-security-checklist.md` ┬º6 and ADR-002.
+// `docs/escrow-security-checklist.md` Ôö¼┬║6 and ADR-002.
 
 fn auth_audit_init_funded(
     env: &Env,
@@ -1326,6 +1355,7 @@ fn auth_audit_sweep_terminal_dust_requires_treasury() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1523,6 +1553,7 @@ fn test_rotate_beneficiary_then_withdraw_goes_to_new_sme() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -777,8 +777,7 @@ fn test_update_funding_target_fails_when_settled() {
 fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
     client.withdraw(); // status → 3 (withdrawn)
     client.update_funding_target(&6_000i128);
 }
@@ -984,8 +983,7 @@ fn test_update_maturity_fails_when_settled() {
 fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
     client.withdraw(); // status → 3
     client.update_maturity(&2000u64);
 }

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -1,4 +1,4 @@
-﻿use super::*;
+use super::*;
 use crate::{AdminProposedEvent, EscrowCloseSnapshot, FundingTargetUpdated};
 use soroban_sdk::Event;
 
@@ -19,7 +19,6 @@ fn test_update_maturity_success() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -48,7 +47,6 @@ fn test_update_maturity_wrong_state() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -84,7 +82,6 @@ fn test_update_maturity_unauthorized() {
         &None,
         &None,
         &None,
-        &None,
     );
     env.mock_auths(&[]);
     client.update_maturity(&2000u64);
@@ -105,7 +102,6 @@ fn test_propose_admin_sets_pending_without_changing_admin() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -134,7 +130,6 @@ fn test_accept_admin_promotes_pending_and_clears_pending() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -172,7 +167,6 @@ fn test_transfer_admin_deprecated_shim_only_proposes() {
         &None,
         &None,
         &None,
-        &None,
     );
 
     let unchanged = client.transfer_admin(&new_admin);
@@ -195,7 +189,6 @@ fn test_transfer_admin_same_address_panics() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -377,7 +370,6 @@ fn test_record_collateral_stored_and_does_not_block_settle() {
         &None,
         &None,
         &None,
-        &None,
     );
     let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
     assert_eq!(c.amount, 5000i128);
@@ -410,7 +402,6 @@ fn test_collateral_zero_panics() {
         &None,
         &None,
         &None,
-        &None,
     );
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
 }
@@ -430,7 +421,6 @@ fn test_collateral_requires_sme_auth() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -457,7 +447,6 @@ fn test_legal_hold_blocks_settle_withdraw_claim_and_fund() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
-        &None,
         &None,
         &None,
         &None,
@@ -517,7 +506,6 @@ fn test_legal_hold_blocks_new_funds_when_open() {
         &None,
         &None,
         &None,
-        &None,
     );
     client.set_legal_hold(&true);
     client.fund(&investor, &1i128);
@@ -529,7 +517,7 @@ fn test_legal_hold_blocks_new_funds_when_open() {
 #[test]
 fn test_get_legal_hold_defaults_false_on_fresh_deploy() {
     let env = Env::default();
-    // No init, no set_legal_hold ÔÇô DataKey::LegalHold is absent from storage.
+    // No init, no set_legal_hold – DataKey::LegalHold is absent from storage.
     let client = deploy(&env);
     assert!(!client.get_legal_hold());
 }
@@ -554,7 +542,6 @@ fn test_update_funding_target_by_admin_succeeds() {
         &token,
         &None,
         &treasury,
-        &None,
         &None,
         &None,
         &None,
@@ -588,7 +575,6 @@ fn test_update_funding_target_by_non_admin_panics() {
         &token,
         &None,
         &treasury,
-        &None,
         &None,
         &None,
         &None,
@@ -629,7 +615,6 @@ fn test_update_funding_target_fails_when_funded() {
         &None,
         &None,
         &None,
-        &None,
     );
     client.fund(&investor, &5_000i128);
     client.update_funding_target(&10_000i128);
@@ -657,7 +642,6 @@ fn test_update_funding_target_below_funded_panics() {
         &token,
         &None,
         &treasury,
-        &None,
         &None,
         &None,
         &None,
@@ -696,7 +680,6 @@ fn test_update_funding_target_zero_panics() {
         &None,
         &None,
         &None,
-        &None,
     );
     client.update_funding_target(&0i128);
 }
@@ -729,7 +712,6 @@ fn test_update_funding_target_event_fields() {
         &token,
         &None,
         &treasury,
-        &None,
         &None,
         &None,
         &None,
@@ -782,10 +764,9 @@ fn test_update_funding_target_fails_when_settled() {
         &None,
         &None,
         &None,
-        &None,
     );
-    client.fund(&investor, &5_000i128); // status ÔåÆ 1 (funded)
-    client.settle(); // status ÔåÆ 2 (settled)
+    client.fund(&investor, &5_000i128); // status → 1 (funded)
+    client.settle(); // status → 2 (settled)
     client.update_funding_target(&6_000i128);
 }
 
@@ -796,9 +777,8 @@ fn test_update_funding_target_fails_when_settled() {
 fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "WD001");
-    client.withdraw(); // status ÔåÆ 3 (withdrawn)
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+    client.withdraw(); // status → 3 (withdrawn)
     client.update_funding_target(&6_000i128);
 }
 
@@ -832,11 +812,10 @@ fn test_update_funding_target_equal_to_funded_amount_succeeds() {
         &None,
         &None,
         &None,
-        &None,
     );
     client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
 
-    // new_target == funded_amount: boundary ÔÇö must not panic.
+    // new_target == funded_amount: boundary — must not panic.
     let updated = client.update_funding_target(&4_000i128);
     assert_eq!(updated.funding_target, 4_000i128);
     assert_eq!(updated.funded_amount, 4_000i128);
@@ -865,7 +844,6 @@ fn test_update_funding_target_negative_panics() {
         &token,
         &None,
         &treasury,
-        &None,
         &None,
         &None,
         &None,
@@ -905,7 +883,6 @@ fn test_update_maturity_event_fields() {
         &token,
         &None,
         &treasury,
-        &None,
         &None,
         &None,
         &None,
@@ -958,9 +935,8 @@ fn test_update_maturity_fails_when_funded() {
         &None,
         &None,
         &None,
-        &None,
     );
-    client.fund(&investor, &5_000i128); // status ÔåÆ 1 (funded)
+    client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.update_maturity(&2000u64);
 }
 
@@ -994,10 +970,9 @@ fn test_update_maturity_fails_when_settled() {
         &None,
         &None,
         &None,
-        &None,
     );
-    client.fund(&investor, &5_000i128); // status ÔåÆ 1
-    client.settle(); // status ÔåÆ 2
+    client.fund(&investor, &5_000i128); // status → 1
+    client.settle(); // status → 2
     client.update_maturity(&2000u64);
 }
 
@@ -1008,13 +983,12 @@ fn test_update_maturity_fails_when_settled() {
 fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
-    client.withdraw(); // status ÔåÆ 3
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+    client.withdraw(); // status → 3
     client.update_maturity(&2000u64);
 }
 
-/// Setting maturity to zero is valid ÔÇö it means no maturity gate.
+/// Setting maturity to zero is valid — it means no maturity gate.
 /// The contract must accept zero as new_maturity in Open state.
 #[test]
 fn test_update_maturity_to_zero_succeeds() {
@@ -1042,7 +1016,6 @@ fn test_update_maturity_to_zero_succeeds() {
         &None,
         &None,
         &None,
-        &None,
     );
     let updated = client.update_maturity(&0u64);
     assert_eq!(updated.maturity, 0u64);
@@ -1050,7 +1023,7 @@ fn test_update_maturity_to_zero_succeeds() {
 }
 
 /// Ledger time semantics: `settle` uses `env.ledger().timestamp()`
-/// (validator-observed seconds). Settle must pass exactly at maturity ÔÇö
+/// (validator-observed seconds). Settle must pass exactly at maturity —
 /// confirming the boundary is `now >= maturity` (inclusive).
 #[test]
 fn test_settle_passes_exactly_at_maturity_ledger_time() {
@@ -1079,17 +1052,16 @@ fn test_settle_passes_exactly_at_maturity_ledger_time() {
         &None,
         &None,
         &None,
-        &None,
     );
     client.fund(&investor, &5_000i128);
 
-    // Advance ledger to exactly maturity ÔÇö must succeed
+    // Advance ledger to exactly maturity — must succeed
     env.ledger().with_mut(|l| l.timestamp = 5000);
     let settled = client.settle();
     assert_eq!(settled.status, 2);
 }
 
-/// Ledger time semantics: settle must panic one second before maturity ÔÇö
+/// Ledger time semantics: settle must panic one second before maturity —
 /// confirming the `>=` boundary strictly excludes values below maturity.
 #[test]
 #[should_panic]
@@ -1119,17 +1091,16 @@ fn test_settle_fails_one_second_before_maturity() {
         &None,
         &None,
         &None,
-        &None,
     );
     client.fund(&investor, &5_000i128);
 
-    // One second before maturity ÔÇö must reject
+    // One second before maturity — must reject
     env.ledger().with_mut(|l| l.timestamp = 4999);
     client.settle();
 }
 
 /// A second `update_maturity` call in the same Open state must overwrite
-/// the previous value correctly ÔÇö storage is atomic per call.
+/// the previous value correctly — storage is atomic per call.
 #[test]
 fn test_update_maturity_twice_overwrites() {
     let env = Env::default();
@@ -1156,7 +1127,6 @@ fn test_update_maturity_twice_overwrites() {
         &None,
         &None,
         &None,
-        &None,
     );
 
     client.update_maturity(&2000u64);
@@ -1165,11 +1135,11 @@ fn test_update_maturity_twice_overwrites() {
     assert_eq!(client.get_escrow().maturity, 3000u64);
 }
 
-// ÔöÇÔöÇ Authorization guard ordering audit (issue #265) ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+// ── Authorization guard ordering audit (issue #265) ───────────────────────────
 //
 // Negative tests: each guarded entrypoint must trap when `require_auth` fails
 // (Soroban host aborts the transaction). Canonical ordering is documented in
-// `docs/escrow-security-checklist.md` ┬º6 and ADR-002.
+// `docs/escrow-security-checklist.md` §6 and ADR-002.
 
 fn auth_audit_init_funded(
     env: &Env,
@@ -1328,7 +1298,6 @@ fn auth_audit_sweep_terminal_dust_requires_treasury() {
         &token.id,
         &None,
         &treasury,
-        &None,
         &None,
         &None,
         &None,
@@ -1525,7 +1494,6 @@ fn test_rotate_beneficiary_then_withdraw_goes_to_new_sme() {
         &token.id,
         &None,
         &treasury,
-        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -1,4 +1,4 @@
-use super::*;
+﻿use super::*;
 use crate::{AdminProposedEvent, EscrowCloseSnapshot, FundingTargetUpdated};
 use soroban_sdk::Event;
 
@@ -27,7 +27,7 @@ fn test_update_maturity_success() {
         &None,
         &None,
     );
-let updated = client.update_maturity(&2000u64);
+    let updated = client.update_maturity(&2000u64);
     assert_eq!(updated.maturity, 2000u64);
     assert_eq!(updated.status, 0);
 }
@@ -56,7 +56,7 @@ fn test_update_maturity_wrong_state() {
         &None,
         &None,
     );
-client.fund(&investor, &1_000i128);
+    client.fund(&investor, &1_000i128);
     client.update_maturity(&2000u64);
 }
 
@@ -86,7 +86,7 @@ fn test_update_maturity_unauthorized() {
         &None,
         &None,
     );
-env.mock_auths(&[]);
+    env.mock_auths(&[]);
     client.update_maturity(&2000u64);
 }
 
@@ -113,7 +113,7 @@ fn test_propose_admin_sets_pending_without_changing_admin() {
         &None,
         &None,
     );
-let pending = client.propose_admin(&new_admin);
+    let pending = client.propose_admin(&new_admin);
     assert_eq!(pending, new_admin);
     assert_eq!(client.get_pending_admin(), Some(new_admin));
     assert_eq!(client.get_escrow().admin, admin);
@@ -142,7 +142,8 @@ fn test_accept_admin_promotes_pending_and_clears_pending() {
         &None,
         &None,
     );
-client.propose_admin(&new_admin);
+
+    client.propose_admin(&new_admin);
     let updated = client.accept_admin();
     assert_eq!(updated.admin, new_admin);
     assert_eq!(client.get_escrow().admin, new_admin);
@@ -173,7 +174,8 @@ fn test_transfer_admin_deprecated_shim_only_proposes() {
         &None,
         &None,
     );
-let unchanged = client.transfer_admin(&new_admin);
+
+    let unchanged = client.transfer_admin(&new_admin);
     assert_eq!(unchanged.admin, admin);
     assert_eq!(client.get_pending_admin(), Some(new_admin));
 }
@@ -201,7 +203,7 @@ fn test_transfer_admin_same_address_panics() {
         &None,
         &None,
     );
-client.propose_admin(&admin);
+    client.propose_admin(&admin);
 }
 
 #[test]
@@ -341,9 +343,9 @@ fn test_read_model_summary_includes_optional_admin_fields() {
         &Some(10_000i128),
         &None,
         &None,
-        &None,
     );
-let summary = client.get_escrow_summary();
+
+    let summary = client.get_escrow_summary();
 
     assert_eq!(summary.escrow, client.get_escrow());
     assert_eq!(summary.legal_hold, client.get_legal_hold());
@@ -377,7 +379,7 @@ fn test_record_collateral_stored_and_does_not_block_settle() {
         &None,
         &None,
     );
-let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
+    let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
     assert_eq!(c.amount, 5000i128);
     assert_eq!(c.asset, symbol_short!("USDC"));
     assert_eq!(client.get_sme_collateral_commitment(), Some(c));
@@ -410,7 +412,7 @@ fn test_collateral_zero_panics() {
         &None,
         &None,
     );
-client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
+    client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
 }
 
 #[test]
@@ -436,7 +438,7 @@ fn test_collateral_requires_sme_auth() {
         &None,
         &None,
     );
-env.mock_auths(&[]);
+    env.mock_auths(&[]);
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &100i128);
 }
 
@@ -463,7 +465,7 @@ fn test_legal_hold_blocks_settle_withdraw_claim_and_fund() {
         &None,
         &None,
     );
-client.fund(&investor, &TARGET);
+    client.fund(&investor, &TARGET);
     client.set_legal_hold(&true);
     assert!(client.get_legal_hold());
 
@@ -517,7 +519,7 @@ fn test_legal_hold_blocks_new_funds_when_open() {
         &None,
         &None,
     );
-client.set_legal_hold(&true);
+    client.set_legal_hold(&true);
     client.fund(&investor, &1i128);
 }
 
@@ -527,7 +529,7 @@ client.set_legal_hold(&true);
 #[test]
 fn test_get_legal_hold_defaults_false_on_fresh_deploy() {
     let env = Env::default();
-    // No init, no set_legal_hold – DataKey::LegalHold is absent from storage.
+    // No init, no set_legal_hold ÔÇô DataKey::LegalHold is absent from storage.
     let client = deploy(&env);
     assert!(!client.get_legal_hold());
 }
@@ -560,7 +562,8 @@ fn test_update_funding_target_by_admin_succeeds() {
         &None,
         &None,
     );
-let updated = client.update_funding_target(&10_000i128);
+
+    let updated = client.update_funding_target(&10_000i128);
     assert_eq!(updated.funding_target, 10_000i128);
     assert_eq!(updated.status, 0);
 }
@@ -593,7 +596,8 @@ fn test_update_funding_target_by_non_admin_panics() {
         &None,
         &None,
     );
-env.mock_auths(&[]);
+
+    env.mock_auths(&[]);
     client.update_funding_target(&10_000i128);
 }
 
@@ -627,7 +631,7 @@ fn test_update_funding_target_fails_when_funded() {
         &None,
         &None,
     );
-client.fund(&investor, &5_000i128);
+    client.fund(&investor, &5_000i128);
     client.update_funding_target(&10_000i128);
 }
 
@@ -661,7 +665,7 @@ fn test_update_funding_target_below_funded_panics() {
         &None,
         &None,
     );
-client.fund(&investor, &4_000i128);
+    client.fund(&investor, &4_000i128);
     client.update_funding_target(&3_000i128);
 }
 
@@ -694,7 +698,7 @@ fn test_update_funding_target_zero_panics() {
         &None,
         &None,
     );
-client.update_funding_target(&0i128);
+    client.update_funding_target(&0i128);
 }
 
 // --- FundingTargetUpdated event and rejection coverage ---
@@ -733,7 +737,8 @@ fn test_update_funding_target_event_fields() {
         &None,
         &None,
     );
-client.update_funding_target(&9_000i128);
+
+    client.update_funding_target(&9_000i128);
 
     assert_eq!(
         env.events().all(),
@@ -779,8 +784,8 @@ fn test_update_funding_target_fails_when_settled() {
         &None,
         &None,
     );
-client.fund(&investor, &5_000i128); // status → 1 (funded)
-    client.settle(); // status → 2 (settled)
+    client.fund(&investor, &5_000i128); // status ÔåÆ 1 (funded)
+    client.settle(); // status ÔåÆ 2 (settled)
     client.update_funding_target(&6_000i128);
 }
 
@@ -791,8 +796,9 @@ client.fund(&investor, &5_000i128); // status → 1 (funded)
 fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
-    client.withdraw(); // status → 3 (withdrawn)
+    let (client, _escrow_id, _sme) =
+        init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+    client.withdraw(); // status ÔåÆ 3 (withdrawn)
     client.update_funding_target(&6_000i128);
 }
 
@@ -828,9 +834,9 @@ fn test_update_funding_target_equal_to_funded_amount_succeeds() {
         &None,
         &None,
     );
-client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
+    client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
 
-    // new_target == funded_amount: boundary — must not panic.
+    // new_target == funded_amount: boundary ÔÇö must not panic.
     let updated = client.update_funding_target(&4_000i128);
     assert_eq!(updated.funding_target, 4_000i128);
     assert_eq!(updated.funded_amount, 4_000i128);
@@ -867,7 +873,7 @@ fn test_update_funding_target_negative_panics() {
         &None,
         &None,
     );
-client.update_funding_target(&-1i128);
+    client.update_funding_target(&-1i128);
 }
 // --- update_maturity: open-only, ledger time semantics, MaturityUpdatedEvent ---
 
@@ -907,7 +913,8 @@ fn test_update_maturity_event_fields() {
         &None,
         &None,
     );
-client.update_maturity(&2000u64);
+
+    client.update_maturity(&2000u64);
 
     assert_eq!(
         env.events().all(),
@@ -953,7 +960,7 @@ fn test_update_maturity_fails_when_funded() {
         &None,
         &None,
     );
-client.fund(&investor, &5_000i128); // status → 1 (funded)
+    client.fund(&investor, &5_000i128); // status ÔåÆ 1 (funded)
     client.update_maturity(&2000u64);
 }
 
@@ -989,8 +996,8 @@ fn test_update_maturity_fails_when_settled() {
         &None,
         &None,
     );
-client.fund(&investor, &5_000i128); // status → 1
-    client.settle(); // status → 2
+    client.fund(&investor, &5_000i128); // status ÔåÆ 1
+    client.settle(); // status ÔåÆ 2
     client.update_maturity(&2000u64);
 }
 
@@ -1001,12 +1008,13 @@ client.fund(&investor, &5_000i128); // status → 1
 fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
-    client.withdraw(); // status → 3
+    let (client, _escrow_id, _sme) =
+        init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+    client.withdraw(); // status ÔåÆ 3
     client.update_maturity(&2000u64);
 }
 
-/// Setting maturity to zero is valid — it means no maturity gate.
+/// Setting maturity to zero is valid ÔÇö it means no maturity gate.
 /// The contract must accept zero as new_maturity in Open state.
 #[test]
 fn test_update_maturity_to_zero_succeeds() {
@@ -1036,13 +1044,13 @@ fn test_update_maturity_to_zero_succeeds() {
         &None,
         &None,
     );
-let updated = client.update_maturity(&0u64);
+    let updated = client.update_maturity(&0u64);
     assert_eq!(updated.maturity, 0u64);
     assert_eq!(updated.status, 0);
 }
 
 /// Ledger time semantics: `settle` uses `env.ledger().timestamp()`
-/// (validator-observed seconds). Settle must pass exactly at maturity —
+/// (validator-observed seconds). Settle must pass exactly at maturity ÔÇö
 /// confirming the boundary is `now >= maturity` (inclusive).
 #[test]
 fn test_settle_passes_exactly_at_maturity_ledger_time() {
@@ -1073,15 +1081,15 @@ fn test_settle_passes_exactly_at_maturity_ledger_time() {
         &None,
         &None,
     );
-client.fund(&investor, &5_000i128);
+    client.fund(&investor, &5_000i128);
 
-    // Advance ledger to exactly maturity — must succeed
+    // Advance ledger to exactly maturity ÔÇö must succeed
     env.ledger().with_mut(|l| l.timestamp = 5000);
     let settled = client.settle();
     assert_eq!(settled.status, 2);
 }
 
-/// Ledger time semantics: settle must panic one second before maturity —
+/// Ledger time semantics: settle must panic one second before maturity ÔÇö
 /// confirming the `>=` boundary strictly excludes values below maturity.
 #[test]
 #[should_panic]
@@ -1113,15 +1121,15 @@ fn test_settle_fails_one_second_before_maturity() {
         &None,
         &None,
     );
-client.fund(&investor, &5_000i128);
+    client.fund(&investor, &5_000i128);
 
-    // One second before maturity — must reject
+    // One second before maturity ÔÇö must reject
     env.ledger().with_mut(|l| l.timestamp = 4999);
     client.settle();
 }
 
 /// A second `update_maturity` call in the same Open state must overwrite
-/// the previous value correctly — storage is atomic per call.
+/// the previous value correctly ÔÇö storage is atomic per call.
 #[test]
 fn test_update_maturity_twice_overwrites() {
     let env = Env::default();
@@ -1150,17 +1158,18 @@ fn test_update_maturity_twice_overwrites() {
         &None,
         &None,
     );
-client.update_maturity(&2000u64);
+
+    client.update_maturity(&2000u64);
     let updated = client.update_maturity(&3000u64);
     assert_eq!(updated.maturity, 3000u64);
     assert_eq!(client.get_escrow().maturity, 3000u64);
 }
 
-// ── Authorization guard ordering audit (issue #265) ───────────────────────────
+// ÔöÇÔöÇ Authorization guard ordering audit (issue #265) ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 //
 // Negative tests: each guarded entrypoint must trap when `require_auth` fails
 // (Soroban host aborts the transaction). Canonical ordering is documented in
-// `docs/escrow-security-checklist.md` §6 and ADR-002.
+// `docs/escrow-security-checklist.md` ┬º6 and ADR-002.
 
 fn auth_audit_init_funded(
     env: &Env,
@@ -1327,7 +1336,7 @@ fn auth_audit_sweep_terminal_dust_requires_treasury() {
         &None,
         &None,
     );
-client.fund(&investor, &TARGET);
+    client.fund(&investor, &TARGET);
     client.settle();
     token.stellar.mint(&escrow_id, &100i128);
     env.mock_auths(&[]);
@@ -1524,7 +1533,7 @@ fn test_rotate_beneficiary_then_withdraw_goes_to_new_sme() {
         &None,
         &None,
     );
-token.stellar.mint(&investor, &TARGET);
+    token.stellar.mint(&investor, &TARGET);
     token.stellar.approve(
         &investor,
         &escrow_id,

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -25,6 +25,7 @@ fn test_update_maturity_success() {
         &None,
         &None,
         &None,
+        &None,
     );
     let updated = client.update_maturity(&2000u64);
     assert_eq!(updated.maturity, 2000u64);
@@ -47,6 +48,7 @@ fn test_update_maturity_wrong_state() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -82,6 +84,7 @@ fn test_update_maturity_unauthorized() {
         &None,
         &None,
         &None,
+        &None,
     );
     env.mock_auths(&[]);
     client.update_maturity(&2000u64);
@@ -102,6 +105,7 @@ fn test_propose_admin_sets_pending_without_changing_admin() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -130,6 +134,7 @@ fn test_accept_admin_promotes_pending_and_clears_pending() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -167,6 +172,7 @@ fn test_transfer_admin_deprecated_shim_only_proposes() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let unchanged = client.transfer_admin(&new_admin);
@@ -189,6 +195,7 @@ fn test_transfer_admin_same_address_panics() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -370,6 +377,7 @@ fn test_record_collateral_stored_and_does_not_block_settle() {
         &None,
         &None,
         &None,
+        &None,
     );
     let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
     assert_eq!(c.amount, 5000i128);
@@ -402,6 +410,7 @@ fn test_collateral_zero_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
 }
@@ -421,6 +430,7 @@ fn test_collateral_requires_sme_auth() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -447,6 +457,7 @@ fn test_legal_hold_blocks_settle_withdraw_claim_and_fund() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -506,6 +517,7 @@ fn test_legal_hold_blocks_new_funds_when_open() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_legal_hold(&true);
     client.fund(&investor, &1i128);
@@ -517,7 +529,7 @@ fn test_legal_hold_blocks_new_funds_when_open() {
 #[test]
 fn test_get_legal_hold_defaults_false_on_fresh_deploy() {
     let env = Env::default();
-    // No init, no set_legal_hold – DataKey::LegalHold is absent from storage.
+    // No init, no set_legal_hold ÔÇô DataKey::LegalHold is absent from storage.
     let client = deploy(&env);
     assert!(!client.get_legal_hold());
 }
@@ -542,6 +554,7 @@ fn test_update_funding_target_by_admin_succeeds() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -575,6 +588,7 @@ fn test_update_funding_target_by_non_admin_panics() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -615,6 +629,7 @@ fn test_update_funding_target_fails_when_funded() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &5_000i128);
     client.update_funding_target(&10_000i128);
@@ -642,6 +657,7 @@ fn test_update_funding_target_below_funded_panics() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -680,6 +696,7 @@ fn test_update_funding_target_zero_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.update_funding_target(&0i128);
 }
@@ -712,6 +729,7 @@ fn test_update_funding_target_event_fields() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -764,9 +782,10 @@ fn test_update_funding_target_fails_when_settled() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128); // status → 1 (funded)
-    client.settle(); // status → 2 (settled)
+    client.fund(&investor, &5_000i128); // status ÔåÆ 1 (funded)
+    client.settle(); // status ÔåÆ 2 (settled)
     client.update_funding_target(&6_000i128);
 }
 
@@ -778,7 +797,7 @@ fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
-    client.withdraw(); // status → 3 (withdrawn)
+    client.withdraw(); // status ÔåÆ 3 (withdrawn)
     client.update_funding_target(&6_000i128);
 }
 
@@ -812,10 +831,11 @@ fn test_update_funding_target_equal_to_funded_amount_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
 
-    // new_target == funded_amount: boundary — must not panic.
+    // new_target == funded_amount: boundary ÔÇö must not panic.
     let updated = client.update_funding_target(&4_000i128);
     assert_eq!(updated.funding_target, 4_000i128);
     assert_eq!(updated.funded_amount, 4_000i128);
@@ -844,6 +864,7 @@ fn test_update_funding_target_negative_panics() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -883,6 +904,7 @@ fn test_update_maturity_event_fields() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -935,8 +957,9 @@ fn test_update_maturity_fails_when_funded() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128); // status → 1 (funded)
+    client.fund(&investor, &5_000i128); // status ÔåÆ 1 (funded)
     client.update_maturity(&2000u64);
 }
 
@@ -970,9 +993,10 @@ fn test_update_maturity_fails_when_settled() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128); // status → 1
-    client.settle(); // status → 2
+    client.fund(&investor, &5_000i128); // status ÔåÆ 1
+    client.settle(); // status ÔåÆ 2
     client.update_maturity(&2000u64);
 }
 
@@ -984,11 +1008,11 @@ fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
-    client.withdraw(); // status → 3
+    client.withdraw(); // status ÔåÆ 3
     client.update_maturity(&2000u64);
 }
 
-/// Setting maturity to zero is valid — it means no maturity gate.
+/// Setting maturity to zero is valid ÔÇö it means no maturity gate.
 /// The contract must accept zero as new_maturity in Open state.
 #[test]
 fn test_update_maturity_to_zero_succeeds() {
@@ -1016,6 +1040,7 @@ fn test_update_maturity_to_zero_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
     let updated = client.update_maturity(&0u64);
     assert_eq!(updated.maturity, 0u64);
@@ -1023,7 +1048,7 @@ fn test_update_maturity_to_zero_succeeds() {
 }
 
 /// Ledger time semantics: `settle` uses `env.ledger().timestamp()`
-/// (validator-observed seconds). Settle must pass exactly at maturity —
+/// (validator-observed seconds). Settle must pass exactly at maturity ÔÇö
 /// confirming the boundary is `now >= maturity` (inclusive).
 #[test]
 fn test_settle_passes_exactly_at_maturity_ledger_time() {
@@ -1052,16 +1077,17 @@ fn test_settle_passes_exactly_at_maturity_ledger_time() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &5_000i128);
 
-    // Advance ledger to exactly maturity — must succeed
+    // Advance ledger to exactly maturity ÔÇö must succeed
     env.ledger().with_mut(|l| l.timestamp = 5000);
     let settled = client.settle();
     assert_eq!(settled.status, 2);
 }
 
-/// Ledger time semantics: settle must panic one second before maturity —
+/// Ledger time semantics: settle must panic one second before maturity ÔÇö
 /// confirming the `>=` boundary strictly excludes values below maturity.
 #[test]
 #[should_panic]
@@ -1091,16 +1117,17 @@ fn test_settle_fails_one_second_before_maturity() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &5_000i128);
 
-    // One second before maturity — must reject
+    // One second before maturity ÔÇö must reject
     env.ledger().with_mut(|l| l.timestamp = 4999);
     client.settle();
 }
 
 /// A second `update_maturity` call in the same Open state must overwrite
-/// the previous value correctly — storage is atomic per call.
+/// the previous value correctly ÔÇö storage is atomic per call.
 #[test]
 fn test_update_maturity_twice_overwrites() {
     let env = Env::default();
@@ -1127,6 +1154,7 @@ fn test_update_maturity_twice_overwrites() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.update_maturity(&2000u64);
@@ -1135,11 +1163,11 @@ fn test_update_maturity_twice_overwrites() {
     assert_eq!(client.get_escrow().maturity, 3000u64);
 }
 
-// ── Authorization guard ordering audit (issue #265) ───────────────────────────
+// ÔöÇÔöÇ Authorization guard ordering audit (issue #265) ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 //
 // Negative tests: each guarded entrypoint must trap when `require_auth` fails
 // (Soroban host aborts the transaction). Canonical ordering is documented in
-// `docs/escrow-security-checklist.md` §6 and ADR-002.
+// `docs/escrow-security-checklist.md` ┬º6 and ADR-002.
 
 fn auth_audit_init_funded(
     env: &Env,
@@ -1298,6 +1326,7 @@ fn auth_audit_sweep_terminal_dust_requires_treasury() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1494,6 +1523,7 @@ fn test_rotate_beneficiary_then_withdraw_goes_to_new_sme() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -25,8 +25,9 @@ fn test_update_maturity_success() {
         &None,
         &None,
         &None,
+        &None,
     );
-    let updated = client.update_maturity(&2000u64);
+let updated = client.update_maturity(&2000u64);
     assert_eq!(updated.maturity, 2000u64);
     assert_eq!(updated.status, 0);
 }
@@ -53,8 +54,9 @@ fn test_update_maturity_wrong_state() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &1_000i128);
+client.fund(&investor, &1_000i128);
     client.update_maturity(&2000u64);
 }
 
@@ -82,8 +84,9 @@ fn test_update_maturity_unauthorized() {
         &None,
         &None,
         &None,
+        &None,
     );
-    env.mock_auths(&[]);
+env.mock_auths(&[]);
     client.update_maturity(&2000u64);
 }
 
@@ -108,8 +111,9 @@ fn test_propose_admin_sets_pending_without_changing_admin() {
         &None,
         &None,
         &None,
+        &None,
     );
-    let pending = client.propose_admin(&new_admin);
+let pending = client.propose_admin(&new_admin);
     assert_eq!(pending, new_admin);
     assert_eq!(client.get_pending_admin(), Some(new_admin));
     assert_eq!(client.get_escrow().admin, admin);
@@ -136,9 +140,9 @@ fn test_accept_admin_promotes_pending_and_clears_pending() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.propose_admin(&new_admin);
+client.propose_admin(&new_admin);
     let updated = client.accept_admin();
     assert_eq!(updated.admin, new_admin);
     assert_eq!(client.get_escrow().admin, new_admin);
@@ -167,9 +171,9 @@ fn test_transfer_admin_deprecated_shim_only_proposes() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let unchanged = client.transfer_admin(&new_admin);
+let unchanged = client.transfer_admin(&new_admin);
     assert_eq!(unchanged.admin, admin);
     assert_eq!(client.get_pending_admin(), Some(new_admin));
 }
@@ -195,8 +199,9 @@ fn test_transfer_admin_same_address_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.propose_admin(&admin);
+client.propose_admin(&admin);
 }
 
 #[test]
@@ -336,9 +341,9 @@ fn test_read_model_summary_includes_optional_admin_fields() {
         &Some(10_000i128),
         &None,
         &None,
+        &None,
     );
-
-    let summary = client.get_escrow_summary();
+let summary = client.get_escrow_summary();
 
     assert_eq!(summary.escrow, client.get_escrow());
     assert_eq!(summary.legal_hold, client.get_legal_hold());
@@ -370,8 +375,9 @@ fn test_record_collateral_stored_and_does_not_block_settle() {
         &None,
         &None,
         &None,
+        &None,
     );
-    let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
+let c = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5000i128);
     assert_eq!(c.amount, 5000i128);
     assert_eq!(c.asset, symbol_short!("USDC"));
     assert_eq!(client.get_sme_collateral_commitment(), Some(c));
@@ -402,8 +408,9 @@ fn test_collateral_zero_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
+client.record_sme_collateral_commitment(&symbol_short!("XLM"), &0i128);
 }
 
 #[test]
@@ -427,8 +434,9 @@ fn test_collateral_requires_sme_auth() {
         &None,
         &None,
         &None,
+        &None,
     );
-    env.mock_auths(&[]);
+env.mock_auths(&[]);
     client.record_sme_collateral_commitment(&symbol_short!("XLM"), &100i128);
 }
 
@@ -453,8 +461,9 @@ fn test_legal_hold_blocks_settle_withdraw_claim_and_fund() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &TARGET);
+client.fund(&investor, &TARGET);
     client.set_legal_hold(&true);
     assert!(client.get_legal_hold());
 
@@ -506,8 +515,9 @@ fn test_legal_hold_blocks_new_funds_when_open() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.set_legal_hold(&true);
+client.set_legal_hold(&true);
     client.fund(&investor, &1i128);
 }
 
@@ -548,9 +558,9 @@ fn test_update_funding_target_by_admin_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let updated = client.update_funding_target(&10_000i128);
+let updated = client.update_funding_target(&10_000i128);
     assert_eq!(updated.funding_target, 10_000i128);
     assert_eq!(updated.status, 0);
 }
@@ -581,9 +591,9 @@ fn test_update_funding_target_by_non_admin_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    env.mock_auths(&[]);
+env.mock_auths(&[]);
     client.update_funding_target(&10_000i128);
 }
 
@@ -615,8 +625,9 @@ fn test_update_funding_target_fails_when_funded() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128);
+client.fund(&investor, &5_000i128);
     client.update_funding_target(&10_000i128);
 }
 
@@ -648,8 +659,9 @@ fn test_update_funding_target_below_funded_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &4_000i128);
+client.fund(&investor, &4_000i128);
     client.update_funding_target(&3_000i128);
 }
 
@@ -680,8 +692,9 @@ fn test_update_funding_target_zero_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.update_funding_target(&0i128);
+client.update_funding_target(&0i128);
 }
 
 // --- FundingTargetUpdated event and rejection coverage ---
@@ -718,9 +731,9 @@ fn test_update_funding_target_event_fields() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.update_funding_target(&9_000i128);
+client.update_funding_target(&9_000i128);
 
     assert_eq!(
         env.events().all(),
@@ -764,8 +777,9 @@ fn test_update_funding_target_fails_when_settled() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128); // status → 1 (funded)
+client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.settle(); // status → 2 (settled)
     client.update_funding_target(&6_000i128);
 }
@@ -812,8 +826,9 @@ fn test_update_funding_target_equal_to_funded_amount_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
+client.fund(&investor, &4_000i128); // funded_amount == 4_000, status still 0
 
     // new_target == funded_amount: boundary — must not panic.
     let updated = client.update_funding_target(&4_000i128);
@@ -850,8 +865,9 @@ fn test_update_funding_target_negative_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.update_funding_target(&-1i128);
+client.update_funding_target(&-1i128);
 }
 // --- update_maturity: open-only, ledger time semantics, MaturityUpdatedEvent ---
 
@@ -889,9 +905,9 @@ fn test_update_maturity_event_fields() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.update_maturity(&2000u64);
+client.update_maturity(&2000u64);
 
     assert_eq!(
         env.events().all(),
@@ -935,8 +951,9 @@ fn test_update_maturity_fails_when_funded() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128); // status → 1 (funded)
+client.fund(&investor, &5_000i128); // status → 1 (funded)
     client.update_maturity(&2000u64);
 }
 
@@ -970,8 +987,9 @@ fn test_update_maturity_fails_when_settled() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128); // status → 1
+client.fund(&investor, &5_000i128); // status → 1
     client.settle(); // status → 2
     client.update_maturity(&2000u64);
 }
@@ -1016,8 +1034,9 @@ fn test_update_maturity_to_zero_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
-    let updated = client.update_maturity(&0u64);
+let updated = client.update_maturity(&0u64);
     assert_eq!(updated.maturity, 0u64);
     assert_eq!(updated.status, 0);
 }
@@ -1052,8 +1071,9 @@ fn test_settle_passes_exactly_at_maturity_ledger_time() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128);
+client.fund(&investor, &5_000i128);
 
     // Advance ledger to exactly maturity — must succeed
     env.ledger().with_mut(|l| l.timestamp = 5000);
@@ -1091,8 +1111,9 @@ fn test_settle_fails_one_second_before_maturity() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &5_000i128);
+client.fund(&investor, &5_000i128);
 
     // One second before maturity — must reject
     env.ledger().with_mut(|l| l.timestamp = 4999);
@@ -1127,9 +1148,9 @@ fn test_update_maturity_twice_overwrites() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.update_maturity(&2000u64);
+client.update_maturity(&2000u64);
     let updated = client.update_maturity(&3000u64);
     assert_eq!(updated.maturity, 3000u64);
     assert_eq!(client.get_escrow().maturity, 3000u64);
@@ -1304,8 +1325,9 @@ fn auth_audit_sweep_terminal_dust_requires_treasury() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &TARGET);
+client.fund(&investor, &TARGET);
     client.settle();
     token.stellar.mint(&escrow_id, &100i128);
     env.mock_auths(&[]);
@@ -1500,8 +1522,9 @@ fn test_rotate_beneficiary_then_withdraw_goes_to_new_sme() {
         &None,
         &None,
         &None,
+        &None,
     );
-    token.stellar.mint(&investor, &TARGET);
+token.stellar.mint(&investor, &TARGET);
     token.stellar.approve(
         &investor,
         &escrow_id,

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -1,9 +1,9 @@
-//! Attestation tests: `bind_primary_attestation_hash` (single-set) and
+﻿//! Attestation tests: `bind_primary_attestation_hash` (single-set) and
 //! `append_attestation_digest` (bounded by [`MAX_ATTESTATION_APPEND_ENTRIES`]).
 //!
 //! These tests prove the two chain-anchor invariants:
-//! 1. The primary hash is **write-once** — a second bind panics regardless of the digest value.
-//! 2. The append log is **capacity-bounded** — the 33rd entry panics; the 32nd succeeds.
+//! 1. The primary hash is **write-once** ÔÇö a second bind panics regardless of the digest value.
+//! 2. The append log is **capacity-bounded** ÔÇö the 33rd entry panics; the 32nd succeeds.
 //!
 //! Neither entrypoint stores ZK proofs or performs off-chain verification. They record a
 //! 32-byte digest (e.g. SHA-256 of an IPFS CID or a KYC/KYB document bundle) so that
@@ -29,7 +29,7 @@ fn setup_with_init(env: &Env) -> (LiquifactEscrowClient<'_>, Address) {
 }
 
 // ---------------------------------------------------------------------------
-// bind_primary_attestation_hash — single-set invariant
+// bind_primary_attestation_hash ÔÇö single-set invariant
 // ---------------------------------------------------------------------------
 
 /// Happy path: first bind succeeds and is readable via the getter.
@@ -50,7 +50,7 @@ fn test_get_primary_hash_none_before_bind() {
     assert_eq!(client.get_primary_attestation_hash(), None);
 }
 
-/// A second bind with the **same** digest must panic — single-set is unconditional.
+/// A second bind with the **same** digest must panic ÔÇö single-set is unconditional.
 #[test]
 #[should_panic]
 fn test_bind_primary_hash_same_digest_panics() {
@@ -61,7 +61,7 @@ fn test_bind_primary_hash_same_digest_panics() {
     client.bind_primary_attestation_hash(&d);
 }
 
-/// A second bind with a **different** digest must also panic — no replacement allowed.
+/// A second bind with a **different** digest must also panic ÔÇö no replacement allowed.
 #[test]
 #[should_panic]
 fn test_bind_primary_hash_different_digest_panics() {
@@ -83,7 +83,7 @@ fn test_bind_primary_hash_non_admin_panics() {
 }
 
 // ---------------------------------------------------------------------------
-// append_attestation_digest — bounded log invariant
+// append_attestation_digest ÔÇö bounded log invariant
 // ---------------------------------------------------------------------------
 
 /// Empty log before any append.
@@ -121,7 +121,7 @@ fn test_append_multiple_entries_ordered() {
     }
 }
 
-/// The 32nd entry (index 31) succeeds — boundary must be inclusive.
+/// The 32nd entry (index 31) succeeds ÔÇö boundary must be inclusive.
 #[test]
 fn test_append_exactly_max_entries_succeeds() {
     let env = Env::default();
@@ -136,7 +136,7 @@ fn test_append_exactly_max_entries_succeeds() {
     );
 }
 
-/// The 33rd entry must panic — capacity is strictly bounded.
+/// The 33rd entry must panic ÔÇö capacity is strictly bounded.
 #[test]
 #[should_panic]
 fn test_append_beyond_max_panics() {
@@ -148,7 +148,7 @@ fn test_append_beyond_max_panics() {
     }
 }
 
-/// Duplicate digests are allowed — the log is an audit trail, not a set.
+/// Duplicate digests are allowed ÔÇö the log is an audit trail, not a set.
 #[test]
 fn test_append_duplicate_digest_allowed() {
     let env = Env::default();
@@ -207,7 +207,7 @@ fn test_primary_and_append_coexist() {
 }
 
 // ---------------------------------------------------------------------------
-// revoke_attestation_digest — revocation tombstone invariant
+// revoke_attestation_digest ÔÇö revocation tombstone invariant
 // ---------------------------------------------------------------------------
 
 /// Happy path: revoke index 0 and confirm via `is_attestation_revoked`.
@@ -302,7 +302,7 @@ fn test_revoke_non_admin_panics() {
     client.revoke_attestation_digest(&0);
 }
 
-/// Revocation does not alter the append log contents — the digest remains readable.
+/// Revocation does not alter the append log contents ÔÇö the digest remains readable.
 #[test]
 fn test_revoke_preserves_log_entry() {
     let env = Env::default();

--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -1,4 +1,4 @@
-﻿//! Standalone test for MaxUniqueInvestorsCap and UniqueFunderCount functionality
+//! Standalone test for MaxUniqueInvestorsCap and UniqueFunderCount functionality
 //! This test file validates the core functionality without dependencies on other test modules
 
 use super::*;
@@ -27,6 +27,7 @@ fn test_unique_funder_count_basic_functionality() {
         &None,
         &None,
         &Some(3u32),
+        &None,
         &None,
         &None,
         &None,
@@ -83,6 +84,7 @@ fn test_cap_enforcement_blocks_excess_investors() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Add two investors ÔÇö reaches the investor cap but NOT the funding target.
@@ -120,6 +122,7 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &Some(1u32),
+        &None,
         &None,
         &None,
         &None,
@@ -166,6 +169,7 @@ fn test_no_cap_allows_unlimited_investors() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_max_unique_investors_cap(), None);
@@ -206,6 +210,7 @@ fn test_max_per_investor_cap_blocks_excess_principal() {
         &Some(50_000_000_000i128),
         &None,
         &None,
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -241,6 +246,7 @@ fn test_init_zero_max_per_investor_panics() {
         &Some(0i128),
         &None,
         &None,
+        &None,
     );
 }
 
@@ -266,6 +272,7 @@ fn test_min_contribution_floor_below_value_rejected() {
         &Address::generate(&env),
         &None,
         &Some(floor),
+        &None,
         &None,
         &None,
         &None,
@@ -297,6 +304,7 @@ fn test_min_contribution_floor_exact_value_accepted() {
         &Address::generate(&env),
         &None,
         &Some(floor),
+        &None,
         &None,
         &None,
         &None,
@@ -335,6 +343,7 @@ fn test_min_contribution_floor_follow_on_below_value_rejected() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&investor, &floor);
@@ -365,6 +374,7 @@ fn test_per_investor_cap_exact_cumulative_value_accepted() {
         &None,
         &None,
         &Some(cap),
+        &None,
         &None,
         &None,
     );
@@ -402,6 +412,7 @@ fn test_per_investor_cap_one_over_rejected() {
         &Some(cap),
         &None,
         &None,
+        &None,
     );
 
     client.fund(&inv, &30_000_000_000i128);
@@ -429,6 +440,7 @@ fn test_unique_investor_cap_exact_value_accepted() {
         &None,
         &None,
         &Some(3u32),
+        &None,
         &None,
         &None,
         &None,
@@ -465,6 +477,7 @@ fn test_unique_investor_cap_new_funder_one_over_rejected() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10_000_000_000i128);
@@ -495,6 +508,7 @@ fn test_unique_investor_cap_existing_investor_follow_on_succeeds() {
         &None,
         &None,
         &Some(1u32),
+        &None,
         &None,
         &None,
         &None,
@@ -531,6 +545,7 @@ fn test_init_min_contribution_not_positive_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -555,6 +570,7 @@ fn test_init_min_contribution_exceeds_amount_panics() {
         &Address::generate(&env),
         &None,
         &Some(20_000_000_000i128),
+        &None,
         &None,
         &None,
         &None,
@@ -584,6 +600,7 @@ fn test_init_zero_max_unique_investors_panics() {
         &None,
         &None,
         &Some(0u32),
+        &None,
         &None,
         &None,
         &None,
@@ -619,6 +636,7 @@ fn test_cap_with_fund_with_commitment() {
         &Some(tiers),
         &None,
         &Some(2u32),
+        &None,
         &None,
         &None,
         &None,
@@ -667,6 +685,7 @@ fn test_lower_max_unique_investors_success() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let inv1 = Address::generate(&env);
@@ -705,6 +724,7 @@ fn test_lower_cap_blocks_new_investors_at_lowered_limit() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&Address::generate(&env), &20_000_000_000i128);
@@ -735,6 +755,7 @@ fn test_lower_cap_existing_investors_may_refund() {
         &None,
         &None,
         &Some(3u32),
+        &None,
         &None,
         &None,
         &None,
@@ -776,6 +797,7 @@ fn test_lower_cap_rejects_raise() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.lower_max_unique_investors(&4u32);
@@ -803,6 +825,7 @@ fn test_lower_cap_rejects_below_funder_count() {
         &None,
         &None,
         &Some(5u32),
+        &None,
         &None,
         &None,
         &None,
@@ -839,6 +862,7 @@ fn test_lower_cap_rejects_non_open_state() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100_000_000_000i128);
@@ -872,6 +896,7 @@ fn test_lower_cap_rejects_unlimited_escrow() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.lower_max_unique_investors(&10u32);
@@ -898,6 +923,7 @@ fn test_lower_cap_requires_admin_auth() {
         &None,
         &None,
         &Some(5u32),
+        &None,
         &None,
         &None,
         &None,
@@ -935,6 +961,7 @@ fn test_lower_cap_unauthorized_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     env.mock_auths(&[]);
@@ -965,6 +992,7 @@ fn test_lower_cap_emits_event() {
         &None,
         &None,
         &Some(5u32),
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -1,4 +1,4 @@
-//! Standalone test for MaxUniqueInvestorsCap and UniqueFunderCount functionality
+﻿//! Standalone test for MaxUniqueInvestorsCap and UniqueFunderCount functionality
 //! This test file validates the core functionality without dependencies on other test modules
 
 use super::*;
@@ -30,9 +30,9 @@ fn test_unique_funder_count_basic_functionality() {
         &None,
         &None,
         &None,
-        &None,
     );
-// Verify initial state
+
+    // Verify initial state
     assert_eq!(client.get_unique_funder_count(), 0);
     assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
 
@@ -83,9 +83,9 @@ fn test_cap_enforcement_blocks_excess_investors() {
         &None,
         &None,
         &None,
-        &None,
     );
-// Add two investors — reaches the investor cap but NOT the funding target.
+
+    // Add two investors ÔÇö reaches the investor cap but NOT the funding target.
     let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     client.fund(&inv1, &50_000_000_000i128);
@@ -93,7 +93,7 @@ fn test_cap_enforcement_blocks_excess_investors() {
     assert_eq!(client.get_unique_funder_count(), 2);
     assert_eq!(client.get_escrow().status, 0); // still open
 
-    // Third investor hits the cap — must panic "unique investor cap reached".
+    // Third investor hits the cap ÔÇö must panic "unique investor cap reached".
     let inv3 = Address::generate(&env);
     client.fund(&inv3, &1_000_000_000i128);
 }
@@ -123,9 +123,9 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &None,
-        &None,
     );
-let investor = Address::generate(&env);
+
+    let investor = Address::generate(&env);
 
     // First fund should succeed
     client.fund(&investor, &30_000_000_000i128);
@@ -166,9 +166,9 @@ fn test_no_cap_allows_unlimited_investors() {
         &None,
         &None,
         &None,
-        &None,
     );
-assert_eq!(client.get_max_unique_investors_cap(), None);
+
+    assert_eq!(client.get_max_unique_investors_cap(), None);
 
     // Should be able to add many investors when no cap is set
     for i in 0..5 {
@@ -206,9 +206,9 @@ fn test_max_per_investor_cap_blocks_excess_principal() {
         &Some(50_000_000_000i128),
         &None,
         &None,
-        &None,
     );
-let inv1 = Address::generate(&env);
+
+    let inv1 = Address::generate(&env);
     client.fund(&inv1, &30_000_000_000i128);
     assert_eq!(client.get_contribution(&inv1), 30_000_000_000i128);
 
@@ -241,7 +241,6 @@ fn test_init_zero_max_per_investor_panics() {
         &Some(0i128),
         &None,
         &None,
-        &None,
     );
 }
 
@@ -271,9 +270,9 @@ fn test_min_contribution_floor_below_value_rejected() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&Address::generate(&env), &(floor - 1));
+
+    client.fund(&Address::generate(&env), &(floor - 1));
 }
 
 #[test]
@@ -302,9 +301,9 @@ fn test_min_contribution_floor_exact_value_accepted() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&inv, &floor);
+
+    client.fund(&inv, &floor);
     assert_eq!(client.get_contribution(&inv), floor);
     assert_eq!(client.get_unique_funder_count(), 1);
 }
@@ -336,9 +335,9 @@ fn test_min_contribution_floor_follow_on_below_value_rejected() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&investor, &floor);
+
+    client.fund(&investor, &floor);
     client.fund(&investor, &(floor - 1));
 }
 
@@ -368,9 +367,9 @@ fn test_per_investor_cap_exact_cumulative_value_accepted() {
         &Some(cap),
         &None,
         &None,
-        &None,
     );
-client.fund(&inv, &30_000_000_000i128);
+
+    client.fund(&inv, &30_000_000_000i128);
     client.fund(&inv, &20_000_000_000i128);
     assert_eq!(client.get_contribution(&inv), cap);
     assert_eq!(client.get_unique_funder_count(), 1);
@@ -403,9 +402,9 @@ fn test_per_investor_cap_one_over_rejected() {
         &Some(cap),
         &None,
         &None,
-        &None,
     );
-client.fund(&inv, &30_000_000_000i128);
+
+    client.fund(&inv, &30_000_000_000i128);
     client.fund(&inv, &20_000_000_001i128);
 }
 
@@ -433,9 +432,9 @@ fn test_unique_investor_cap_exact_value_accepted() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&Address::generate(&env), &10_000_000_000i128);
+
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     assert_eq!(client.get_unique_funder_count(), 3);
@@ -466,9 +465,9 @@ fn test_unique_investor_cap_new_funder_one_over_rejected() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&Address::generate(&env), &10_000_000_000i128);
+
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &1_000_000_000i128);
@@ -499,9 +498,9 @@ fn test_unique_investor_cap_existing_investor_follow_on_succeeds() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&inv, &10_000_000_000i128);
+
+    client.fund(&inv, &10_000_000_000i128);
     client.fund(&inv, &10_000_000_000i128);
     assert_eq!(client.get_contribution(&inv), 20_000_000_000i128);
     assert_eq!(client.get_unique_funder_count(), 1);
@@ -528,7 +527,6 @@ fn test_init_min_contribution_not_positive_panics() {
         &Address::generate(&env),
         &None,
         &Some(0i128),
-        &None,
         &None,
         &None,
         &None,
@@ -561,7 +559,6 @@ fn test_init_min_contribution_exceeds_amount_panics() {
         &None,
         &None,
         &None,
-        &None,
     );
 }
 
@@ -587,7 +584,6 @@ fn test_init_zero_max_unique_investors_panics() {
         &None,
         &None,
         &Some(0u32),
-        &None,
         &None,
         &None,
         &None,
@@ -626,9 +622,9 @@ fn test_cap_with_fund_with_commitment() {
         &None,
         &None,
         &None,
-        &None,
     );
-assert_eq!(client.get_unique_funder_count(), 0);
+
+    assert_eq!(client.get_unique_funder_count(), 0);
 
     // First investor uses fund_with_commitment
     let inv1 = Address::generate(&env);
@@ -671,9 +667,9 @@ fn test_lower_max_unique_investors_success() {
         &None,
         &None,
         &None,
-        &None,
     );
-let inv1 = Address::generate(&env);
+
+    let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     client.fund(&inv1, &20_000_000_000i128);
     client.fund(&inv2, &20_000_000_000i128);
@@ -709,9 +705,9 @@ fn test_lower_cap_blocks_new_investors_at_lowered_limit() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&Address::generate(&env), &20_000_000_000i128);
+
+    client.fund(&Address::generate(&env), &20_000_000_000i128);
     client.fund(&Address::generate(&env), &20_000_000_000i128);
     client.lower_max_unique_investors(&2u32);
 
@@ -742,9 +738,9 @@ fn test_lower_cap_existing_investors_may_refund() {
         &None,
         &None,
         &None,
-        &None,
     );
-let inv1 = Address::generate(&env);
+
+    let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     client.fund(&inv1, &30_000_000_000i128);
     client.fund(&inv2, &30_000_000_000i128);
@@ -780,9 +776,9 @@ fn test_lower_cap_rejects_raise() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.lower_max_unique_investors(&4u32);
+
+    client.lower_max_unique_investors(&4u32);
 }
 
 #[test]
@@ -810,9 +806,9 @@ fn test_lower_cap_rejects_below_funder_count() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&Address::generate(&env), &10_000_000_000i128);
+
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.lower_max_unique_investors(&2u32);
@@ -843,9 +839,9 @@ fn test_lower_cap_rejects_non_open_state() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&Address::generate(&env), &100_000_000_000i128);
+
+    client.fund(&Address::generate(&env), &100_000_000_000i128);
     assert_eq!(client.get_escrow().status, 1);
     client.lower_max_unique_investors(&2u32);
 }
@@ -877,7 +873,8 @@ fn test_lower_cap_rejects_unlimited_escrow() {
         &None,
         &None,
     );
-client.lower_max_unique_investors(&10u32);
+
+    client.lower_max_unique_investors(&10u32);
 }
 
 #[test]
@@ -904,9 +901,9 @@ fn test_lower_cap_requires_admin_auth() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.lower_max_unique_investors(&3u32);
+
+    client.lower_max_unique_investors(&3u32);
     assert!(
         env.auths().iter().any(|(addr, _)| *addr == admin),
         "admin auth was not recorded for lower_max_unique_investors"
@@ -938,9 +935,9 @@ fn test_lower_cap_unauthorized_panics() {
         &None,
         &None,
         &None,
-        &None,
     );
-env.mock_auths(&[]);
+
+    env.mock_auths(&[]);
     client.lower_max_unique_investors(&3u32);
 }
 
@@ -971,9 +968,9 @@ fn test_lower_cap_emits_event() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&Address::generate(&env), &10_000_000_000i128);
+
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.lower_max_unique_investors(&3u32);
 
     assert_eq!(

--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -30,9 +30,9 @@ fn test_unique_funder_count_basic_functionality() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Verify initial state
+// Verify initial state
     assert_eq!(client.get_unique_funder_count(), 0);
     assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
 
@@ -83,9 +83,9 @@ fn test_cap_enforcement_blocks_excess_investors() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Add two investors — reaches the investor cap but NOT the funding target.
+// Add two investors — reaches the investor cap but NOT the funding target.
     let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     client.fund(&inv1, &50_000_000_000i128);
@@ -123,9 +123,9 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let investor = Address::generate(&env);
+let investor = Address::generate(&env);
 
     // First fund should succeed
     client.fund(&investor, &30_000_000_000i128);
@@ -166,9 +166,9 @@ fn test_no_cap_allows_unlimited_investors() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    assert_eq!(client.get_max_unique_investors_cap(), None);
+assert_eq!(client.get_max_unique_investors_cap(), None);
 
     // Should be able to add many investors when no cap is set
     for i in 0..5 {
@@ -206,9 +206,9 @@ fn test_max_per_investor_cap_blocks_excess_principal() {
         &Some(50_000_000_000i128),
         &None,
         &None,
+        &None,
     );
-
-    let inv1 = Address::generate(&env);
+let inv1 = Address::generate(&env);
     client.fund(&inv1, &30_000_000_000i128);
     assert_eq!(client.get_contribution(&inv1), 30_000_000_000i128);
 
@@ -241,6 +241,7 @@ fn test_init_zero_max_per_investor_panics() {
         &Some(0i128),
         &None,
         &None,
+        &None,
     );
 }
 
@@ -270,9 +271,9 @@ fn test_min_contribution_floor_below_value_rejected() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&Address::generate(&env), &(floor - 1));
+client.fund(&Address::generate(&env), &(floor - 1));
 }
 
 #[test]
@@ -301,9 +302,9 @@ fn test_min_contribution_floor_exact_value_accepted() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&inv, &floor);
+client.fund(&inv, &floor);
     assert_eq!(client.get_contribution(&inv), floor);
     assert_eq!(client.get_unique_funder_count(), 1);
 }
@@ -335,9 +336,9 @@ fn test_min_contribution_floor_follow_on_below_value_rejected() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&investor, &floor);
+client.fund(&investor, &floor);
     client.fund(&investor, &(floor - 1));
 }
 
@@ -367,9 +368,9 @@ fn test_per_investor_cap_exact_cumulative_value_accepted() {
         &Some(cap),
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&inv, &30_000_000_000i128);
+client.fund(&inv, &30_000_000_000i128);
     client.fund(&inv, &20_000_000_000i128);
     assert_eq!(client.get_contribution(&inv), cap);
     assert_eq!(client.get_unique_funder_count(), 1);
@@ -402,9 +403,9 @@ fn test_per_investor_cap_one_over_rejected() {
         &Some(cap),
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&inv, &30_000_000_000i128);
+client.fund(&inv, &30_000_000_000i128);
     client.fund(&inv, &20_000_000_001i128);
 }
 
@@ -432,9 +433,9 @@ fn test_unique_investor_cap_exact_value_accepted() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&Address::generate(&env), &10_000_000_000i128);
+client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     assert_eq!(client.get_unique_funder_count(), 3);
@@ -465,9 +466,9 @@ fn test_unique_investor_cap_new_funder_one_over_rejected() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&Address::generate(&env), &10_000_000_000i128);
+client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &1_000_000_000i128);
@@ -498,9 +499,9 @@ fn test_unique_investor_cap_existing_investor_follow_on_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&inv, &10_000_000_000i128);
+client.fund(&inv, &10_000_000_000i128);
     client.fund(&inv, &10_000_000_000i128);
     assert_eq!(client.get_contribution(&inv), 20_000_000_000i128);
     assert_eq!(client.get_unique_funder_count(), 1);
@@ -527,6 +528,7 @@ fn test_init_min_contribution_not_positive_panics() {
         &Address::generate(&env),
         &None,
         &Some(0i128),
+        &None,
         &None,
         &None,
         &None,
@@ -559,6 +561,7 @@ fn test_init_min_contribution_exceeds_amount_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -584,6 +587,7 @@ fn test_init_zero_max_unique_investors_panics() {
         &None,
         &None,
         &Some(0u32),
+        &None,
         &None,
         &None,
         &None,
@@ -622,9 +626,9 @@ fn test_cap_with_fund_with_commitment() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    assert_eq!(client.get_unique_funder_count(), 0);
+assert_eq!(client.get_unique_funder_count(), 0);
 
     // First investor uses fund_with_commitment
     let inv1 = Address::generate(&env);
@@ -667,9 +671,9 @@ fn test_lower_max_unique_investors_success() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let inv1 = Address::generate(&env);
+let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     client.fund(&inv1, &20_000_000_000i128);
     client.fund(&inv2, &20_000_000_000i128);
@@ -705,9 +709,9 @@ fn test_lower_cap_blocks_new_investors_at_lowered_limit() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&Address::generate(&env), &20_000_000_000i128);
+client.fund(&Address::generate(&env), &20_000_000_000i128);
     client.fund(&Address::generate(&env), &20_000_000_000i128);
     client.lower_max_unique_investors(&2u32);
 
@@ -738,9 +742,9 @@ fn test_lower_cap_existing_investors_may_refund() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let inv1 = Address::generate(&env);
+let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     client.fund(&inv1, &30_000_000_000i128);
     client.fund(&inv2, &30_000_000_000i128);
@@ -776,9 +780,9 @@ fn test_lower_cap_rejects_raise() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.lower_max_unique_investors(&4u32);
+client.lower_max_unique_investors(&4u32);
 }
 
 #[test]
@@ -806,9 +810,9 @@ fn test_lower_cap_rejects_below_funder_count() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&Address::generate(&env), &10_000_000_000i128);
+client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.lower_max_unique_investors(&2u32);
@@ -839,9 +843,9 @@ fn test_lower_cap_rejects_non_open_state() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&Address::generate(&env), &100_000_000_000i128);
+client.fund(&Address::generate(&env), &100_000_000_000i128);
     assert_eq!(client.get_escrow().status, 1);
     client.lower_max_unique_investors(&2u32);
 }
@@ -871,9 +875,9 @@ fn test_lower_cap_rejects_unlimited_escrow() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.lower_max_unique_investors(&10u32);
+client.lower_max_unique_investors(&10u32);
 }
 
 #[test]
@@ -900,9 +904,9 @@ fn test_lower_cap_requires_admin_auth() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.lower_max_unique_investors(&3u32);
+client.lower_max_unique_investors(&3u32);
     assert!(
         env.auths().iter().any(|(addr, _)| *addr == admin),
         "admin auth was not recorded for lower_max_unique_investors"
@@ -934,9 +938,9 @@ fn test_lower_cap_unauthorized_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    env.mock_auths(&[]);
+env.mock_auths(&[]);
     client.lower_max_unique_investors(&3u32);
 }
 
@@ -967,9 +971,9 @@ fn test_lower_cap_emits_event() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&Address::generate(&env), &10_000_000_000i128);
+client.fund(&Address::generate(&env), &10_000_000_000i128);
     client.lower_max_unique_investors(&3u32);
 
     assert_eq!(

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -53,6 +53,7 @@ fn typed_error_codes_cover_init_and_state_guards() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -84,6 +85,7 @@ fn typed_error_codes_cover_allowlist_attestation_and_dust_guards() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -294,6 +296,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &None,
         &None,
         &None,
+        &None,
     );
     treasury_client.cancel_funding();
     env.as_contract(&treasury_client.address, || {
@@ -316,6 +319,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -350,6 +354,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &None,
         &None,
         &None,
+        &None,
     );
     token.stellar.mint(&floor_client.address, &fund_amount);
     floor_client.fund(&sweep_investor, &fund_amount);
@@ -371,6 +376,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -410,6 +416,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &None,
         &None,
         &None,
+        &None,
     );
     let asset = soroban_sdk::Symbol::new(&env, "GOLD");
     assert_contract_error(
@@ -442,6 +449,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_contract_error(
         admin_client.try_update_funding_target(&0),
@@ -452,7 +460,7 @@ fn typed_error_codes_cover_range_boundaries() {
         EscrowError::NewAdminSameAsCurrent,
     );
 
-    // Migration group: 90–92
+    // Migration group: 90ÔÇô92
     let migrate_client = super::deploy(&env);
     migrate_client.init(
         &admin,
@@ -464,6 +472,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -502,6 +511,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_contract_error(
         fund_client.try_fund(&investor, &0),
@@ -520,6 +530,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -550,6 +561,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -587,6 +599,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &None,
         &Some(10u64),
         &None,
+        &None,
     );
     lh_client.set_legal_hold(&true);
     assert_contract_error(
@@ -599,7 +612,7 @@ fn typed_error_codes_cover_range_boundaries() {
         EscrowError::LegalHoldClearNotReady,
     );
 
-    // Beneficiary rotation group: 160–162
+    // Beneficiary rotation group: 160ÔÇô162
     let rot_client = super::deploy(&env);
     rot_client.init(
         &admin,
@@ -611,6 +624,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -642,6 +656,7 @@ fn typed_error_codes_cover_range_boundaries() {
         &rot_token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -681,6 +696,7 @@ fn typed_error_codes_cover_legal_hold_clear_delay_overflow() {
         &None,
         &Some(10u64),
         &None,
+        &None,
     );
     client.set_legal_hold(&true);
     assert_contract_error(
@@ -706,6 +722,7 @@ fn test_migrate_wrong_version() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -743,6 +760,7 @@ fn test_migrate_already_current() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_contract_error(
@@ -768,6 +786,7 @@ fn test_migrate_no_path() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -800,6 +819,7 @@ fn test_admin_handover_and_maturity_updates() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -846,6 +866,7 @@ fn test_update_maturity_not_open() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -877,6 +898,7 @@ fn test_transfer_admin_same_admin() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.propose_admin(&admin);
@@ -900,6 +922,7 @@ fn test_fund_during_legal_hold() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -937,6 +960,7 @@ fn test_fund_below_floor() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let investor = Address::generate(&env);
@@ -961,6 +985,7 @@ fn test_claim_not_settled() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -992,6 +1017,7 @@ fn test_claim_lock_not_expired() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1033,6 +1059,7 @@ fn test_all_getters() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_funding_token(), funding_token);
@@ -1064,6 +1091,7 @@ fn test_attestations_happy_path() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1107,6 +1135,7 @@ fn test_bind_primary_attestation_twice() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let hash = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
@@ -1134,6 +1163,7 @@ fn test_unique_investors_cap() {
         &None,
         &None,
         &Some(2),
+        &None,
         &None,
         &None,
         &None,
@@ -1168,6 +1198,7 @@ fn test_unique_investors_cap_exceeded() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&Address::generate(&env), &10);
@@ -1192,6 +1223,7 @@ fn test_sweep_terminal_dust_happy_path() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1235,6 +1267,7 @@ fn test_bump_ttl_covers_persistent_investor_keys() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.set_investor_allowlisted(&investor, &true);
     client.fund(&investor, &100);
@@ -1268,6 +1301,7 @@ fn test_sweep_not_terminal() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_contract_error(
@@ -1294,6 +1328,7 @@ fn test_sweep_no_balance() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1343,6 +1378,7 @@ fn test_withdraw_happy_path() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -1378,6 +1414,7 @@ fn test_settle_too_early() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&Address::generate(&env), &100);
@@ -1400,6 +1437,7 @@ fn test_update_funding_target_happy_path() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1435,6 +1473,7 @@ fn test_update_funding_target_too_low() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&Address::generate(&env), &50);
@@ -1457,6 +1496,7 @@ fn test_sme_collateral_commitment() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1497,6 +1537,7 @@ fn test_sme_collateral_empty_asset_rejected() {
         &None,
         &None,
         &None,
+        &None,
     );
     let empty_asset = soroban_sdk::Symbol::new(&env, "");
     client.record_sme_collateral_commitment(&empty_asset, &5000);
@@ -1519,6 +1560,7 @@ fn test_sme_collateral_stale_timestamp_rejected() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1552,6 +1594,7 @@ fn test_sme_collateral_replacement_preserves_prior_amount() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1597,6 +1640,7 @@ fn test_clear_legal_hold_convenience() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.set_legal_hold(&true);
@@ -1621,6 +1665,7 @@ fn test_claim_not_before_getter() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1668,6 +1713,7 @@ fn test_init_with_tiers() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(client.get_escrow().yield_bps, 100); // Default yield
 }
@@ -1689,6 +1735,7 @@ fn test_sweep_too_much() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1727,6 +1774,7 @@ fn test_withdraw_not_funded() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.withdraw();
@@ -1755,6 +1803,7 @@ fn test_settle_not_funded() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.settle();
@@ -1776,6 +1825,7 @@ fn test_fund_with_zero_commitment() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1812,6 +1862,7 @@ fn test_update_target_invalid() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.update_funding_target(&0);
@@ -1840,6 +1891,7 @@ fn test_init_yield_out_of_range() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -1862,6 +1914,7 @@ fn test_init_min_contribution_zero() {
         &treasury,
         &None,
         &Some(0),
+        &None,
         &None,
         &None,
         &None,
@@ -1896,6 +1949,7 @@ fn test_init_tiers_unsorted() {
         &None,
         &treasury,
         &Some(tiers),
+        &None,
         &None,
         &None,
         &None,
@@ -1936,6 +1990,7 @@ fn test_init_tiers_not_increasing_yield() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -1967,6 +2022,7 @@ fn test_init_tiers_lower_than_base() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -1986,6 +2042,7 @@ fn test_get_yield_bps_empty_tiers_branch() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -2035,6 +2092,7 @@ fn test_init_tier_yield_out_of_range() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -2063,6 +2121,7 @@ fn test_get_escrow_summary_happy_path() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -2135,6 +2194,7 @@ fn test_get_escrow_summary_after_state_changes() {
         &funding_token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -2234,6 +2294,7 @@ fn test_get_escrow_summary_with_collateral_and_attestations() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Record SME collateral
@@ -2311,6 +2372,7 @@ fn test_record_sme_collateral_commitment_semantics() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -2413,9 +2475,9 @@ fn test_record_sme_collateral_commitment_semantics() {
     );
 }
 
-// ──────────────────────────────────────────────────────────────────────────────
-// `is_settleable` view — readiness across status/maturity/hold combinations
-// ──────────────────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+// `is_settleable` view ÔÇö readiness across status/maturity/hold combinations
+// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 /// Helper: initialise a standard escrow for is_settleable tests.
 fn init_settleable_test(
@@ -2442,6 +2504,7 @@ fn init_settleable_test(
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -2458,7 +2521,7 @@ fn test_is_settleable_open_status_returns_false() {
     env.mock_all_auths();
     let (client, admin, sme) = setup(&env);
     init_settleable_test(&env, &client, &admin, &sme, 0);
-    // status = 0 (open) — not funded yet
+    // status = 0 (open) ÔÇö not funded yet
     assert!(!client.is_settleable());
 }
 
@@ -2469,7 +2532,7 @@ fn test_is_settleable_funded_no_maturity_returns_true() {
     let (client, admin, sme) = setup(&env);
     init_settleable_test(&env, &client, &admin, &sme, 0);
     fund_to_target_stl(&env, &client);
-    // status = 1 (funded), maturity = 0, no hold → settleable
+    // status = 1 (funded), maturity = 0, no hold ÔåÆ settleable
     assert!(client.is_settleable());
 }
 
@@ -2535,7 +2598,7 @@ fn test_is_settleable_withdrawn_returns_false() {
 fn test_is_settleable_not_initialized_panics() {
     let env = Env::default();
     let (client, _admin, _sme) = setup(&env);
-    // No init call — get_escrow returns error
+    // No init call ÔÇö get_escrow returns error
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.is_settleable();
     }));
@@ -2559,9 +2622,9 @@ fn test_is_settleable_funded_maturity_zero_hold_active_returns_false() {
     );
 }
 
-// ──────────────────────────────────────────────────────────────────────────────
-// `EscrowSettled` event — `settled_at_ledger_timestamp` field
-// ──────────────────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+// `EscrowSettled` event ÔÇö `settled_at_ledger_timestamp` field
+// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 fn test_settle_event_timestamp_matches_ledger_time() {
@@ -2581,6 +2644,7 @@ fn test_settle_event_timestamp_matches_ledger_time() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -2618,6 +2682,7 @@ fn test_settle_event_timestamp_with_maturity() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -2662,6 +2727,7 @@ fn test_settle_event_emitted_at_current_ledger_time() {
         &None,
         &None,
         &None,
+        &None,
     );
     fund_to_target_stl(&env, &client);
     client.settle();
@@ -2670,9 +2736,9 @@ fn test_settle_event_emitted_at_current_ledger_time() {
     assert_eq!(client.get_escrow().status, 2);
 }
 
-// ──────────────────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 // `is_settleable` edge: partial_settle then pre-maturity
-// ──────────────────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 fn test_is_settleable_after_partial_settle_with_maturity() {

--- a/escrow/src/tests/external_calls.rs
+++ b/escrow/src/tests/external_calls.rs
@@ -1,4 +1,4 @@
-use super::super::external_calls::transfer_funding_token_with_balance_checks;
+﻿use super::super::external_calls::transfer_funding_token_with_balance_checks;
 use super::*;
 use soroban_sdk::{Address, Env, MuxedAddress};
 
@@ -199,7 +199,7 @@ fn test_edge_case_maximum_amount_transfer() {
     assert_eq!(treasury_after, large_amount);
 }
 
-// ── Liability floor tests for sweep_terminal_dust ────────────────────────────
+// ÔöÇÔöÇ Liability floor tests for sweep_terminal_dust ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 fn setup_cancelled_with_token<'a>(
     env: &'a Env,
@@ -229,7 +229,7 @@ fn setup_cancelled_with_token<'a>(
         &None,
         &None,
     );
-// Mint tokens into the contract to simulate on-chain custody
+    // Mint tokens into the contract to simulate on-chain custody
     token.stellar.mint(&client.address, &fund_amount);
     client.fund(investor, &fund_amount);
     client.cancel_funding();
@@ -250,11 +250,11 @@ fn sweep_liability_floor_allows_true_dust_after_all_refunded() {
     // Mint 1 extra unit of dust on top of the principal
     token.stellar.mint(&client.address, &1i128);
 
-    // Refund the investor — this increments DistributedPrincipal by fund_amount
+    // Refund the investor ÔÇö this increments DistributedPrincipal by fund_amount
     client.refund(&investor);
 
     // Now outstanding = funded_amount - distributed = 1000 - 1000 = 0
-    // balance = 1 (the dust), sweep_amt = 1, floor check: 1 - 1 >= 0 ✓
+    // balance = 1 (the dust), sweep_amt = 1, floor check: 1 - 1 >= 0 Ô£ô
     let swept = client.sweep_terminal_dust(&1i128);
     assert_eq!(swept, 1i128);
     assert_eq!(token.token.balance(&treasury), 1i128);
@@ -309,18 +309,19 @@ fn sweep_liability_floor_allows_sweep_of_excess_above_outstanding() {
         &None,
         &None,
     );
-// Mint 1001 into contract: 500 for A, 500 for B, 1 dust
+
+    // Mint 1001 into contract: 500 for A, 500 for B, 1 dust
     token.stellar.mint(&client.address, &1_001i128);
     client.fund(&investor_a, &500i128);
     client.fund(&investor_b, &500i128);
     client.cancel_funding();
 
-    // Refund investor_a → distributed = 500, outstanding = 500
+    // Refund investor_a ÔåÆ distributed = 500, outstanding = 500
     client.refund(&investor_a);
     assert_eq!(client.get_distributed_principal(), 500i128);
 
     // balance = 501 (500 for B + 1 dust), outstanding = 500
-    // sweep of 1: 501 - 1 = 500 >= 500 ✓
+    // sweep of 1: 501 - 1 = 500 >= 500 Ô£ô
     let swept = client.sweep_terminal_dust(&1i128);
     assert_eq!(swept, 1i128);
     assert_eq!(token.token.balance(&treasury), 1i128);
@@ -356,13 +357,14 @@ fn sweep_liability_floor_blocks_sweep_that_would_eat_into_outstanding() {
         &None,
         &None,
     );
-token.stellar.mint(&client.address, &1_001i128);
+
+    token.stellar.mint(&client.address, &1_001i128);
     client.fund(&investor_a, &500i128);
     client.fund(&investor_b, &500i128);
     client.cancel_funding();
     client.refund(&investor_a);
 
-    // balance = 501, outstanding = 500; sweep of 2 → 501 - 2 = 499 < 500 ✗
+    // balance = 501, outstanding = 500; sweep of 2 ÔåÆ 501 - 2 = 499 < 500 Ô£ù
     client.sweep_terminal_dust(&2i128);
 }
 
@@ -394,7 +396,7 @@ fn sweep_liability_floor_zero_funded_amount_allows_sweep() {
         &None,
         &None,
     );
-client.cancel_funding();
+    client.cancel_funding();
 
     // Stray airdrop of 50 tokens
     token.stellar.mint(&client.address, &50i128);
@@ -434,7 +436,8 @@ fn distributed_principal_accumulates_across_multiple_refunds() {
         &None,
         &None,
     );
-token.stellar.mint(&client.address, &900i128);
+
+    token.stellar.mint(&client.address, &900i128);
     client.fund(&inv_a, &300i128);
     client.fund(&inv_b, &300i128);
     client.fund(&inv_c, &300i128);
@@ -451,7 +454,7 @@ token.stellar.mint(&client.address, &900i128);
     client.refund(&inv_c);
     assert_eq!(client.get_distributed_principal(), 900i128);
 
-    // All refunded — outstanding = 0, any dust can be swept
+    // All refunded ÔÇö outstanding = 0, any dust can be swept
     token.stellar.mint(&client.address, &5i128);
     let swept = client.sweep_terminal_dust(&5i128);
     assert_eq!(swept, 5i128);

--- a/escrow/src/tests/external_calls.rs
+++ b/escrow/src/tests/external_calls.rs
@@ -227,8 +227,9 @@ fn setup_cancelled_with_token<'a>(
         &None,
         &None,
         &None,
+        &None,
     );
-    // Mint tokens into the contract to simulate on-chain custody
+// Mint tokens into the contract to simulate on-chain custody
     token.stellar.mint(&client.address, &fund_amount);
     client.fund(investor, &fund_amount);
     client.cancel_funding();
@@ -306,9 +307,9 @@ fn sweep_liability_floor_allows_sweep_of_excess_above_outstanding() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Mint 1001 into contract: 500 for A, 500 for B, 1 dust
+// Mint 1001 into contract: 500 for A, 500 for B, 1 dust
     token.stellar.mint(&client.address, &1_001i128);
     client.fund(&investor_a, &500i128);
     client.fund(&investor_b, &500i128);
@@ -353,9 +354,9 @@ fn sweep_liability_floor_blocks_sweep_that_would_eat_into_outstanding() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    token.stellar.mint(&client.address, &1_001i128);
+token.stellar.mint(&client.address, &1_001i128);
     client.fund(&investor_a, &500i128);
     client.fund(&investor_b, &500i128);
     client.cancel_funding();
@@ -391,8 +392,9 @@ fn sweep_liability_floor_zero_funded_amount_allows_sweep() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.cancel_funding();
+client.cancel_funding();
 
     // Stray airdrop of 50 tokens
     token.stellar.mint(&client.address, &50i128);
@@ -430,9 +432,9 @@ fn distributed_principal_accumulates_across_multiple_refunds() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    token.stellar.mint(&client.address, &900i128);
+token.stellar.mint(&client.address, &900i128);
     client.fund(&inv_a, &300i128);
     client.fund(&inv_b, &300i128);
     client.fund(&inv_c, &300i128);

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -1,4 +1,4 @@
-﻿use super::*;
+use super::*;
 use soroban_sdk::{Error, InvokeError};
 use std::fmt::Debug;
 
@@ -45,6 +45,7 @@ fn test_fund_and_settle() {
         &None,
         &None,
         &None,
+        &None,
     );
     let funded = client.fund(&investor, &TARGET);
     assert_eq!(funded.funded_amount, TARGET);
@@ -68,6 +69,7 @@ fn test_fund_partial_then_full() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -140,6 +142,7 @@ fn test_single_investor_contribution_tracked() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &(30_000_000_000i128));
     let contribution = client.get_contribution(&investor);
@@ -179,6 +182,7 @@ fn test_repeated_funding_accumulates_contribution() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &(20_000_000_000i128));
     client.fund(&investor, &(30_000_000_000i128));
@@ -209,6 +213,7 @@ fn test_funding_amount_accumulation_overflow_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&investor_a, &(i128::MAX - 1));
@@ -230,6 +235,7 @@ fn test_funding_amount_overflow_does_not_mutate_state() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -277,6 +283,7 @@ fn test_fund_with_commitment_overflow_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&investor_a, &(i128::MAX - 1));
@@ -299,6 +306,7 @@ fn test_fund_with_commitment_overflow_does_not_mutate_state() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -342,6 +350,7 @@ fn test_per_investor_contribution_uses_persistent_storage() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -403,6 +412,7 @@ fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     env.as_contract(&contract_id, || {
@@ -443,6 +453,7 @@ fn test_investor_contribution_overflow_does_not_mutate_state() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -499,6 +510,7 @@ fn test_multiple_investors_tracked_independently() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
@@ -529,6 +541,7 @@ fn test_contributions_sum_equals_funded_amount() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -568,6 +581,7 @@ fn test_cost_baseline_fund_partial() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &(10_000_000_000i128));
 }
@@ -594,6 +608,7 @@ fn test_cost_baseline_fund_full() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &TARGET);
 }
@@ -613,6 +628,7 @@ fn test_cost_baseline_fund_overshoot() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -647,6 +663,7 @@ fn test_cost_baseline_fund_two_step_completion() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &(TARGET / 2));
     client.fund(&investor, &(TARGET / 2));
@@ -672,6 +689,7 @@ fn test_funding_close_snapshot_captures_overfunded_total_once() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -716,6 +734,7 @@ fn test_funding_snapshot_immutable_across_second_fund_after_funded() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&a, &(TARGET / 2));
     assert_eq!(client.get_funding_close_snapshot(), None);
@@ -746,6 +765,7 @@ fn test_pro_rata_weight_ratio_from_snapshot() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -797,6 +817,7 @@ fn test_tiered_yield_and_follow_on_fund() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund_with_commitment(&inv, &5_000i128, &200u64);
     assert_eq!(client.get_investor_yield_bps(&inv), 900);
@@ -832,6 +853,7 @@ fn test_tier_selection_edges_base_vs_high_bucket() {
         &None,
         &tre,
         &Some(tiers),
+        &None,
         &None,
         &None,
         &None,
@@ -875,6 +897,7 @@ fn test_fund_with_commitment_twice_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
@@ -900,6 +923,7 @@ fn test_fund_then_fund_with_commitment_panics() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -942,6 +966,7 @@ fn test_tier_selection_ladder() {
         &None,
         &tre,
         &Some(tiers),
+        &None,
         &None,
         &None,
         &None,
@@ -1000,6 +1025,7 @@ fn test_yield_tier_emitted_in_event() {
         &None,
         &tre,
         &Some(tiers),
+        &None,
         &None,
         &None,
         &None,
@@ -1081,6 +1107,7 @@ fn test_yield_tier_emitted_no_tiers() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let inv = Address::generate(&env);
@@ -1136,6 +1163,7 @@ fn test_yield_tier_emitted_between_tiers() {
         &None,
         &tre,
         &Some(tiers),
+        &None,
         &None,
         &None,
         &None,
@@ -1197,6 +1225,7 @@ fn test_fund_with_commitment_zero_lock_behaves_as_fund() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund_with_commitment(&inv, &5_000i128, &0u64);
@@ -1226,6 +1255,7 @@ fn test_commitment_claim_time_allows_u64_max_boundary() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1270,6 +1300,7 @@ fn test_commitment_claim_time_overflow_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund_with_commitment(&investor, &100i128, &6u64);
@@ -1297,6 +1328,7 @@ fn test_commitment_claim_time_overflow_does_not_record_position() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1350,6 +1382,7 @@ fn test_init_bad_tier_order_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -1383,6 +1416,7 @@ fn test_init_tier_yield_below_base_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -1406,6 +1440,7 @@ fn test_differential_funding_target_eq_exact_cross() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1448,6 +1483,7 @@ fn test_ledger_sequence_recorded_in_snapshot_with_tick() {
         &None,
         &None,
         &None,
+        &None,
     );
     let seq = env.ledger().sequence();
     client.fund(&inv, &1_000i128);
@@ -1474,6 +1510,7 @@ fn test_get_funding_close_snapshot_absent_before_any_funding() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1509,6 +1546,7 @@ fn test_get_funding_close_snapshot_present_after_funding_completes() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -1562,6 +1600,7 @@ fn test_get_funding_close_snapshot_immutable_after_set() {
         &None,
         &None,
         &None,
+        &None,
     );
     // Fund exactly to target ÔÇö snapshot is written here.
     client.fund(&inv, &TARGET);
@@ -1602,6 +1641,7 @@ fn test_unique_funder_count_initialized_to_zero() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(client.get_unique_funder_count(), 0);
 }
@@ -1621,6 +1661,7 @@ fn test_unique_funder_count_increments_on_first_investor() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -1653,6 +1694,7 @@ fn test_unique_funder_count_increments_for_distinct_investors() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -1706,6 +1748,7 @@ fn test_unique_funder_count_with_fund_with_commitment() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -1739,6 +1782,7 @@ fn test_max_unique_investors_cap_none_allows_unlimited() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Should be able to add many investors when no cap is set
@@ -1767,6 +1811,7 @@ fn test_max_unique_investors_cap_enforced_at_limit() {
         &None,
         &None,
         &Some(3u32), // Cap of 3 investors
+        &None,
         &None,
         &None,
         &None,
@@ -1811,6 +1856,7 @@ fn test_max_unique_investors_cap_blocks_excess_investors() {
         &None,
         &None,
         &Some(2u32), // Cap of 2 investors
+        &None,
         &None,
         &None,
         &None,
@@ -1859,6 +1905,7 @@ fn test_max_unique_investors_cap_blocks_fund_with_commitment() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // First investor succeeds
@@ -1889,6 +1936,7 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &Some(1u32), // Cap of 1 investor
+        &None,
         &None,
         &None,
         &None,
@@ -1929,6 +1977,7 @@ fn test_zero_contribution_then_non_zero_contribution_counts_as_unique_investor()
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert_eq!(client.get_unique_funder_count(), 0);
@@ -1963,6 +2012,7 @@ fn test_cap_validation_at_init_positive_value_required() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -1987,6 +2037,7 @@ fn test_init_panics_for_zero_cap() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -2008,6 +2059,7 @@ fn test_cap_edge_case_exact_limit_reached() {
         &None,
         &None,
         &Some(5u32), // Cap of 5 investors
+        &None,
         &None,
         &None,
         &None,
@@ -2049,6 +2101,7 @@ fn test_cap_edge_case_exactly_one_over_limit_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Add exactly 5 investors
@@ -2080,6 +2133,7 @@ fn test_cap_with_min_contribution_floor_interaction() {
         &None,
         &Some(1_000i128), // Min contribution floor
         &Some(3u32),      // Cap of 3 investors
+        &None,
         &None,
         &None,
         &None,
@@ -2125,6 +2179,7 @@ fn test_cap_blocks_even_with_large_contribution() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // First investor can fund large amount
@@ -2162,6 +2217,7 @@ fn test_cap_panic_message_quality() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Add first investor
@@ -2196,6 +2252,7 @@ fn init_with_token<'a>(
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -2472,6 +2529,7 @@ fn test_commitment_claim_lock_preserved_after_follow_on_fund() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Set ledger timestamp to a known value so claim_nb is deterministic.
@@ -2539,6 +2597,7 @@ fn test_commitment_invariant_across_multiple_follow_on_funds() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     env.ledger().with_mut(|l| l.timestamp = 2_000_000u64);
@@ -2596,6 +2655,7 @@ fn test_commitment_zero_lock_follow_on_fund_no_claim_gate() {
         &None,
         &tre,
         &Some(tiers),
+        &None,
         &None,
         &None,
         &None,
@@ -2661,6 +2721,7 @@ fn test_second_fund_with_commitment_panics_without_tier_table() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund_with_commitment(&inv, &3_000i128, &0u64);
@@ -2701,6 +2762,7 @@ fn test_fund_first_then_commitment_second_panics() {
         &None,
         &tre,
         &Some(tiers),
+        &None,
         &None,
         &None,
         &None,
@@ -2752,6 +2814,7 @@ fn test_fund_first_deposit_sets_base_yield_and_no_claim_gate() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund(&inv, &5_000i128);
@@ -2788,6 +2851,7 @@ fn init_with_maturity(
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -2902,6 +2966,7 @@ fn lock_with_zero_maturity_is_always_accepted() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -3061,6 +3126,7 @@ fn test_fund_batch_per_investor_cap_rejection() {
         &Some(per_investor_cap),
         &None,
         &None,
+        &None,
     );
 
     let mut entries = SorobanVec::new(&env);
@@ -3091,6 +3157,7 @@ fn test_fund_batch_mid_batch_funded_transition() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -3157,6 +3224,7 @@ fn test_fund_batch_duplicate_addresses() {
         &None,
         &None,
         &Some(per_investor_cap),
+        &None,
         &None,
         &None,
     );
@@ -3237,6 +3305,7 @@ fn test_fund_batch_max_batch_size() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Create exactly MAX_FUND_BATCH entries
@@ -3274,6 +3343,7 @@ fn test_fund_batch_preserves_event_semantics() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -1,4 +1,4 @@
-use super::*;
+﻿use super::*;
 use soroban_sdk::{Error, InvokeError};
 use std::fmt::Debug;
 
@@ -46,7 +46,7 @@ fn test_fund_and_settle() {
         &None,
         &None,
     );
-let funded = client.fund(&investor, &TARGET);
+    let funded = client.fund(&investor, &TARGET);
     assert_eq!(funded.funded_amount, TARGET);
     assert_eq!(funded.status, 1);
     let settled = client.settle();
@@ -76,7 +76,7 @@ fn test_fund_partial_then_full() {
         &None,
         &None,
     );
-let partial = client.fund(&investor, &(TARGET / 2));
+    let partial = client.fund(&investor, &(TARGET / 2));
     assert_eq!(partial.status, 0);
     assert_eq!(partial.funded_amount, TARGET / 2);
     let full = client.fund(&investor, &(TARGET / 2));
@@ -141,7 +141,7 @@ fn test_single_investor_contribution_tracked() {
         &None,
         &None,
     );
-client.fund(&investor, &(30_000_000_000i128));
+    client.fund(&investor, &(30_000_000_000i128));
     let contribution = client.get_contribution(&investor);
     assert_eq!(contribution, 30_000_000_000i128);
 }
@@ -180,7 +180,7 @@ fn test_repeated_funding_accumulates_contribution() {
         &None,
         &None,
     );
-client.fund(&investor, &(20_000_000_000i128));
+    client.fund(&investor, &(20_000_000_000i128));
     client.fund(&investor, &(30_000_000_000i128));
     assert_eq!(client.get_contribution(&investor), 50_000_000_000i128);
 }
@@ -210,7 +210,8 @@ fn test_funding_amount_accumulation_overflow_panics() {
         &None,
         &None,
     );
-client.fund(&investor_a, &(i128::MAX - 1));
+
+    client.fund(&investor_a, &(i128::MAX - 1));
     client.fund(&investor_b, &2i128);
 }
 
@@ -237,7 +238,8 @@ fn test_funding_amount_overflow_does_not_mutate_state() {
         &None,
         &None,
     );
-client.fund(&investor, &(i128::MAX - 1));
+
+    client.fund(&investor, &(i128::MAX - 1));
     let before = client.get_escrow();
 
     let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -276,7 +278,8 @@ fn test_fund_with_commitment_overflow_panics() {
         &None,
         &None,
     );
-client.fund(&investor_a, &(i128::MAX - 1));
+
+    client.fund(&investor_a, &(i128::MAX - 1));
     client.fund_with_commitment(&investor_b, &2i128, &0u64);
 }
 
@@ -304,7 +307,8 @@ fn test_fund_with_commitment_overflow_does_not_mutate_state() {
         &None,
         &None,
     );
-client.fund(&investor_a, &(i128::MAX - 1));
+
+    client.fund(&investor_a, &(i128::MAX - 1));
     let before = client.get_escrow();
 
     let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -346,7 +350,7 @@ fn test_per_investor_contribution_uses_persistent_storage() {
         &None,
         &None,
     );
-client.fund(&investor, &500i128);
+    client.fund(&investor, &500i128);
 
     env.as_contract(&contract_id, || {
         assert_eq!(
@@ -400,7 +404,8 @@ fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
         &None,
         &None,
     );
-env.as_contract(&contract_id, || {
+
+    env.as_contract(&contract_id, || {
         // Force the contribution near i128::MAX while keeping funded_amount small.
         // `fund` must still trap on contribution overflow even if funded_amount would not.
         env.storage().persistent().set(
@@ -446,7 +451,8 @@ fn test_investor_contribution_overflow_does_not_mutate_state() {
         &None,
         &None,
     );
-env.as_contract(&contract_id, || {
+
+    env.as_contract(&contract_id, || {
         env.storage().persistent().set(
             &DataKey::InvestorContribution(investor.clone()),
             &(i128::MAX - 1),
@@ -494,7 +500,7 @@ fn test_multiple_investors_tracked_independently() {
         &None,
         &None,
     );
-client.fund(&inv_a, &(20_000_000_000i128));
+    client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
     client.fund(&inv_c, &(30_000_000_000i128));
     assert_eq!(client.get_contribution(&inv_a), 20_000_000_000i128);
@@ -531,7 +537,7 @@ fn test_contributions_sum_equals_funded_amount() {
         &None,
         &None,
     );
-client.fund(&inv_a, &(20_000_000_000i128));
+    client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
     client.fund(&inv_c, &(30_000_000_000i128));
     let sum = client.get_contribution(&inv_a)
@@ -563,7 +569,7 @@ fn test_cost_baseline_fund_partial() {
         &None,
         &None,
     );
-client.fund(&investor, &(10_000_000_000i128));
+    client.fund(&investor, &(10_000_000_000i128));
 }
 
 #[test]
@@ -589,7 +595,7 @@ fn test_cost_baseline_fund_full() {
         &None,
         &None,
     );
-client.fund(&investor, &TARGET);
+    client.fund(&investor, &TARGET);
 }
 
 #[test]
@@ -615,7 +621,7 @@ fn test_cost_baseline_fund_overshoot() {
         &None,
         &None,
     );
-client.fund(&investor, &(150_000_000_000i128));
+    client.fund(&investor, &(150_000_000_000i128));
     assert_eq!(client.get_escrow().status, 1);
 }
 
@@ -642,7 +648,7 @@ fn test_cost_baseline_fund_two_step_completion() {
         &None,
         &None,
     );
-client.fund(&investor, &(TARGET / 2));
+    client.fund(&investor, &(TARGET / 2));
     client.fund(&investor, &(TARGET / 2));
     assert_eq!(client.get_escrow().status, 1);
 }
@@ -674,7 +680,7 @@ fn test_funding_close_snapshot_captures_overfunded_total_once() {
         &None,
         &None,
     );
-assert_eq!(client.get_funding_close_snapshot(), None);
+    assert_eq!(client.get_funding_close_snapshot(), None);
     client.fund(&inv, &(TARGET + 50_000_000_000i128));
     let snap = client.get_funding_close_snapshot().expect("snapshot");
     assert_eq!(snap.total_principal, TARGET + 50_000_000_000i128);
@@ -711,7 +717,7 @@ fn test_funding_snapshot_immutable_across_second_fund_after_funded() {
         &None,
         &None,
     );
-client.fund(&a, &(TARGET / 2));
+    client.fund(&a, &(TARGET / 2));
     assert_eq!(client.get_funding_close_snapshot(), None);
     client.fund(&b, &(TARGET / 2));
     let s1 = client.get_funding_close_snapshot().unwrap();
@@ -748,7 +754,7 @@ fn test_pro_rata_weight_ratio_from_snapshot() {
         &None,
         &None,
     );
-client.fund(&a, &(20_000_000_000i128));
+    client.fund(&a, &(20_000_000_000i128));
     client.fund(&b, &(80_000_000_000i128));
     let snap = client.get_funding_close_snapshot().unwrap();
     assert_eq!(snap.total_principal, TARGET);
@@ -791,9 +797,8 @@ fn test_tiered_yield_and_follow_on_fund() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund_with_commitment(&inv, &5_000i128, &200u64);
+    client.fund_with_commitment(&inv, &5_000i128, &200u64);
     assert_eq!(client.get_investor_yield_bps(&inv), 900);
     assert_eq!(client.get_investor_claim_not_before(&inv), 200);
     client.fund(&inv, &5_000i128);
@@ -832,9 +837,8 @@ fn test_tier_selection_edges_base_vs_high_bucket() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund_with_commitment(&i_short, &10_000i128, &40u64);
+    client.fund_with_commitment(&i_short, &10_000i128, &40u64);
     assert_eq!(client.get_investor_yield_bps(&i_short), 800);
     client.fund_with_commitment(&i_long, &10_000i128, &50u64);
     assert_eq!(client.get_investor_yield_bps(&i_long), 850);
@@ -871,9 +875,8 @@ fn test_fund_with_commitment_twice_panics() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund_with_commitment(&inv, &5_000i128, &10u64);
+    client.fund_with_commitment(&inv, &5_000i128, &10u64);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
 }
 
@@ -905,7 +908,7 @@ fn test_fund_then_fund_with_commitment_panics() {
         &None,
         &None,
     );
-client.fund(&inv, &5_000i128);
+    client.fund(&inv, &5_000i128);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
 }
 
@@ -944,9 +947,9 @@ fn test_tier_selection_ladder() {
         &None,
         &None,
         &None,
-        &None,
     );
-let inv_base = Address::generate(&env);
+
+    let inv_base = Address::generate(&env);
     let inv_tier1 = Address::generate(&env);
     let inv_tier2 = Address::generate(&env);
     let inv_mid = Address::generate(&env);
@@ -1002,9 +1005,9 @@ fn test_yield_tier_emitted_in_event() {
         &None,
         &None,
         &None,
-        &None,
     );
-let inv = Address::generate(&env);
+
+    let inv = Address::generate(&env);
 
     // 1. Tiered fund: committed_lock_secs=150 >= tier.min_lock_secs=100 => yield 900, lock 100.
     client.fund_with_commitment(&inv, &1_000i128, &150u64);
@@ -1079,7 +1082,8 @@ fn test_yield_tier_emitted_no_tiers() {
         &None,
         &None,
     );
-let inv = Address::generate(&env);
+
+    let inv = Address::generate(&env);
     // fund_with_commitment even with no tiers configured
     client.fund_with_commitment(&inv, &1_000i128, &150u64);
 
@@ -1137,9 +1141,9 @@ fn test_yield_tier_emitted_between_tiers() {
         &None,
         &None,
         &None,
-        &None,
     );
-let inv = Address::generate(&env);
+
+    let inv = Address::generate(&env);
     // Committing 150 secs (between 100 and 200) -> matches the 100 sec tier.
     client.fund_with_commitment(&inv, &1_000i128, &150u64);
 
@@ -1193,9 +1197,9 @@ fn test_fund_with_commitment_zero_lock_behaves_as_fund() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund_with_commitment(&inv, &5_000i128, &0u64);
+
+    client.fund_with_commitment(&inv, &5_000i128, &0u64);
     assert_eq!(client.get_investor_yield_bps(&inv), 800);
     assert_eq!(client.get_investor_claim_not_before(&inv), 0);
 }
@@ -1230,7 +1234,8 @@ fn test_commitment_claim_time_allows_u64_max_boundary() {
         &None,
         &None,
     );
-client.fund_with_commitment(&investor, &100i128, &5u64);
+
+    client.fund_with_commitment(&investor, &100i128, &5u64);
 
     assert_eq!(client.get_investor_claim_not_before(&investor), u64::MAX);
 }
@@ -1266,7 +1271,8 @@ fn test_commitment_claim_time_overflow_panics() {
         &None,
         &None,
     );
-client.fund_with_commitment(&investor, &100i128, &6u64);
+
+    client.fund_with_commitment(&investor, &100i128, &6u64);
 }
 
 #[test]
@@ -1299,7 +1305,8 @@ fn test_commitment_claim_time_overflow_does_not_record_position() {
         &None,
         &None,
     );
-let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+
+    let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.fund_with_commitment(&investor, &100i128, &6u64);
     }));
     assert!(overflowed.is_err());
@@ -1343,7 +1350,6 @@ fn test_init_bad_tier_order_panics() {
         &None,
         &None,
         &None,
-        &None,
     );
 }
 
@@ -1372,7 +1378,6 @@ fn test_init_tier_yield_below_base_panics() {
         &None,
         &tre,
         &Some(tiers),
-        &None,
         &None,
         &None,
         &None,
@@ -1409,7 +1414,7 @@ fn test_differential_funding_target_eq_exact_cross() {
         &None,
         &None,
     );
-let escrow = client.fund(&inv, &t);
+    let escrow = client.fund(&inv, &t);
     assert_eq!(escrow.funded_amount, t);
     assert_eq!(escrow.status, 1);
     let snap = client.get_funding_close_snapshot().unwrap();
@@ -1444,7 +1449,7 @@ fn test_ledger_sequence_recorded_in_snapshot_with_tick() {
         &None,
         &None,
     );
-let seq = env.ledger().sequence();
+    let seq = env.ledger().sequence();
     client.fund(&inv, &1_000i128);
     let snap = client.get_funding_close_snapshot().unwrap();
     assert_eq!(snap.closed_at_ledger_sequence, seq);
@@ -1477,7 +1482,7 @@ fn test_get_funding_close_snapshot_absent_before_any_funding() {
         &None,
         &None,
     );
-assert_eq!(
+    assert_eq!(
         client.get_funding_close_snapshot(),
         None,
         "snapshot must be absent before any funding"
@@ -1512,14 +1517,14 @@ fn test_get_funding_close_snapshot_present_after_funding_completes() {
         &None,
         &None,
     );
-// Partial fund — snapshot still absent.
+    // Partial fund ÔÇö snapshot still absent.
     client.fund(&inv, &(TARGET / 2));
     assert_eq!(
         client.get_funding_close_snapshot(),
         None,
         "snapshot must remain absent while escrow is still open"
     );
-    // Final fund that crosses the target — snapshot must now be present.
+    // Final fund that crosses the target ÔÇö snapshot must now be present.
     client.fund(&inv, &(TARGET / 2));
     let snap = client
         .get_funding_close_snapshot()
@@ -1558,12 +1563,12 @@ fn test_get_funding_close_snapshot_immutable_after_set() {
         &None,
         &None,
     );
-// Fund exactly to target — snapshot is written here.
+    // Fund exactly to target ÔÇö snapshot is written here.
     client.fund(&inv, &TARGET);
     let snap_at_close = client
         .get_funding_close_snapshot()
         .expect("snapshot must be present after funding");
-    // Advance through settlement — snapshot must remain identical.
+    // Advance through settlement ÔÇö snapshot must remain identical.
     client.settle();
     let snap_after_settle = client
         .get_funding_close_snapshot()
@@ -1598,7 +1603,7 @@ fn test_unique_funder_count_initialized_to_zero() {
         &None,
         &None,
     );
-assert_eq!(client.get_unique_funder_count(), 0);
+    assert_eq!(client.get_unique_funder_count(), 0);
 }
 
 #[test]
@@ -1624,7 +1629,7 @@ fn test_unique_funder_count_increments_on_first_investor() {
         &None,
         &None,
     );
-assert_eq!(client.get_unique_funder_count(), 0);
+    assert_eq!(client.get_unique_funder_count(), 0);
     client.fund(&investor, &(TARGET / 2));
     assert_eq!(client.get_unique_funder_count(), 1);
     client.fund(&investor, &(TARGET / 2));
@@ -1656,7 +1661,7 @@ fn test_unique_funder_count_increments_for_distinct_investors() {
         &None,
         &None,
     );
-assert_eq!(client.get_unique_funder_count(), 0);
+    assert_eq!(client.get_unique_funder_count(), 0);
 
     client.fund(&inv_a, &(TARGET / 3));
     assert_eq!(client.get_unique_funder_count(), 1);
@@ -1701,9 +1706,9 @@ fn test_unique_funder_count_with_fund_with_commitment() {
         &None,
         &None,
         &None,
-        &None,
     );
-assert_eq!(client.get_unique_funder_count(), 0);
+
+    assert_eq!(client.get_unique_funder_count(), 0);
 
     // First investor uses fund_with_commitment
     client.fund_with_commitment(&inv_a, &(TARGET / 2), &200u64);
@@ -1734,9 +1739,9 @@ fn test_max_unique_investors_cap_none_allows_unlimited() {
         &None,
         &None,
         &None,
-        &None,
     );
-// Should be able to add many investors when no cap is set
+
+    // Should be able to add many investors when no cap is set
     for i in 0..10 {
         let investor = Address::generate(&env);
         client.fund(&investor, &(TARGET / 20));
@@ -1765,9 +1770,9 @@ fn test_max_unique_investors_cap_enforced_at_limit() {
         &None,
         &None,
         &None,
-        &None,
     );
-assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
+
+    assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
 
     // Add 3 investors - should succeed
     let inv1 = Address::generate(&env);
@@ -1809,9 +1814,9 @@ fn test_max_unique_investors_cap_blocks_excess_investors() {
         &None,
         &None,
         &None,
-        &None,
     );
-// Add 2 investors
+
+    // Add 2 investors
     let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     client.fund(&inv1, &(TARGET / 4));
@@ -1854,9 +1859,9 @@ fn test_max_unique_investors_cap_blocks_fund_with_commitment() {
         &None,
         &None,
         &None,
-        &None,
     );
-// First investor succeeds
+
+    // First investor succeeds
     let inv1 = Address::generate(&env);
     client.fund_with_commitment(&inv1, &(TARGET / 2), &200u64);
 
@@ -1887,9 +1892,9 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &None,
-        &None,
     );
-// First fund should succeed
+
+    // First fund should succeed
     client.fund(&investor, &(TARGET / 3));
     assert_eq!(client.get_unique_funder_count(), 1);
 
@@ -1924,9 +1929,9 @@ fn test_zero_contribution_then_non_zero_contribution_counts_as_unique_investor()
         &None,
         &None,
         &None,
-        &None,
     );
-assert_eq!(client.get_unique_funder_count(), 0);
+
+    assert_eq!(client.get_unique_funder_count(), 0);
     assert_eq!(client.get_contribution(&investor), 0);
 
     // First non-zero contribution should increment count
@@ -1958,7 +1963,6 @@ fn test_cap_validation_at_init_positive_value_required() {
         &None,
         &None,
         &None,
-        &None,
     );
 }
 
@@ -1980,7 +1984,6 @@ fn test_init_panics_for_zero_cap() {
         &None,
         &None,
         &Some(0u32), // Invalid: zero cap
-        &None,
         &None,
         &None,
         &None,
@@ -2008,9 +2011,9 @@ fn test_cap_edge_case_exact_limit_reached() {
         &None,
         &None,
         &None,
-        &None,
     );
-// Add exactly 5 investors - should all succeed
+
+    // Add exactly 5 investors - should all succeed
     for i in 0..5 {
         let investor = Address::generate(&env);
         client.fund(&investor, &(TARGET / 10));
@@ -2046,9 +2049,9 @@ fn test_cap_edge_case_exactly_one_over_limit_panics() {
         &None,
         &None,
         &None,
-        &None,
     );
-// Add exactly 5 investors
+
+    // Add exactly 5 investors
     for _i in 0..5 {
         let investor = Address::generate(&env);
         client.fund(&investor, &(TARGET / 10));
@@ -2080,9 +2083,9 @@ fn test_cap_with_min_contribution_floor_interaction() {
         &None,
         &None,
         &None,
-        &None,
     );
-// Should respect both cap and floor
+
+    // Should respect both cap and floor
     let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     let inv3 = Address::generate(&env);
@@ -2122,9 +2125,9 @@ fn test_cap_blocks_even_with_large_contribution() {
         &None,
         &None,
         &None,
-        &None,
     );
-// First investor can fund large amount
+
+    // First investor can fund large amount
     let inv1 = Address::generate(&env);
     client.fund(&inv1, &(TARGET * 5));
 
@@ -2159,9 +2162,9 @@ fn test_cap_panic_message_quality() {
         &None,
         &None,
         &None,
-        &None,
     );
-// Add first investor
+
+    // Add first investor
     let inv1 = Address::generate(&env);
     client.fund(&inv1, &(TARGET / 2));
 
@@ -2170,7 +2173,7 @@ fn test_cap_panic_message_quality() {
     client.fund(&inv2, &(TARGET / 2));
 }
 
-// ── cancel_funding and refund tests ──────────────────────────────────────────
+// ÔöÇÔöÇ cancel_funding and refund tests ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 fn init_with_token<'a>(
     env: &'a Env,
@@ -2201,7 +2204,7 @@ fn init_with_token<'a>(
         &None,
         &None,
     );
-(token, treasury)
+    (token, treasury)
 }
 
 #[test]
@@ -2268,7 +2271,7 @@ fn test_refund_returns_principal_to_investor() {
     token.stellar.mint(&contract_id, &TARGET);
 
     client.fund(&investor, &TARGET);
-    // Undo funded status by cancelling — but fund() moved status to 1, so we need open state.
+    // Undo funded status by cancelling ÔÇö but fund() moved status to 1, so we need open state.
     // Re-init with partial fund instead.
     let env2 = Env::default();
     let (client2, admin2, sme2) = setup(&env2);
@@ -2432,7 +2435,7 @@ fn test_sweep_terminal_dust_allowed_in_cancelled_state() {
     assert_eq!(token.token.balance(&treasury), 1i128);
 }
 
-// ─── Commitment first-deposit-only invariant (issue #260) ────────────────────
+// ÔöÇÔöÇÔöÇ Commitment first-deposit-only invariant (issue #260) ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 /// After `fund_with_commitment(lock_secs > 0)`, a subsequent `fund()` call from the
 /// same investor must preserve **both** `InvestorEffectiveYield` (tier rate) and
@@ -2469,12 +2472,12 @@ fn test_commitment_claim_lock_preserved_after_follow_on_fund() {
         &None,
         &None,
         &None,
-        &None,
     );
-// Set ledger timestamp to a known value so claim_nb is deterministic.
+
+    // Set ledger timestamp to a known value so claim_nb is deterministic.
     env.ledger().with_mut(|l| l.timestamp = 1_000_000u64);
 
-    // First deposit: tier at 100 s → effective yield = 950 bps, lock until 1_000_100.
+    // First deposit: tier at 100 s ÔåÆ effective yield = 950 bps, lock until 1_000_100.
     client.fund_with_commitment(&inv, &3_000i128, &100u64);
     let yield_after_first = client.get_investor_yield_bps(&inv);
     let lock_after_first = client.get_investor_claim_not_before(&inv);
@@ -2484,7 +2487,7 @@ fn test_commitment_claim_lock_preserved_after_follow_on_fund() {
         "claim lock not set correctly"
     );
 
-    // Follow-on deposit using fund() — must succeed and preserve both values.
+    // Follow-on deposit using fund() ÔÇö must succeed and preserve both values.
     client.fund(&inv, &3_000i128);
     assert_eq!(
         client.get_investor_yield_bps(&inv),
@@ -2536,18 +2539,18 @@ fn test_commitment_invariant_across_multiple_follow_on_funds() {
         &None,
         &None,
         &None,
-        &None,
     );
-env.ledger().with_mut(|l| l.timestamp = 2_000_000u64);
 
-    // First deposit: 200 s commitment → top tier (1100 bps), lock until 2_000_200.
+    env.ledger().with_mut(|l| l.timestamp = 2_000_000u64);
+
+    // First deposit: 200 s commitment ÔåÆ top tier (1100 bps), lock until 2_000_200.
     client.fund_with_commitment(&inv, &5_000i128, &200u64);
     let expected_yield = client.get_investor_yield_bps(&inv);
     let expected_lock = client.get_investor_claim_not_before(&inv);
     assert_eq!(expected_yield, 1100);
     assert_eq!(expected_lock, 2_000_200u64);
 
-    // Three follow-on fund() calls — invariant must hold after each.
+    // Three follow-on fund() calls ÔÇö invariant must hold after each.
     for round in 1u32..=3 {
         client.fund(&inv, &1_000i128);
         assert_eq!(
@@ -2565,7 +2568,7 @@ env.ledger().with_mut(|l| l.timestamp = 2_000_000u64);
 
 /// `fund_with_commitment(lock_secs = 0)` must assign base yield and leave
 /// `InvestorClaimNotBefore` at zero. A subsequent `fund()` call must keep both
-/// at their zero / base values — no claim gate is imposed.
+/// at their zero / base values ÔÇö no claim gate is imposed.
 #[test]
 fn test_commitment_zero_lock_follow_on_fund_no_claim_gate() {
     let env = Env::default();
@@ -2598,9 +2601,9 @@ fn test_commitment_zero_lock_follow_on_fund_no_claim_gate() {
         &None,
         &None,
         &None,
-        &None,
     );
-// Zero lock → base yield only, no claim gate.
+
+    // Zero lock ÔåÆ base yield only, no claim gate.
     client.fund_with_commitment(&inv, &4_000i128, &0u64);
     assert_eq!(
         client.get_investor_yield_bps(&inv),
@@ -2659,7 +2662,8 @@ fn test_second_fund_with_commitment_panics_without_tier_table() {
         &None,
         &None,
     );
-client.fund_with_commitment(&inv, &3_000i128, &0u64);
+
+    client.fund_with_commitment(&inv, &3_000i128, &0u64);
     // Second call must trap.
     assert_contract_error(
         client.try_fund_with_commitment(&inv, &3_000i128, &0u64),
@@ -2668,7 +2672,7 @@ client.fund_with_commitment(&inv, &3_000i128, &0u64);
 }
 
 /// After a plain `fund()` first deposit, calling `fund_with_commitment` on the same
-/// investor must panic — the tier/lock selection window is permanently closed.
+/// investor must panic ÔÇö the tier/lock selection window is permanently closed.
 /// This is the "inverse" direction of the state-machine rule.
 #[test]
 fn test_fund_first_then_commitment_second_panics() {
@@ -2702,11 +2706,11 @@ fn test_fund_first_then_commitment_second_panics() {
         &None,
         &None,
         &None,
-        &None,
     );
-// First leg via fund() → establishes base-yield position.
+
+    // First leg via fund() ÔåÆ establishes base-yield position.
     client.fund(&inv, &3_000i128);
-    // Attempt to re-select tier via fund_with_commitment → must panic.
+    // Attempt to re-select tier via fund_with_commitment ÔåÆ must panic.
     assert_contract_error(
         client.try_fund_with_commitment(&inv, &3_000i128, &100u64),
         EscrowError::TieredSecondDeposit,
@@ -2748,9 +2752,9 @@ fn test_fund_first_deposit_sets_base_yield_and_no_claim_gate() {
         &None,
         &None,
         &None,
-        &None,
     );
-client.fund(&inv, &5_000i128);
+
+    client.fund(&inv, &5_000i128);
     assert_eq!(
         client.get_investor_yield_bps(&inv),
         800,
@@ -2763,7 +2767,7 @@ client.fund(&inv, &5_000i128);
     );
 }
 
-// ── CommitmentLockExceedsMaturity bound ──────────────────────────────────────
+// ÔöÇÔöÇ CommitmentLockExceedsMaturity bound ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 // Helper: init an escrow with a specific maturity timestamp.
 fn init_with_maturity(
@@ -2796,7 +2800,7 @@ fn init_with_maturity(
 
 #[test]
 fn commitment_lock_within_maturity_is_accepted() {
-    // now=1000, maturity=2000, lock=500 → claim_nb=1500 ≤ 2000  ✓
+    // now=1000, maturity=2000, lock=500 ÔåÆ claim_nb=1500 Ôëñ 2000  Ô£ô
     let env = Env::default();
     env.mock_all_auths();
     let mut li = env.ledger().get();
@@ -2812,7 +2816,7 @@ fn commitment_lock_within_maturity_is_accepted() {
 
 #[test]
 fn commitment_lock_exactly_at_maturity_is_accepted() {
-    // now=1000, maturity=2000, lock=1000 → claim_nb=2000 == maturity  ✓ (inclusive)
+    // now=1000, maturity=2000, lock=1000 ÔåÆ claim_nb=2000 == maturity  Ô£ô (inclusive)
     let env = Env::default();
     env.mock_all_auths();
     let mut li = env.ledger().get();
@@ -2828,7 +2832,7 @@ fn commitment_lock_exactly_at_maturity_is_accepted() {
 
 #[test]
 fn commitment_lock_one_second_past_maturity_is_rejected() {
-    // now=1000, maturity=2000, lock=1001 → claim_nb=2001 > 2000  ✗
+    // now=1000, maturity=2000, lock=1001 ÔåÆ claim_nb=2001 > 2000  Ô£ù
     let env = Env::default();
     env.mock_all_auths();
     let mut li = env.ledger().get();
@@ -2845,7 +2849,7 @@ fn commitment_lock_one_second_past_maturity_is_rejected() {
 
 #[test]
 fn commitment_lock_far_past_maturity_is_rejected() {
-    // now=1000, maturity=2000, lock=5000 → claim_nb=6000 >> 2000  ✗
+    // now=1000, maturity=2000, lock=5000 ÔåÆ claim_nb=6000 >> 2000  Ô£ù
     let env = Env::default();
     env.mock_all_auths();
     let mut li = env.ledger().get();
@@ -2862,7 +2866,7 @@ fn commitment_lock_far_past_maturity_is_rejected() {
 
 #[test]
 fn zero_lock_with_maturity_is_always_accepted() {
-    // committed_lock_secs==0 → claim_nb=0, no maturity bound applied
+    // committed_lock_secs==0 ÔåÆ claim_nb=0, no maturity bound applied
     let env = Env::default();
     env.mock_all_auths();
     let mut li = env.ledger().get();
@@ -2885,7 +2889,7 @@ fn lock_with_zero_maturity_is_always_accepted() {
     env.ledger().set(li);
     let (client, admin, sme) = setup(&env);
     let investor = soroban_sdk::Address::generate(&env);
-    // maturity = 0 → no bound applied even for a huge lock
+    // maturity = 0 ÔåÆ no bound applied even for a huge lock
     let (token, treasury) = free_addresses(&env);
     client.init(
         &admin,
@@ -2906,7 +2910,7 @@ fn lock_with_zero_maturity_is_always_accepted() {
         &None,
         &None,
     );
-let escrow = client.fund_with_commitment(&investor, &1_000i128, &9999u64);
+    let escrow = client.fund_with_commitment(&investor, &1_000i128, &9999u64);
     assert_eq!(escrow.status, 0);
     assert_eq!(client.get_investor_claim_not_before(&investor), 10999u64);
 }
@@ -2927,9 +2931,9 @@ fn plain_fund_with_maturity_ignores_lock_bound() {
     assert_eq!(escrow.status, 0);
     assert_eq!(client.get_investor_claim_not_before(&investor), 0u64);
 }
-// ─────────────────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 // Tests for fund_batch entrypoint (Issue #311)
-// ─────────────────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 #[should_panic(expected = "FundingBatchEmpty")]
@@ -2988,9 +2992,8 @@ fn test_fund_batch_equals_n_single_funds() {
             &None,
             &None,
             &None,
-        &None,
-    );
-}
+        );
+    }
 
     // Create 5 investors
     let mut investors = SorobanVec::new(&env);
@@ -3058,9 +3061,9 @@ fn test_fund_batch_per_investor_cap_rejection() {
         &Some(per_investor_cap),
         &None,
         &None,
-        &None,
     );
-let mut entries = SorobanVec::new(&env);
+
+    let mut entries = SorobanVec::new(&env);
     entries.push_back((inv1.clone(), 25_000i128)); // Within cap
     entries.push_back((inv2.clone(), 35_000i128)); // Exceeds cap
 
@@ -3096,7 +3099,8 @@ fn test_fund_batch_mid_batch_funded_transition() {
         &None,
         &None,
     );
-let inv1 = Address::generate(&env);
+
+    let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     let inv3 = Address::generate(&env);
 
@@ -3155,9 +3159,9 @@ fn test_fund_batch_duplicate_addresses() {
         &Some(per_investor_cap),
         &None,
         &None,
-        &None,
     );
-let mut entries = SorobanVec::new(&env);
+
+    let mut entries = SorobanVec::new(&env);
     entries.push_back((inv.clone(), 30_000i128)); // First entry: 30k
     entries.push_back((inv.clone(), 25_000i128)); // Second entry: 30k + 25k = 55k > cap
 
@@ -3234,7 +3238,8 @@ fn test_fund_batch_max_batch_size() {
         &None,
         &None,
     );
-// Create exactly MAX_FUND_BATCH entries
+
+    // Create exactly MAX_FUND_BATCH entries
     let mut entries = SorobanVec::new(&env);
     for _ in 0..MAX_FUND_BATCH {
         let inv = Address::generate(&env);
@@ -3277,7 +3282,8 @@ fn test_fund_batch_preserves_event_semantics() {
         &None,
         &None,
     );
-let inv1 = Address::generate(&env);
+
+    let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
 
     let mut entries = SorobanVec::new(&env);

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -44,8 +44,9 @@ fn test_fund_and_settle() {
         &None,
         &None,
         &None,
+        &None,
     );
-    let funded = client.fund(&investor, &TARGET);
+let funded = client.fund(&investor, &TARGET);
     assert_eq!(funded.funded_amount, TARGET);
     assert_eq!(funded.status, 1);
     let settled = client.settle();
@@ -73,8 +74,9 @@ fn test_fund_partial_then_full() {
         &None,
         &None,
         &None,
+        &None,
     );
-    let partial = client.fund(&investor, &(TARGET / 2));
+let partial = client.fund(&investor, &(TARGET / 2));
     assert_eq!(partial.status, 0);
     assert_eq!(partial.funded_amount, TARGET / 2);
     let full = client.fund(&investor, &(TARGET / 2));
@@ -137,8 +139,9 @@ fn test_single_investor_contribution_tracked() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &(30_000_000_000i128));
+client.fund(&investor, &(30_000_000_000i128));
     let contribution = client.get_contribution(&investor);
     assert_eq!(contribution, 30_000_000_000i128);
 }
@@ -175,8 +178,9 @@ fn test_repeated_funding_accumulates_contribution() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &(20_000_000_000i128));
+client.fund(&investor, &(20_000_000_000i128));
     client.fund(&investor, &(30_000_000_000i128));
     assert_eq!(client.get_contribution(&investor), 50_000_000_000i128);
 }
@@ -204,9 +208,9 @@ fn test_funding_amount_accumulation_overflow_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&investor_a, &(i128::MAX - 1));
+client.fund(&investor_a, &(i128::MAX - 1));
     client.fund(&investor_b, &2i128);
 }
 
@@ -231,9 +235,9 @@ fn test_funding_amount_overflow_does_not_mutate_state() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&investor, &(i128::MAX - 1));
+client.fund(&investor, &(i128::MAX - 1));
     let before = client.get_escrow();
 
     let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -270,9 +274,9 @@ fn test_fund_with_commitment_overflow_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&investor_a, &(i128::MAX - 1));
+client.fund(&investor_a, &(i128::MAX - 1));
     client.fund_with_commitment(&investor_b, &2i128, &0u64);
 }
 
@@ -298,9 +302,9 @@ fn test_fund_with_commitment_overflow_does_not_mutate_state() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&investor_a, &(i128::MAX - 1));
+client.fund(&investor_a, &(i128::MAX - 1));
     let before = client.get_escrow();
 
     let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -340,8 +344,9 @@ fn test_per_investor_contribution_uses_persistent_storage() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &500i128);
+client.fund(&investor, &500i128);
 
     env.as_contract(&contract_id, || {
         assert_eq!(
@@ -393,9 +398,9 @@ fn test_investor_contribution_overflow_panics_even_if_state_is_inconsistent() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    env.as_contract(&contract_id, || {
+env.as_contract(&contract_id, || {
         // Force the contribution near i128::MAX while keeping funded_amount small.
         // `fund` must still trap on contribution overflow even if funded_amount would not.
         env.storage().persistent().set(
@@ -439,9 +444,9 @@ fn test_investor_contribution_overflow_does_not_mutate_state() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    env.as_contract(&contract_id, || {
+env.as_contract(&contract_id, || {
         env.storage().persistent().set(
             &DataKey::InvestorContribution(investor.clone()),
             &(i128::MAX - 1),
@@ -487,8 +492,9 @@ fn test_multiple_investors_tracked_independently() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&inv_a, &(20_000_000_000i128));
+client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
     client.fund(&inv_c, &(30_000_000_000i128));
     assert_eq!(client.get_contribution(&inv_a), 20_000_000_000i128);
@@ -523,8 +529,9 @@ fn test_contributions_sum_equals_funded_amount() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&inv_a, &(20_000_000_000i128));
+client.fund(&inv_a, &(20_000_000_000i128));
     client.fund(&inv_b, &(50_000_000_000i128));
     client.fund(&inv_c, &(30_000_000_000i128));
     let sum = client.get_contribution(&inv_a)
@@ -554,8 +561,9 @@ fn test_cost_baseline_fund_partial() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &(10_000_000_000i128));
+client.fund(&investor, &(10_000_000_000i128));
 }
 
 #[test]
@@ -579,8 +587,9 @@ fn test_cost_baseline_fund_full() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &TARGET);
+client.fund(&investor, &TARGET);
 }
 
 #[test]
@@ -604,8 +613,9 @@ fn test_cost_baseline_fund_overshoot() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &(150_000_000_000i128));
+client.fund(&investor, &(150_000_000_000i128));
     assert_eq!(client.get_escrow().status, 1);
 }
 
@@ -630,8 +640,9 @@ fn test_cost_baseline_fund_two_step_completion() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&investor, &(TARGET / 2));
+client.fund(&investor, &(TARGET / 2));
     client.fund(&investor, &(TARGET / 2));
     assert_eq!(client.get_escrow().status, 1);
 }
@@ -661,8 +672,9 @@ fn test_funding_close_snapshot_captures_overfunded_total_once() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_funding_close_snapshot(), None);
+assert_eq!(client.get_funding_close_snapshot(), None);
     client.fund(&inv, &(TARGET + 50_000_000_000i128));
     let snap = client.get_funding_close_snapshot().expect("snapshot");
     assert_eq!(snap.total_principal, TARGET + 50_000_000_000i128);
@@ -697,8 +709,9 @@ fn test_funding_snapshot_immutable_across_second_fund_after_funded() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&a, &(TARGET / 2));
+client.fund(&a, &(TARGET / 2));
     assert_eq!(client.get_funding_close_snapshot(), None);
     client.fund(&b, &(TARGET / 2));
     let s1 = client.get_funding_close_snapshot().unwrap();
@@ -733,8 +746,9 @@ fn test_pro_rata_weight_ratio_from_snapshot() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&a, &(20_000_000_000i128));
+client.fund(&a, &(20_000_000_000i128));
     client.fund(&b, &(80_000_000_000i128));
     let snap = client.get_funding_close_snapshot().unwrap();
     assert_eq!(snap.total_principal, TARGET);
@@ -777,8 +791,9 @@ fn test_tiered_yield_and_follow_on_fund() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund_with_commitment(&inv, &5_000i128, &200u64);
+client.fund_with_commitment(&inv, &5_000i128, &200u64);
     assert_eq!(client.get_investor_yield_bps(&inv), 900);
     assert_eq!(client.get_investor_claim_not_before(&inv), 200);
     client.fund(&inv, &5_000i128);
@@ -817,8 +832,9 @@ fn test_tier_selection_edges_base_vs_high_bucket() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund_with_commitment(&i_short, &10_000i128, &40u64);
+client.fund_with_commitment(&i_short, &10_000i128, &40u64);
     assert_eq!(client.get_investor_yield_bps(&i_short), 800);
     client.fund_with_commitment(&i_long, &10_000i128, &50u64);
     assert_eq!(client.get_investor_yield_bps(&i_long), 850);
@@ -855,8 +871,9 @@ fn test_fund_with_commitment_twice_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund_with_commitment(&inv, &5_000i128, &10u64);
+client.fund_with_commitment(&inv, &5_000i128, &10u64);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
 }
 
@@ -886,8 +903,9 @@ fn test_fund_then_fund_with_commitment_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(&inv, &5_000i128);
+client.fund(&inv, &5_000i128);
     client.fund_with_commitment(&inv, &5_000i128, &10u64);
 }
 
@@ -926,9 +944,9 @@ fn test_tier_selection_ladder() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let inv_base = Address::generate(&env);
+let inv_base = Address::generate(&env);
     let inv_tier1 = Address::generate(&env);
     let inv_tier2 = Address::generate(&env);
     let inv_mid = Address::generate(&env);
@@ -984,9 +1002,9 @@ fn test_yield_tier_emitted_in_event() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let inv = Address::generate(&env);
+let inv = Address::generate(&env);
 
     // 1. Tiered fund: committed_lock_secs=150 >= tier.min_lock_secs=100 => yield 900, lock 100.
     client.fund_with_commitment(&inv, &1_000i128, &150u64);
@@ -1059,9 +1077,9 @@ fn test_yield_tier_emitted_no_tiers() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let inv = Address::generate(&env);
+let inv = Address::generate(&env);
     // fund_with_commitment even with no tiers configured
     client.fund_with_commitment(&inv, &1_000i128, &150u64);
 
@@ -1119,9 +1137,9 @@ fn test_yield_tier_emitted_between_tiers() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let inv = Address::generate(&env);
+let inv = Address::generate(&env);
     // Committing 150 secs (between 100 and 200) -> matches the 100 sec tier.
     client.fund_with_commitment(&inv, &1_000i128, &150u64);
 
@@ -1175,9 +1193,9 @@ fn test_fund_with_commitment_zero_lock_behaves_as_fund() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund_with_commitment(&inv, &5_000i128, &0u64);
+client.fund_with_commitment(&inv, &5_000i128, &0u64);
     assert_eq!(client.get_investor_yield_bps(&inv), 800);
     assert_eq!(client.get_investor_claim_not_before(&inv), 0);
 }
@@ -1210,9 +1228,9 @@ fn test_commitment_claim_time_allows_u64_max_boundary() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund_with_commitment(&investor, &100i128, &5u64);
+client.fund_with_commitment(&investor, &100i128, &5u64);
 
     assert_eq!(client.get_investor_claim_not_before(&investor), u64::MAX);
 }
@@ -1246,9 +1264,9 @@ fn test_commitment_claim_time_overflow_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund_with_commitment(&investor, &100i128, &6u64);
+client.fund_with_commitment(&investor, &100i128, &6u64);
 }
 
 #[test]
@@ -1279,9 +1297,9 @@ fn test_commitment_claim_time_overflow_does_not_record_position() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.fund_with_commitment(&investor, &100i128, &6u64);
     }));
     assert!(overflowed.is_err());
@@ -1325,6 +1343,7 @@ fn test_init_bad_tier_order_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -1353,6 +1372,7 @@ fn test_init_tier_yield_below_base_panics() {
         &None,
         &tre,
         &Some(tiers),
+        &None,
         &None,
         &None,
         &None,
@@ -1387,8 +1407,9 @@ fn test_differential_funding_target_eq_exact_cross() {
         &None,
         &None,
         &None,
+        &None,
     );
-    let escrow = client.fund(&inv, &t);
+let escrow = client.fund(&inv, &t);
     assert_eq!(escrow.funded_amount, t);
     assert_eq!(escrow.status, 1);
     let snap = client.get_funding_close_snapshot().unwrap();
@@ -1421,8 +1442,9 @@ fn test_ledger_sequence_recorded_in_snapshot_with_tick() {
         &None,
         &None,
         &None,
+        &None,
     );
-    let seq = env.ledger().sequence();
+let seq = env.ledger().sequence();
     client.fund(&inv, &1_000i128);
     let snap = client.get_funding_close_snapshot().unwrap();
     assert_eq!(snap.closed_at_ledger_sequence, seq);
@@ -1453,8 +1475,9 @@ fn test_get_funding_close_snapshot_absent_before_any_funding() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(
+assert_eq!(
         client.get_funding_close_snapshot(),
         None,
         "snapshot must be absent before any funding"
@@ -1487,8 +1510,9 @@ fn test_get_funding_close_snapshot_present_after_funding_completes() {
         &None,
         &None,
         &None,
+        &None,
     );
-    // Partial fund — snapshot still absent.
+// Partial fund — snapshot still absent.
     client.fund(&inv, &(TARGET / 2));
     assert_eq!(
         client.get_funding_close_snapshot(),
@@ -1532,8 +1556,9 @@ fn test_get_funding_close_snapshot_immutable_after_set() {
         &None,
         &None,
         &None,
+        &None,
     );
-    // Fund exactly to target — snapshot is written here.
+// Fund exactly to target — snapshot is written here.
     client.fund(&inv, &TARGET);
     let snap_at_close = client
         .get_funding_close_snapshot()
@@ -1571,8 +1596,9 @@ fn test_unique_funder_count_initialized_to_zero() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_unique_funder_count(), 0);
+assert_eq!(client.get_unique_funder_count(), 0);
 }
 
 #[test]
@@ -1596,8 +1622,9 @@ fn test_unique_funder_count_increments_on_first_investor() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_unique_funder_count(), 0);
+assert_eq!(client.get_unique_funder_count(), 0);
     client.fund(&investor, &(TARGET / 2));
     assert_eq!(client.get_unique_funder_count(), 1);
     client.fund(&investor, &(TARGET / 2));
@@ -1627,8 +1654,9 @@ fn test_unique_funder_count_increments_for_distinct_investors() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_unique_funder_count(), 0);
+assert_eq!(client.get_unique_funder_count(), 0);
 
     client.fund(&inv_a, &(TARGET / 3));
     assert_eq!(client.get_unique_funder_count(), 1);
@@ -1673,9 +1701,9 @@ fn test_unique_funder_count_with_fund_with_commitment() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    assert_eq!(client.get_unique_funder_count(), 0);
+assert_eq!(client.get_unique_funder_count(), 0);
 
     // First investor uses fund_with_commitment
     client.fund_with_commitment(&inv_a, &(TARGET / 2), &200u64);
@@ -1706,9 +1734,9 @@ fn test_max_unique_investors_cap_none_allows_unlimited() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Should be able to add many investors when no cap is set
+// Should be able to add many investors when no cap is set
     for i in 0..10 {
         let investor = Address::generate(&env);
         client.fund(&investor, &(TARGET / 20));
@@ -1737,9 +1765,9 @@ fn test_max_unique_investors_cap_enforced_at_limit() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
+assert_eq!(client.get_max_unique_investors_cap(), Some(3u32));
 
     // Add 3 investors - should succeed
     let inv1 = Address::generate(&env);
@@ -1781,9 +1809,9 @@ fn test_max_unique_investors_cap_blocks_excess_investors() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Add 2 investors
+// Add 2 investors
     let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     client.fund(&inv1, &(TARGET / 4));
@@ -1826,9 +1854,9 @@ fn test_max_unique_investors_cap_blocks_fund_with_commitment() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // First investor succeeds
+// First investor succeeds
     let inv1 = Address::generate(&env);
     client.fund_with_commitment(&inv1, &(TARGET / 2), &200u64);
 
@@ -1859,9 +1887,9 @@ fn test_re_funding_same_address_doesnt_count_against_cap() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // First fund should succeed
+// First fund should succeed
     client.fund(&investor, &(TARGET / 3));
     assert_eq!(client.get_unique_funder_count(), 1);
 
@@ -1896,9 +1924,9 @@ fn test_zero_contribution_then_non_zero_contribution_counts_as_unique_investor()
         &None,
         &None,
         &None,
+        &None,
     );
-
-    assert_eq!(client.get_unique_funder_count(), 0);
+assert_eq!(client.get_unique_funder_count(), 0);
     assert_eq!(client.get_contribution(&investor), 0);
 
     // First non-zero contribution should increment count
@@ -1930,6 +1958,7 @@ fn test_cap_validation_at_init_positive_value_required() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -1951,6 +1980,7 @@ fn test_init_panics_for_zero_cap() {
         &None,
         &None,
         &Some(0u32), // Invalid: zero cap
+        &None,
         &None,
         &None,
         &None,
@@ -1978,9 +2008,9 @@ fn test_cap_edge_case_exact_limit_reached() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Add exactly 5 investors - should all succeed
+// Add exactly 5 investors - should all succeed
     for i in 0..5 {
         let investor = Address::generate(&env);
         client.fund(&investor, &(TARGET / 10));
@@ -2016,9 +2046,9 @@ fn test_cap_edge_case_exactly_one_over_limit_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Add exactly 5 investors
+// Add exactly 5 investors
     for _i in 0..5 {
         let investor = Address::generate(&env);
         client.fund(&investor, &(TARGET / 10));
@@ -2050,9 +2080,9 @@ fn test_cap_with_min_contribution_floor_interaction() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Should respect both cap and floor
+// Should respect both cap and floor
     let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     let inv3 = Address::generate(&env);
@@ -2092,9 +2122,9 @@ fn test_cap_blocks_even_with_large_contribution() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // First investor can fund large amount
+// First investor can fund large amount
     let inv1 = Address::generate(&env);
     client.fund(&inv1, &(TARGET * 5));
 
@@ -2129,9 +2159,9 @@ fn test_cap_panic_message_quality() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Add first investor
+// Add first investor
     let inv1 = Address::generate(&env);
     client.fund(&inv1, &(TARGET / 2));
 
@@ -2169,8 +2199,9 @@ fn init_with_token<'a>(
         &None,
         &None,
         &None,
+        &None,
     );
-    (token, treasury)
+(token, treasury)
 }
 
 #[test]
@@ -2438,9 +2469,9 @@ fn test_commitment_claim_lock_preserved_after_follow_on_fund() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Set ledger timestamp to a known value so claim_nb is deterministic.
+// Set ledger timestamp to a known value so claim_nb is deterministic.
     env.ledger().with_mut(|l| l.timestamp = 1_000_000u64);
 
     // First deposit: tier at 100 s → effective yield = 950 bps, lock until 1_000_100.
@@ -2505,9 +2536,9 @@ fn test_commitment_invariant_across_multiple_follow_on_funds() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    env.ledger().with_mut(|l| l.timestamp = 2_000_000u64);
+env.ledger().with_mut(|l| l.timestamp = 2_000_000u64);
 
     // First deposit: 200 s commitment → top tier (1100 bps), lock until 2_000_200.
     client.fund_with_commitment(&inv, &5_000i128, &200u64);
@@ -2567,9 +2598,9 @@ fn test_commitment_zero_lock_follow_on_fund_no_claim_gate() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Zero lock → base yield only, no claim gate.
+// Zero lock → base yield only, no claim gate.
     client.fund_with_commitment(&inv, &4_000i128, &0u64);
     assert_eq!(
         client.get_investor_yield_bps(&inv),
@@ -2626,9 +2657,9 @@ fn test_second_fund_with_commitment_panics_without_tier_table() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund_with_commitment(&inv, &3_000i128, &0u64);
+client.fund_with_commitment(&inv, &3_000i128, &0u64);
     // Second call must trap.
     assert_contract_error(
         client.try_fund_with_commitment(&inv, &3_000i128, &0u64),
@@ -2671,9 +2702,9 @@ fn test_fund_first_then_commitment_second_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // First leg via fund() → establishes base-yield position.
+// First leg via fund() → establishes base-yield position.
     client.fund(&inv, &3_000i128);
     // Attempt to re-select tier via fund_with_commitment → must panic.
     assert_contract_error(
@@ -2717,9 +2748,9 @@ fn test_fund_first_deposit_sets_base_yield_and_no_claim_gate() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    client.fund(&inv, &5_000i128);
+client.fund(&inv, &5_000i128);
     assert_eq!(
         client.get_investor_yield_bps(&inv),
         800,
@@ -2753,6 +2784,7 @@ fn init_with_maturity(
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -2872,8 +2904,9 @@ fn lock_with_zero_maturity_is_always_accepted() {
         &None,
         &None,
         &None,
+        &None,
     );
-    let escrow = client.fund_with_commitment(&investor, &1_000i128, &9999u64);
+let escrow = client.fund_with_commitment(&investor, &1_000i128, &9999u64);
     assert_eq!(escrow.status, 0);
     assert_eq!(client.get_investor_claim_not_before(&investor), 10999u64);
 }
@@ -2955,8 +2988,9 @@ fn test_fund_batch_equals_n_single_funds() {
             &None,
             &None,
             &None,
-        );
-    }
+        &None,
+    );
+}
 
     // Create 5 investors
     let mut investors = SorobanVec::new(&env);
@@ -3024,9 +3058,9 @@ fn test_fund_batch_per_investor_cap_rejection() {
         &Some(per_investor_cap),
         &None,
         &None,
+        &None,
     );
-
-    let mut entries = SorobanVec::new(&env);
+let mut entries = SorobanVec::new(&env);
     entries.push_back((inv1.clone(), 25_000i128)); // Within cap
     entries.push_back((inv2.clone(), 35_000i128)); // Exceeds cap
 
@@ -3060,9 +3094,9 @@ fn test_fund_batch_mid_batch_funded_transition() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let inv1 = Address::generate(&env);
+let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
     let inv3 = Address::generate(&env);
 
@@ -3121,9 +3155,9 @@ fn test_fund_batch_duplicate_addresses() {
         &Some(per_investor_cap),
         &None,
         &None,
+        &None,
     );
-
-    let mut entries = SorobanVec::new(&env);
+let mut entries = SorobanVec::new(&env);
     entries.push_back((inv.clone(), 30_000i128)); // First entry: 30k
     entries.push_back((inv.clone(), 25_000i128)); // Second entry: 30k + 25k = 55k > cap
 
@@ -3198,9 +3232,9 @@ fn test_fund_batch_max_batch_size() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Create exactly MAX_FUND_BATCH entries
+// Create exactly MAX_FUND_BATCH entries
     let mut entries = SorobanVec::new(&env);
     for _ in 0..MAX_FUND_BATCH {
         let inv = Address::generate(&env);
@@ -3241,9 +3275,9 @@ fn test_fund_batch_preserves_event_semantics() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let inv1 = Address::generate(&env);
+let inv1 = Address::generate(&env);
     let inv2 = Address::generate(&env);
 
     let mut entries = SorobanVec::new(&env);

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -581,10 +581,7 @@ fn test_get_funding_token_before_init_fails_with_typed_error() {
 fn test_get_treasury_before_init_fails_with_typed_error() {
     let env = Env::default();
     let client = deploy(&env);
-    assert_contract_error(
-        client.try_get_treasury(),
-        EscrowError::TreasuryNotSet,
-    );
+    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
 }
 
 #[test]

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -1,4 +1,4 @@
-﻿use super::*;
+use super::*;
 use crate::EscrowInitialized;
 use proptest::prelude::*;
 extern crate std;
@@ -20,6 +20,7 @@ fn test_init_stores_escrow() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -60,6 +61,7 @@ fn test_init_stores_keyed_invoice_and_lists_it() {
         &None,
         &None,
         &None,
+        &None,
     );
     let got = client.get_escrow();
     assert_eq!(got, escrow);
@@ -79,6 +81,7 @@ fn test_init_requires_admin_auth() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -182,6 +185,7 @@ fn test_cost_baseline_init() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -206,6 +210,7 @@ fn test_cost_baseline_init_zero_maturity() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -223,6 +228,7 @@ fn test_cost_baseline_init_max_amount() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -259,6 +265,7 @@ fn test_init_invoice_id_empty_string_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -281,6 +288,7 @@ fn test_init_invoice_id_whitespace_panics() {
         &t,
         &None,
         &tr,
+        &None,
         &None,
         &None,
         &None,
@@ -318,6 +326,7 @@ fn test_init_invoice_id_too_long_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -340,6 +349,7 @@ fn test_init_invoice_id_bad_charset_hyphen_panics() {
         &t,
         &None,
         &tr,
+        &None,
         &None,
         &None,
         &None,
@@ -376,6 +386,7 @@ fn test_init_invoice_id_non_ascii_multibyte_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -396,6 +407,7 @@ fn test_init_invoice_id_embedded_null_panics() {
     client.init(
         &admin, &s, &sme, &1000i128, &500i64, &0u64, &t, &None, &tr, &None, &None, &None, &None,
         &None, &None,
+        &None,
     );
 }
 
@@ -419,6 +431,7 @@ fn test_init_stores_registry_some_and_getters() {
         &token,
         &Some(reg.clone()),
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -459,6 +472,7 @@ fn test_init_min_contribution_floor_stored() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(client.get_min_contribution_floor(), 1_000i128);
 }
@@ -482,6 +496,7 @@ fn test_init_min_contribution_floor_defaults_to_zero() {
         &tok,
         &None,
         &tre,
+        &None,
         &None,
         &None,
         &None,
@@ -519,6 +534,7 @@ fn test_init_min_contribution_zero_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -548,6 +564,7 @@ fn test_init_min_contribution_exceeds_amount_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -572,6 +589,7 @@ fn test_init_min_contribution_equal_to_amount_accepted() {
         &tre,
         &None,
         &Some(5_000i128),
+        &None,
         &None,
         &None,
         &None,
@@ -619,6 +637,7 @@ fn test_get_funding_token_after_init_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(client.get_funding_token(), token);
 }
@@ -638,6 +657,7 @@ fn test_get_treasury_after_init_succeeds() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -682,6 +702,7 @@ fn test_init_registry_none_roundtrip() {
         &None,
         &None,
         &None,
+        &None,
     );
     assert_eq!(client.get_registry_ref(), None);
 }
@@ -710,6 +731,7 @@ fn test_init_escrow_initialized_event_includes_bound_refs() {
         &token,
         &Some(registry.clone()),
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -756,6 +778,7 @@ fn test_init_escrow_initialized_event_registry_none() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -849,6 +872,7 @@ fn test_invoice_id_length_33_panics() {
         &t,
         &None,
         &tr,
+        &None,
         &None,
         &None,
         &None,
@@ -1058,6 +1082,7 @@ fn datakey_distributed_principal_starts_at_zero_and_increments_on_refund() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -1,4 +1,4 @@
-use super::*;
+﻿use super::*;
 use crate::EscrowInitialized;
 use proptest::prelude::*;
 extern crate std;
@@ -28,7 +28,7 @@ fn test_init_stores_escrow() {
         &None,
         &None,
     );
-assert_eq!(escrow.invoice_id, symbol_short!("INV001"));
+    assert_eq!(escrow.invoice_id, symbol_short!("INV001"));
     assert_eq!(escrow.admin, admin);
     assert_eq!(escrow.sme_address, sme);
     assert_eq!(escrow.amount, TARGET);
@@ -61,7 +61,7 @@ fn test_init_stores_keyed_invoice_and_lists_it() {
         &None,
         &None,
     );
-let got = client.get_escrow();
+    let got = client.get_escrow();
     assert_eq!(got, escrow);
 }
 
@@ -87,7 +87,7 @@ fn test_init_requires_admin_auth() {
         &None,
         &None,
     );
-assert!(
+    assert!(
         env.auths().iter().any(|(addr, _)| *addr == admin),
         "admin auth was not recorded for init"
     );
@@ -139,9 +139,8 @@ fn test_init_unauthorized_panics() {
             &None,
             &None,
             &None,
-        &None,
-    );
-}));
+        );
+    }));
     assert!(result.is_err(), "Expected panic without auth");
 }
 
@@ -359,10 +358,10 @@ fn test_init_invoice_id_non_ascii_multibyte_panics() {
     let client = deploy(&env);
     let (admin, sme) = (Address::generate(&env), Address::generate(&env));
     let (t, tr) = free_addresses(&env);
-    // "INV-💩" contains multi-byte UTF-8
+    // "INV-­ƒÆ®" contains multi-byte UTF-8
     client.init(
         &admin,
-        &soroban_sdk::String::from_str(&env, "INV_💩"),
+        &soroban_sdk::String::from_str(&env, "INV_­ƒÆ®"),
         &sme,
         &1000i128,
         &500i64,
@@ -397,7 +396,6 @@ fn test_init_invoice_id_embedded_null_panics() {
     client.init(
         &admin, &s, &sme, &1000i128, &500i64, &0u64, &t, &None, &tr, &None, &None, &None, &None,
         &None, &None,
-        &None,
     );
 }
 
@@ -429,7 +427,7 @@ fn test_init_stores_registry_some_and_getters() {
         &None,
         &None,
     );
-assert_eq!(client.get_registry_ref(), Some(reg));
+    assert_eq!(client.get_registry_ref(), Some(reg));
     assert_eq!(client.get_funding_token(), token);
     assert_eq!(client.get_treasury(), treasury);
 }
@@ -461,9 +459,8 @@ fn test_init_min_contribution_floor_stored() {
         &None,
         &None,
         &None,
-        &None,
     );
-assert_eq!(client.get_min_contribution_floor(), 1_000i128);
+    assert_eq!(client.get_min_contribution_floor(), 1_000i128);
 }
 
 /// Floor defaults to 0 when `min_contribution` is `None`.
@@ -493,10 +490,10 @@ fn test_init_min_contribution_floor_defaults_to_zero() {
         &None,
         &None,
     );
-assert_eq!(client.get_min_contribution_floor(), 0i128);
+    assert_eq!(client.get_min_contribution_floor(), 0i128);
 }
 
-/// `min_contribution = Some(0)` is rejected — the value must be positive when supplied.
+/// `min_contribution = Some(0)` is rejected ÔÇö the value must be positive when supplied.
 #[test]
 #[should_panic]
 fn test_init_min_contribution_zero_panics() {
@@ -518,7 +515,6 @@ fn test_init_min_contribution_zero_panics() {
         &tre,
         &None,
         &Some(0i128),
-        &None,
         &None,
         &None,
         &None,
@@ -552,11 +548,10 @@ fn test_init_min_contribution_exceeds_amount_panics() {
         &None,
         &None,
         &None,
-        &None,
     );
 }
 
-/// Floor equal to the invoice amount is the boundary — must be accepted.
+/// Floor equal to the invoice amount is the boundary ÔÇö must be accepted.
 #[test]
 fn test_init_min_contribution_equal_to_amount_accepted() {
     let env = Env::default();
@@ -581,9 +576,8 @@ fn test_init_min_contribution_equal_to_amount_accepted() {
         &None,
         &None,
         &None,
-        &None,
     );
-assert_eq!(client.get_min_contribution_floor(), 5_000i128);
+    assert_eq!(client.get_min_contribution_floor(), 5_000i128);
 }
 
 #[test]
@@ -600,7 +594,10 @@ fn test_get_funding_token_before_init_fails_with_typed_error() {
 fn test_get_treasury_before_init_fails_with_typed_error() {
     let env = Env::default();
     let client = deploy(&env);
-    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
+    assert_contract_error(
+        client.try_get_treasury(),
+        EscrowError::TreasuryNotSet,
+    );
 }
 
 #[test]
@@ -626,7 +623,7 @@ fn test_get_funding_token_after_init_succeeds() {
         &None,
         &None,
     );
-assert_eq!(client.get_funding_token(), token);
+    assert_eq!(client.get_funding_token(), token);
 }
 
 #[test]
@@ -652,7 +649,7 @@ fn test_get_treasury_after_init_succeeds() {
         &None,
         &None,
     );
-assert_eq!(client.get_treasury(), treasury);
+    assert_eq!(client.get_treasury(), treasury);
 }
 
 #[test]
@@ -689,7 +686,7 @@ fn test_init_registry_none_roundtrip() {
         &None,
         &None,
     );
-assert_eq!(client.get_registry_ref(), None);
+    assert_eq!(client.get_registry_ref(), None);
 }
 
 #[test]
@@ -724,7 +721,8 @@ fn test_init_escrow_initialized_event_includes_bound_refs() {
         &None,
         &None,
     );
-assert_eq!(
+
+    assert_eq!(
         env.events().all(),
         std::vec![EscrowInitialized {
             name: symbol_short!("escrow_ii"),
@@ -769,7 +767,8 @@ fn test_init_escrow_initialized_event_registry_none() {
         &None,
         &None,
     );
-assert_eq!(
+
+    assert_eq!(
         env.events().all(),
         std::vec![EscrowInitialized {
             name: symbol_short!("escrow_ii"),
@@ -811,9 +810,8 @@ fn try_init_with_id(env: &Env, id: &str) -> Result<(), ()> {
             &None,
             &None,
             &None,
-        &None,
-    );
-}));
+        );
+    }));
     result.map(|_| ()).map_err(|_| ())
 }
 
@@ -893,7 +891,7 @@ fn test_invoice_id_digits_only_accepted() {
 /// This covers common punctuation, operators, whitespace, and non-ASCII bytes.
 #[test]
 fn test_invoice_id_illegal_chars_all_rejected() {
-    // Characters that are NOT in [A-Za-z0-9_] — representative set covering
+    // Characters that are NOT in [A-Za-z0-9_] ÔÇö representative set covering
     // punctuation, operators, whitespace, and boundary ASCII values.
     let illegal: &[&str] = &[
         "INV-DASH",  // hyphen
@@ -978,7 +976,7 @@ proptest! {
     /// Any string with at least one character outside [A-Za-z0-9_] (length 1..=32) must panic.
     #[test]
     fn prop_invalid_charset_invoice_id_always_rejected(
-        // valid prefix + one illegal char + optional valid suffix, total ≤ 32
+        // valid prefix + one illegal char + optional valid suffix, total Ôëñ 32
         prefix in "[A-Za-z0-9_]{0,15}",
         bad_char in "[^A-Za-z0-9_]",
         suffix in "[A-Za-z0-9_]{0,15}",
@@ -1010,11 +1008,11 @@ proptest! {
     }
 }
 
-// ── DataKey default-on-absence verification (docs/escrow-data-model.md) ──────
+// ÔöÇÔöÇ DataKey default-on-absence verification (docs/escrow-data-model.md) ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 fn datakey_defaults_on_fresh_init() {
-    // Verifies that every key documented as "absent ⇒ default" actually returns
+    // Verifies that every key documented as "absent ÔçÆ default" actually returns
     // the documented default on a freshly initialised escrow with no optional
     // configuration supplied.
     let env = Env::default();
@@ -1022,19 +1020,19 @@ fn datakey_defaults_on_fresh_init() {
     let investor = Address::generate(&env);
     default_init(&client, &env, &admin, &sme);
 
-    // Absent ⇒ false
+    // Absent ÔçÆ false
     assert!(!client.get_legal_hold());
     assert!(!client.is_investor_allowlisted(&investor));
     assert!(!client.is_allowlist_active());
     assert!(!client.is_investor_refunded(&investor));
 
-    // Absent ⇒ 0
+    // Absent ÔçÆ 0
     assert_eq!(client.get_contribution(&investor), 0i128);
     assert_eq!(client.get_min_contribution_floor(), 0i128);
     assert_eq!(client.get_unique_funder_count(), 0u32);
     assert_eq!(client.get_distributed_principal(), 0i128);
 
-    // Optional caps absent ⇒ None
+    // Optional caps absent ÔçÆ None
     assert!(client.get_max_unique_investors_cap().is_none());
     assert!(client.get_max_per_investor_cap().is_none());
 
@@ -1071,7 +1069,8 @@ fn datakey_distributed_principal_starts_at_zero_and_increments_on_refund() {
         &None,
         &None,
     );
-assert_eq!(client.get_distributed_principal(), 0i128);
+
+    assert_eq!(client.get_distributed_principal(), 0i128);
 
     token.stellar.mint(&client.address, &500i128);
     client.fund(&investor, &500i128);

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -594,10 +594,7 @@ fn test_get_funding_token_before_init_fails_with_typed_error() {
 fn test_get_treasury_before_init_fails_with_typed_error() {
     let env = Env::default();
     let client = deploy(&env);
-    assert_contract_error(
-        client.try_get_treasury(),
-        EscrowError::TreasuryNotSet,
-    );
+    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
 }
 
 #[test]

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -26,8 +26,9 @@ fn test_init_stores_escrow() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(escrow.invoice_id, symbol_short!("INV001"));
+assert_eq!(escrow.invoice_id, symbol_short!("INV001"));
     assert_eq!(escrow.admin, admin);
     assert_eq!(escrow.sme_address, sme);
     assert_eq!(escrow.amount, TARGET);
@@ -58,8 +59,9 @@ fn test_init_stores_keyed_invoice_and_lists_it() {
         &None,
         &None,
         &None,
+        &None,
     );
-    let got = client.get_escrow();
+let got = client.get_escrow();
     assert_eq!(got, escrow);
 }
 
@@ -83,8 +85,9 @@ fn test_init_requires_admin_auth() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert!(
+assert!(
         env.auths().iter().any(|(addr, _)| *addr == admin),
         "admin auth was not recorded for init"
     );
@@ -136,8 +139,9 @@ fn test_init_unauthorized_panics() {
             &None,
             &None,
             &None,
-        );
-    }));
+        &None,
+    );
+}));
     assert!(result.is_err(), "Expected panic without auth");
 }
 
@@ -178,6 +182,7 @@ fn test_cost_baseline_init() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -201,6 +206,7 @@ fn test_cost_baseline_init_zero_maturity() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -218,6 +224,7 @@ fn test_cost_baseline_init_max_amount() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -252,6 +259,7 @@ fn test_init_invoice_id_empty_string_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -274,6 +282,7 @@ fn test_init_invoice_id_whitespace_panics() {
         &t,
         &None,
         &tr,
+        &None,
         &None,
         &None,
         &None,
@@ -309,6 +318,7 @@ fn test_init_invoice_id_too_long_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -331,6 +341,7 @@ fn test_init_invoice_id_bad_charset_hyphen_panics() {
         &t,
         &None,
         &tr,
+        &None,
         &None,
         &None,
         &None,
@@ -365,6 +376,7 @@ fn test_init_invoice_id_non_ascii_multibyte_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -385,6 +397,7 @@ fn test_init_invoice_id_embedded_null_panics() {
     client.init(
         &admin, &s, &sme, &1000i128, &500i64, &0u64, &t, &None, &tr, &None, &None, &None, &None,
         &None, &None,
+        &None,
     );
 }
 
@@ -414,8 +427,9 @@ fn test_init_stores_registry_some_and_getters() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_registry_ref(), Some(reg));
+assert_eq!(client.get_registry_ref(), Some(reg));
     assert_eq!(client.get_funding_token(), token);
     assert_eq!(client.get_treasury(), treasury);
 }
@@ -447,8 +461,9 @@ fn test_init_min_contribution_floor_stored() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_min_contribution_floor(), 1_000i128);
+assert_eq!(client.get_min_contribution_floor(), 1_000i128);
 }
 
 /// Floor defaults to 0 when `min_contribution` is `None`.
@@ -476,8 +491,9 @@ fn test_init_min_contribution_floor_defaults_to_zero() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_min_contribution_floor(), 0i128);
+assert_eq!(client.get_min_contribution_floor(), 0i128);
 }
 
 /// `min_contribution = Some(0)` is rejected — the value must be positive when supplied.
@@ -502,6 +518,7 @@ fn test_init_min_contribution_zero_panics() {
         &tre,
         &None,
         &Some(0i128),
+        &None,
         &None,
         &None,
         &None,
@@ -535,6 +552,7 @@ fn test_init_min_contribution_exceeds_amount_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
 }
 
@@ -563,8 +581,9 @@ fn test_init_min_contribution_equal_to_amount_accepted() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_min_contribution_floor(), 5_000i128);
+assert_eq!(client.get_min_contribution_floor(), 5_000i128);
 }
 
 #[test]
@@ -605,8 +624,9 @@ fn test_get_funding_token_after_init_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_funding_token(), token);
+assert_eq!(client.get_funding_token(), token);
 }
 
 #[test]
@@ -630,8 +650,9 @@ fn test_get_treasury_after_init_succeeds() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_treasury(), treasury);
+assert_eq!(client.get_treasury(), treasury);
 }
 
 #[test]
@@ -666,8 +687,9 @@ fn test_init_registry_none_roundtrip() {
         &None,
         &None,
         &None,
+        &None,
     );
-    assert_eq!(client.get_registry_ref(), None);
+assert_eq!(client.get_registry_ref(), None);
 }
 
 #[test]
@@ -700,9 +722,9 @@ fn test_init_escrow_initialized_event_includes_bound_refs() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    assert_eq!(
+assert_eq!(
         env.events().all(),
         std::vec![EscrowInitialized {
             name: symbol_short!("escrow_ii"),
@@ -745,9 +767,9 @@ fn test_init_escrow_initialized_event_registry_none() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    assert_eq!(
+assert_eq!(
         env.events().all(),
         std::vec![EscrowInitialized {
             name: symbol_short!("escrow_ii"),
@@ -789,8 +811,9 @@ fn try_init_with_id(env: &Env, id: &str) -> Result<(), ()> {
             &None,
             &None,
             &None,
-        );
-    }));
+        &None,
+    );
+}));
     result.map(|_| ()).map_err(|_| ())
 }
 
@@ -831,6 +854,7 @@ fn test_invoice_id_length_33_panics() {
         &t,
         &None,
         &tr,
+        &None,
         &None,
         &None,
         &None,
@@ -1045,9 +1069,9 @@ fn datakey_distributed_principal_starts_at_zero_and_increments_on_refund() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    assert_eq!(client.get_distributed_principal(), 0i128);
+assert_eq!(client.get_distributed_principal(), 0i128);
 
     token.stellar.mint(&client.address, &500i128);
     client.fund(&investor, &500i128);

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -406,8 +406,7 @@ fn test_init_invoice_id_embedded_null_panics() {
 
     client.init(
         &admin, &s, &sme, &1000i128, &500i64, &0u64, &t, &None, &tr, &None, &None, &None, &None,
-        &None, &None,
-        &None,
+        &None, &None, &None,
     );
 }
 

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -58,9 +58,10 @@ fn test_legal_hold_midflow_blocks_and_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
+        &None,
     );
 
-    // We will not fund or settle ÔÇö just exercise legal hold at multiple points.
+    // We will not fund or settle ├ö├ç├Â just exercise legal hold at multiple points.
     // The contract id is derived from the deploy_and_init sequence, so we
     // capture it for auth mock setup.
 
@@ -161,6 +162,7 @@ fn test_escrow_gold_standard_happy_path_open_overfund_snapshot_settle_claim() {
         &None, // No yield tiers for simplicity
         &None, // No min contribution floor
         &None, // No max investors cap
+        &None,
         &None,
         &None,
         &None,
@@ -300,7 +302,7 @@ fn test_escrow_gold_standard_happy_path_open_overfund_snapshot_settle_claim() {
 
     // Note: The contract tracks claims but doesn't return payout amounts.
     // In a real integration, the payout calculation would be:
-    // payout = principal + (principal ├ù yield_bps) / 10_000
+    // payout = principal + (principal Ôö£├╣ yield_bps) / 10_000
     assert_eq!(
         alice_expected_payout,
         alice_amount + (alice_amount * YIELD_BPS as i128) / 10_000
@@ -318,17 +320,17 @@ fn test_escrow_gold_standard_happy_path_open_overfund_snapshot_settle_claim() {
 
     // === SUCCESS SUMMARY ===
     // This test successfully demonstrates:
-    // Ô£ô Escrow initialization with realistic USDC amounts
-    // Ô£ô Multi-investor funding with overfunding at funding close
-    // Ô£ô Automatic status transitions (Open ÔåÆ Funded ÔåÆ Settled)
-    // Ô£ô Funding close snapshot capture and verification
-    // Ô£ô Maturity-gated settlement by SME
-    // Ô£ô Individual investor claim processing with correct yield calculation
-    // Ô£ô State consistency throughout the complete lifecycle
+    // ├ö┬ú├┤ Escrow initialization with realistic USDC amounts
+    // ├ö┬ú├┤ Multi-investor funding with overfunding at funding close
+    // ├ö┬ú├┤ Automatic status transitions (Open ├ö├Ñ├å Funded ├ö├Ñ├å Settled)
+    // ├ö┬ú├┤ Funding close snapshot capture and verification
+    // ├ö┬ú├┤ Maturity-gated settlement by SME
+    // ├ö┬ú├┤ Individual investor claim processing with correct yield calculation
+    // ├ö┬ú├┤ State consistency throughout the complete lifecycle
 }
 
 /// Helper function to calculate expected payout using the same formula as the contract.
-/// Formula: payout = principal + (principal ├ù yield_bps) / 10_000
+/// Formula: payout = principal + (principal Ôö£├╣ yield_bps) / 10_000
 /// This matches the contract's `calculate_principal_plus_yield` function.
 fn calculate_expected_payout(principal: i128, yield_bps: i64) -> i128 {
     let yield_amount = (principal * yield_bps as i128) / 10_000;
@@ -388,6 +390,7 @@ fn test_escrow_tiered_yield_with_commitment_locks() {
         &None,
         &treasury,
         &Some(yield_tiers),
+        &None,
         &None,
         &None,
         &None,
@@ -513,6 +516,7 @@ fn test_collateral_record_is_metadata_only_and_does_not_invoke_token_contract() 
         &funding,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -754,6 +758,7 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Initial funding succeeds while hold is off.
@@ -808,7 +813,7 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
     }
     .to_xdr(&env, &contract_id);
 
-    // Iterate via index ÔÇö soroban Vec iterator adapters don't include position().
+    // Iterate via index ├ö├ç├Â soroban Vec iterator adapters don't include position().
     let events_all = env.events().all();
     let all_event_list = events_all.events();
     let mut hold_on_pos: Option<usize> = None;
@@ -830,9 +835,9 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
     );
 }
 
-// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+// ├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç
 // On-chain SME disbursement tests (contracts-02)
-// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+// ├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç├ö├Â├ç
 
 /// Helper: deploy, init with a real SAC token, fund to `target`, and mint
 /// `target` tokens into the escrow contract.  Returns
@@ -871,6 +876,7 @@ fn setup_withdraw_with_token(
         &token_id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -939,7 +945,7 @@ fn withdraw_updates_distributed_principal() {
 
     client.withdraw();
 
-    // DistributedPrincipal is internal storage ÔÇö verify indirectly via the
+    // DistributedPrincipal is internal storage ├ö├ç├Â verify indirectly via the
     // dust-sweep liability floor.  After disbursement the outstanding liability
     // is zero (funded_amount == distributed_principal), so a dust sweep of any
     // residual amount must not be blocked by SweepExceedsLiabilityFloor.
@@ -997,8 +1003,9 @@ fn withdraw_rejected_wrong_status_open() {
         &None,
         &None,
         &None,
+        &None,
     );
-    // No funding ÔÇö status is 0.
+    // No funding ├ö├ç├Â status is 0.
     client.withdraw(); // must panic: WithdrawalNotFunded
 }
 
@@ -1040,12 +1047,13 @@ fn withdraw_rejected_insufficient_contract_balance() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     let investor = soroban_sdk::Address::generate(&env);
     client.fund(&investor, &target);
 
-    // Mint only half ÔÇö contract balance < funded_amount.
+    // Mint only half ├ö├ç├Â contract balance < funded_amount.
     sac_admin.mint(&escrow_id, &(target / 2));
 
     client.withdraw(); // must panic: InsufficientContractBalance
@@ -1061,7 +1069,7 @@ fn withdraw_double_withdraw_panics() {
     let (client, _escrow_id, _token, _sme) =
         setup_withdraw_with_token(&env, 10_000_000i128, "WD_DW001");
 
-    client.withdraw(); // succeeds ÔÇö status ÔåÆ 3
+    client.withdraw(); // succeeds ├ö├ç├Â status ├ö├Ñ├å 3
     client.withdraw(); // must panic: WithdrawalNotFunded (status == 3 != 1)
 }
 

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -890,12 +890,14 @@ fn withdraw_transfers_funded_amount_to_sme() {
     env.mock_all_auths();
 
     let target = 50_000_000i128;
-    let (client, escrow_id, token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_BAL001");
+    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
 
     let sme_before = token.balance(&sme);
     let contract_before = token.balance(&escrow_id);
-    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
+    assert_eq!(
+        contract_before, target,
+        "escrow must hold exactly funded_amount before withdraw"
+    );
 
     client.withdraw();
 
@@ -911,7 +913,11 @@ fn withdraw_transfers_funded_amount_to_sme() {
         contract_after, 0,
         "escrow contract balance must be zero after disbursement"
     );
-    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
+    assert_eq!(
+        client.get_escrow().status,
+        3u32,
+        "status must be 3 after withdraw"
+    );
 }
 
 /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
@@ -921,8 +927,7 @@ fn withdraw_updates_distributed_principal() {
     env.mock_all_auths();
 
     let target = 20_000_000i128;
-    let (client, _escrow_id, _token, _sme) =
-        setup_withdraw_with_token(&env, target, "WD_DP001");
+    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
 
     client.withdraw();
 
@@ -1058,8 +1063,7 @@ fn withdraw_event_includes_recipient() {
     env.mock_all_auths();
 
     let target = 5_000_000i128;
-    let (client, escrow_id, _token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_EV001");
+    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
 
     client.withdraw();
 
@@ -1074,9 +1078,9 @@ fn withdraw_event_includes_recipient() {
     .to_xdr(&env, &escrow_id);
 
     let all_events = env.events().all().filter_by_contract(&escrow_id);
-    let found = all_events
-        .events()
-        .iter()
-        .any(|e| *e == expected_xdr);
-    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
+    let found = all_events.events().iter().any(|e| *e == expected_xdr);
+    assert!(
+        found,
+        "SmeWithdrew event with correct recipient and amount must be emitted"
+    );
 }

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -894,12 +894,14 @@ fn withdraw_transfers_funded_amount_to_sme() {
     env.mock_all_auths();
 
     let target = 50_000_000i128;
-    let (client, escrow_id, token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_BAL001");
+    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
 
     let sme_before = token.balance(&sme);
     let contract_before = token.balance(&escrow_id);
-    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
+    assert_eq!(
+        contract_before, target,
+        "escrow must hold exactly funded_amount before withdraw"
+    );
 
     client.withdraw();
 
@@ -915,7 +917,11 @@ fn withdraw_transfers_funded_amount_to_sme() {
         contract_after, 0,
         "escrow contract balance must be zero after disbursement"
     );
-    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
+    assert_eq!(
+        client.get_escrow().status,
+        3u32,
+        "status must be 3 after withdraw"
+    );
 }
 
 /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
@@ -925,8 +931,7 @@ fn withdraw_updates_distributed_principal() {
     env.mock_all_auths();
 
     let target = 20_000_000i128;
-    let (client, _escrow_id, _token, _sme) =
-        setup_withdraw_with_token(&env, target, "WD_DP001");
+    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
 
     client.withdraw();
 
@@ -1064,8 +1069,7 @@ fn withdraw_event_includes_recipient() {
     env.mock_all_auths();
 
     let target = 5_000_000i128;
-    let (client, escrow_id, _token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_EV001");
+    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
 
     client.withdraw();
 
@@ -1080,9 +1084,9 @@ fn withdraw_event_includes_recipient() {
     .to_xdr(&env, &escrow_id);
 
     let all_events = env.events().all().filter_by_contract(&escrow_id);
-    let found = all_events
-        .events()
-        .iter()
-        .any(|e| *e == expected_xdr);
-    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
+    let found = all_events.events().iter().any(|e| *e == expected_xdr);
+    assert!(
+        found,
+        "SmeWithdrew event with correct recipient and amount must be emitted"
+    );
 }

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -1,4 +1,4 @@
-use super::super::external_calls::transfer_funding_token_with_balance_checks;
+﻿use super::super::external_calls::transfer_funding_token_with_balance_checks;
 use super::*;
 use crate::{CollateralRecordedEvt, DataKey, InvoiceEscrow, LegalHoldChanged};
 use soroban_sdk::{
@@ -58,7 +58,8 @@ fn test_legal_hold_midflow_blocks_and_resumes_with_ordered_events() {
         &None,
         &None,
     );
-// We will not fund or settle — just exercise legal hold at multiple points.
+
+    // We will not fund or settle ÔÇö just exercise legal hold at multiple points.
     // The contract id is derived from the deploy_and_init sequence, so we
     // capture it for auth mock setup.
 
@@ -162,9 +163,9 @@ fn test_escrow_gold_standard_happy_path_open_overfund_snapshot_settle_claim() {
         &None,
         &None,
         &None,
-        &None,
     );
-let initial_escrow = client.get_escrow();
+
+    let initial_escrow = client.get_escrow();
     assert_eq!(
         initial_escrow.status, 0,
         "Escrow should start in Open status"
@@ -298,7 +299,7 @@ let initial_escrow = client.get_escrow();
 
     // Note: The contract tracks claims but doesn't return payout amounts.
     // In a real integration, the payout calculation would be:
-    // payout = principal + (principal × yield_bps) / 10_000
+    // payout = principal + (principal ├ù yield_bps) / 10_000
     assert_eq!(
         alice_expected_payout,
         alice_amount + (alice_amount * YIELD_BPS as i128) / 10_000
@@ -316,17 +317,17 @@ let initial_escrow = client.get_escrow();
 
     // === SUCCESS SUMMARY ===
     // This test successfully demonstrates:
-    // ✓ Escrow initialization with realistic USDC amounts
-    // ✓ Multi-investor funding with overfunding at funding close
-    // ✓ Automatic status transitions (Open → Funded → Settled)
-    // ✓ Funding close snapshot capture and verification
-    // ✓ Maturity-gated settlement by SME
-    // ✓ Individual investor claim processing with correct yield calculation
-    // ✓ State consistency throughout the complete lifecycle
+    // Ô£ô Escrow initialization with realistic USDC amounts
+    // Ô£ô Multi-investor funding with overfunding at funding close
+    // Ô£ô Automatic status transitions (Open ÔåÆ Funded ÔåÆ Settled)
+    // Ô£ô Funding close snapshot capture and verification
+    // Ô£ô Maturity-gated settlement by SME
+    // Ô£ô Individual investor claim processing with correct yield calculation
+    // Ô£ô State consistency throughout the complete lifecycle
 }
 
 /// Helper function to calculate expected payout using the same formula as the contract.
-/// Formula: payout = principal + (principal × yield_bps) / 10_000
+/// Formula: payout = principal + (principal ├ù yield_bps) / 10_000
 /// This matches the contract's `calculate_principal_plus_yield` function.
 fn calculate_expected_payout(principal: i128, yield_bps: i64) -> i128 {
     let yield_amount = (principal * yield_bps as i128) / 10_000;
@@ -391,9 +392,9 @@ fn test_escrow_tiered_yield_with_commitment_locks() {
         &None,
         &None,
         &None,
-        &None,
     );
-let investor_base = Address::generate(&env);
+
+    let investor_base = Address::generate(&env);
     let investor_tier1 = Address::generate(&env);
     let investor_tier2 = Address::generate(&env);
     let investor_tier3 = Address::generate(&env);
@@ -519,7 +520,8 @@ fn test_collateral_record_is_metadata_only_and_does_not_invoke_token_contract() 
         &None,
         &None,
     );
-let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+
+    let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
     assert_eq!(commitment.asset, symbol_short!("USDC"));
     assert_eq!(commitment.amount, 5_000i128);
     assert!(client.get_sme_collateral_commitment().is_some());
@@ -750,7 +752,8 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
         &None,
         &None,
     );
-// Initial funding succeeds while hold is off.
+
+    // Initial funding succeeds while hold is off.
     let open_state = client.fund(&investor, &4_000i128);
     assert_eq!(open_state.status, 0);
 
@@ -802,7 +805,7 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
     }
     .to_xdr(&env, &contract_id);
 
-    // Iterate via index — soroban Vec iterator adapters don't include position().
+    // Iterate via index ÔÇö soroban Vec iterator adapters don't include position().
     let events_all = env.events().all();
     let all_event_list = events_all.events();
     let mut hold_on_pos: Option<usize> = None;
@@ -824,9 +827,9 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
     );
 }
 
-// ──────────────────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 // On-chain SME disbursement tests (contracts-02)
-// ──────────────────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 /// Helper: deploy, init with a real SAC token, fund to `target`, and mint
 /// `target` tokens into the escrow contract.  Returns
@@ -873,7 +876,8 @@ fn setup_withdraw_with_token(
         &None,
         &None,
     );
-let investor = soroban_sdk::Address::generate(env);
+
+    let investor = soroban_sdk::Address::generate(env);
     client.fund(&investor, &target);
 
     // Mint the funded amount into the escrow contract so withdraw() can send it.
@@ -890,14 +894,12 @@ fn withdraw_transfers_funded_amount_to_sme() {
     env.mock_all_auths();
 
     let target = 50_000_000i128;
-    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
+    let (client, escrow_id, token, sme) =
+        setup_withdraw_with_token(&env, target, "WD_BAL001");
 
     let sme_before = token.balance(&sme);
     let contract_before = token.balance(&escrow_id);
-    assert_eq!(
-        contract_before, target,
-        "escrow must hold exactly funded_amount before withdraw"
-    );
+    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
 
     client.withdraw();
 
@@ -913,11 +915,7 @@ fn withdraw_transfers_funded_amount_to_sme() {
         contract_after, 0,
         "escrow contract balance must be zero after disbursement"
     );
-    assert_eq!(
-        client.get_escrow().status,
-        3u32,
-        "status must be 3 after withdraw"
-    );
+    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
 }
 
 /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
@@ -927,11 +925,12 @@ fn withdraw_updates_distributed_principal() {
     env.mock_all_auths();
 
     let target = 20_000_000i128;
-    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
+    let (client, _escrow_id, _token, _sme) =
+        setup_withdraw_with_token(&env, target, "WD_DP001");
 
     client.withdraw();
 
-    // DistributedPrincipal is internal storage — verify indirectly via the
+    // DistributedPrincipal is internal storage ÔÇö verify indirectly via the
     // dust-sweep liability floor.  After disbursement the outstanding liability
     // is zero (funded_amount == distributed_principal), so a dust sweep of any
     // residual amount must not be blocked by SweepExceedsLiabilityFloor.
@@ -989,7 +988,7 @@ fn withdraw_rejected_wrong_status_open() {
         &None,
         &None,
     );
-// No funding — status is 0.
+    // No funding ÔÇö status is 0.
     client.withdraw(); // must panic: WithdrawalNotFunded
 }
 
@@ -1031,10 +1030,11 @@ fn withdraw_rejected_insufficient_contract_balance() {
         &None,
         &None,
     );
-let investor = soroban_sdk::Address::generate(&env);
+
+    let investor = soroban_sdk::Address::generate(&env);
     client.fund(&investor, &target);
 
-    // Mint only half — contract balance < funded_amount.
+    // Mint only half ÔÇö contract balance < funded_amount.
     sac_admin.mint(&escrow_id, &(target / 2));
 
     client.withdraw(); // must panic: InsufficientContractBalance
@@ -1050,7 +1050,7 @@ fn withdraw_double_withdraw_panics() {
     let (client, _escrow_id, _token, _sme) =
         setup_withdraw_with_token(&env, 10_000_000i128, "WD_DW001");
 
-    client.withdraw(); // succeeds — status → 3
+    client.withdraw(); // succeeds ÔÇö status ÔåÆ 3
     client.withdraw(); // must panic: WithdrawalNotFunded (status == 3 != 1)
 }
 
@@ -1064,7 +1064,8 @@ fn withdraw_event_includes_recipient() {
     env.mock_all_auths();
 
     let target = 5_000_000i128;
-    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
+    let (client, escrow_id, _token, sme) =
+        setup_withdraw_with_token(&env, target, "WD_EV001");
 
     client.withdraw();
 
@@ -1079,9 +1080,9 @@ fn withdraw_event_includes_recipient() {
     .to_xdr(&env, &escrow_id);
 
     let all_events = env.events().all().filter_by_contract(&escrow_id);
-    let found = all_events.events().iter().any(|e| *e == expected_xdr);
-    assert!(
-        found,
-        "SmeWithdrew event with correct recipient and amount must be emitted"
-    );
+    let found = all_events
+        .events()
+        .iter()
+        .any(|e| *e == expected_xdr);
+    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
 }

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -1,4 +1,4 @@
-﻿use super::super::external_calls::transfer_funding_token_with_balance_checks;
+use super::super::external_calls::transfer_funding_token_with_balance_checks;
 use super::*;
 use crate::{CollateralRecordedEvt, DataKey, InvoiceEscrow, LegalHoldChanged};
 use soroban_sdk::{
@@ -50,6 +50,7 @@ fn test_legal_hold_midflow_blocks_and_resumes_with_ordered_events() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -519,6 +520,7 @@ fn test_collateral_record_is_metadata_only_and_does_not_invoke_token_contract() 
         &None,
         &None,
         &None,
+        &None,
     );
 
     let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
@@ -751,6 +753,7 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     // Initial funding succeeds while hold is off.
@@ -875,6 +878,7 @@ fn setup_withdraw_with_token(
         &None,
         &None,
         &None,
+        &None,
     );
 
     let investor = soroban_sdk::Address::generate(env);
@@ -992,6 +996,7 @@ fn withdraw_rejected_wrong_status_open() {
         &None,
         &None,
         &None,
+        &None,
     );
     // No funding ÔÇö status is 0.
     client.withdraw(); // must panic: WithdrawalNotFunded
@@ -1027,6 +1032,7 @@ fn withdraw_rejected_insufficient_contract_balance() {
         &token_id,
         &None,
         &soroban_sdk::Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -56,9 +56,9 @@ fn test_legal_hold_midflow_blocks_and_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // We will not fund or settle — just exercise legal hold at multiple points.
+// We will not fund or settle — just exercise legal hold at multiple points.
     // The contract id is derived from the deploy_and_init sequence, so we
     // capture it for auth mock setup.
 
@@ -162,9 +162,9 @@ fn test_escrow_gold_standard_happy_path_open_overfund_snapshot_settle_claim() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let initial_escrow = client.get_escrow();
+let initial_escrow = client.get_escrow();
     assert_eq!(
         initial_escrow.status, 0,
         "Escrow should start in Open status"
@@ -391,9 +391,9 @@ fn test_escrow_tiered_yield_with_commitment_locks() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let investor_base = Address::generate(&env);
+let investor_base = Address::generate(&env);
     let investor_tier1 = Address::generate(&env);
     let investor_tier2 = Address::generate(&env);
     let investor_tier3 = Address::generate(&env);
@@ -517,9 +517,9 @@ fn test_collateral_record_is_metadata_only_and_does_not_invoke_token_contract() 
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
     assert_eq!(commitment.asset, symbol_short!("USDC"));
     assert_eq!(commitment.amount, 5_000i128);
     assert!(client.get_sme_collateral_commitment().is_some());
@@ -748,9 +748,9 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    // Initial funding succeeds while hold is off.
+// Initial funding succeeds while hold is off.
     let open_state = client.fund(&investor, &4_000i128);
     assert_eq!(open_state.status, 0);
 
@@ -871,9 +871,9 @@ fn setup_withdraw_with_token(
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let investor = soroban_sdk::Address::generate(env);
+let investor = soroban_sdk::Address::generate(env);
     client.fund(&investor, &target);
 
     // Mint the funded amount into the escrow contract so withdraw() can send it.
@@ -987,8 +987,9 @@ fn withdraw_rejected_wrong_status_open() {
         &None,
         &None,
         &None,
+        &None,
     );
-    // No funding — status is 0.
+// No funding — status is 0.
     client.withdraw(); // must panic: WithdrawalNotFunded
 }
 
@@ -1028,9 +1029,9 @@ fn withdraw_rejected_insufficient_contract_balance() {
         &None,
         &None,
         &None,
+        &None,
     );
-
-    let investor = soroban_sdk::Address::generate(&env);
+let investor = soroban_sdk::Address::generate(&env);
     client.fund(&investor, &target);
 
     // Mint only half — contract balance < funded_amount.

--- a/escrow/src/tests/legal_hold.rs
+++ b/escrow/src/tests/legal_hold.rs
@@ -1,12 +1,12 @@
-//! Legal-hold matrix tests.
+﻿//! Legal-hold matrix tests.
 //!
 //! Each risk-bearing function gets two focused tests:
-//!   `*_blocked_under_hold`  — hold=true  → must panic with the exact contract message
-//!   `*_passes_when_hold_cleared` — hold=false → operation succeeds normally
+//!   `*_blocked_under_hold`  ÔÇö hold=true  ÔåÆ must panic with the exact contract message
+//!   `*_passes_when_hold_cleared` ÔÇö hold=false ÔåÆ operation succeeds normally
 //!
 //! Edge-case tests verify:
 //!   - Hold check fires before status validation (fund, settle, withdraw)
-//!   - Idempotent toggling (set true→true, clear false→false)
+//!   - Idempotent toggling (set trueÔåÆtrue, clear falseÔåÆfalse)
 //!   - Non-gated operations (`update_maturity`, admin handover, getters) are NOT blocked
 //!   - Claim idempotency survives a hold toggle
 //!   - A single hold toggle blocks all gated ops in separate escrows
@@ -14,16 +14,16 @@
 //! Auth tests verify that only the admin can set or clear the hold.
 //!
 //! Gated functions (6 entrypoints, 5 unique messages):
-//!   fund / fund_with_commitment  → "Legal hold blocks new funding while active"
-//!   settle                       → "Legal hold blocks settlement finalization"
-//!   withdraw                     → "Legal hold blocks SME withdrawal"
-//!   claim_investor_payout        → "Legal hold blocks investor claims"
-//!   sweep_terminal_dust          → "Legal hold blocks treasury dust sweep"
+//!   fund / fund_with_commitment  ÔåÆ "Legal hold blocks new funding while active"
+//!   settle                       ÔåÆ "Legal hold blocks settlement finalization"
+//!   withdraw                     ÔåÆ "Legal hold blocks SME withdrawal"
+//!   claim_investor_payout        ÔåÆ "Legal hold blocks investor claims"
+//!   sweep_terminal_dust          ÔåÆ "Legal hold blocks treasury dust sweep"
 
 use super::*;
 use soroban_sdk::token::StellarAssetClient;
 
-// ── helpers ──────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇ helpers ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 /// Initialise a minimal escrow (open, maturity=0, no tiers).
 fn init_open(
@@ -53,7 +53,7 @@ fn init_open(
         &None,
         &None,
     );
-(token, treasury)
+    (token, treasury)
 }
 
 /// Initialise an open escrow with a configured legal-hold clear delay.
@@ -83,9 +83,8 @@ fn init_open_with_clear_delay(
         &None,
         &legal_hold_clear_delay,
         &None,
-        &None,
     );
-(token, treasury)
+    (token, treasury)
 }
 
 /// Initialise with a real SAC token, fund to target, and mint `TARGET` tokens
@@ -121,7 +120,7 @@ fn init_funded_with_real_token<'a>(
         &None,
         &None,
     );
-client.fund(investor, &TARGET);
+    client.fund(investor, &TARGET);
     sac_admin.mint(&escrow_id, &TARGET);
     (client, escrow_id)
 }
@@ -171,12 +170,12 @@ fn init_settled<'a>(
         &None,
         &None,
     );
-client.fund(investor, &TARGET);
+    client.fund(investor, &TARGET);
     client.settle();
     (client, escrow_id, token, treasury)
 }
 
-// ── 1. fund ──────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇ 1. fund ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 #[should_panic]
@@ -202,7 +201,7 @@ fn fund_passes_when_hold_cleared() {
     assert_eq!(escrow.status, 1);
 }
 
-// ── 2. fund_with_commitment ───────────────────────────────────────────────────
+// ÔöÇÔöÇ 2. fund_with_commitment ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 #[should_panic]
@@ -227,7 +226,7 @@ fn fund_with_commitment_passes_when_hold_cleared() {
     assert_eq!(escrow.status, 1);
 }
 
-// ── 3. settle ────────────────────────────────────────────────────────────────
+// ÔöÇÔöÇ 3. settle ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 #[should_panic]
@@ -252,7 +251,7 @@ fn settle_passes_when_hold_cleared() {
     assert_eq!(escrow.status, 2);
 }
 
-// ── 4. withdraw ──────────────────────────────────────────────────────────────
+// ÔöÇÔöÇ 4. withdraw ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 #[should_panic]
@@ -279,7 +278,7 @@ fn withdraw_passes_when_hold_cleared() {
     assert_eq!(escrow.status, 3);
 }
 
-// ── 5. claim_investor_payout ─────────────────────────────────────────────────
+// ÔöÇÔöÇ 5. claim_investor_payout ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 #[should_panic]
@@ -306,7 +305,7 @@ fn claim_investor_payout_passes_when_hold_cleared() {
     assert!(client.is_investor_claimed(&investor));
 }
 
-// ── 6. sweep_terminal_dust ───────────────────────────────────────────────────
+// ÔöÇÔöÇ 6. sweep_terminal_dust ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 #[should_panic]
@@ -342,7 +341,7 @@ fn sweep_terminal_dust_passes_when_hold_cleared() {
     assert_eq!(stellar.balance(&treasury), 500i128);
 }
 
-// ── 7. Admin-only: set_legal_hold ────────────────────────────────────────────
+// ÔöÇÔöÇ 7. Admin-only: set_legal_hold ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 fn set_legal_hold_by_admin_succeeds() {
@@ -360,13 +359,13 @@ fn set_legal_hold_emits_event_with_correct_flag() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
     init_open(&client, &env, &admin, &sme, "LHA002");
-    // set → active=1
+    // set ÔåÆ active=1
     client.set_legal_hold(&true);
     assert!(
         env.auths().iter().any(|(addr, _)| *addr == admin),
         "admin auth must be recorded for set_legal_hold"
     );
-    // clear → active=0
+    // clear ÔåÆ active=0
     client.clear_legal_hold();
     assert!(!client.get_legal_hold());
 }
@@ -382,7 +381,7 @@ fn set_legal_hold_by_non_admin_panics() {
     client.set_legal_hold(&true);
 }
 
-// ── 8. Admin-only: clear_legal_hold ──────────────────────────────────────────
+// ÔöÇÔöÇ 8. Admin-only: clear_legal_hold ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 fn clear_legal_hold_by_admin_succeeds() {
@@ -453,7 +452,7 @@ fn clear_legal_hold_by_non_admin_panics() {
     client.clear_legal_hold();
 }
 
-// ── 9. Default state ─────────────────────────────────────────────────────────
+// ÔöÇÔöÇ 9. Default state ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 fn legal_hold_defaults_to_false_after_init() {
@@ -463,7 +462,7 @@ fn legal_hold_defaults_to_false_after_init() {
     assert!(!client.get_legal_hold());
 }
 
-// ── 10. No-bypass: hold survives state transitions ───────────────────────────
+// ÔöÇÔöÇ 10. No-bypass: hold survives state transitions ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 /// A hold set while open must still block settle after the escrow becomes funded.
 #[test]
@@ -474,7 +473,7 @@ fn hold_set_before_funding_still_blocks_settle_after_funded() {
     init_open(&client, &env, &admin, &sme, "LHX001");
     // Hold is set while escrow is still open.
     client.set_legal_hold(&true);
-    // fund() itself is blocked — clear hold, fund, then re-apply hold.
+    // fund() itself is blocked ÔÇö clear hold, fund, then re-apply hold.
     client.clear_legal_hold();
     client.fund(&investor, &TARGET);
     assert_eq!(client.get_escrow().status, 1);
@@ -497,13 +496,13 @@ fn hold_can_be_toggled_and_re_blocks_operations() {
     let investor = Address::generate(&env);
     init_funded(&client, &env, &admin, &sme, &investor, "LHX002");
 
-    // First toggle: set → clear → settle succeeds.
+    // First toggle: set ÔåÆ clear ÔåÆ settle succeeds.
     client.set_legal_hold(&true);
     client.clear_legal_hold();
     let settled = client.settle();
     assert_eq!(settled.status, 2);
 
-    // Second toggle: re-set → claim is blocked.
+    // Second toggle: re-set ÔåÆ claim is blocked.
     client.set_legal_hold(&true);
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.claim_investor_payout(&investor);
@@ -513,7 +512,7 @@ fn hold_can_be_toggled_and_re_blocks_operations() {
         "claim must be blocked after re-setting hold"
     );
 
-    // Clear again → claim succeeds.
+    // Clear again ÔåÆ claim succeeds.
     client.clear_legal_hold();
     client.claim_investor_payout(&investor);
     assert!(client.is_investor_claimed(&investor));
@@ -548,7 +547,7 @@ fn hold_persists_after_admin_handover() {
     assert_eq!(settled.status, 2);
 }
 
-// ── 11. Edge-case: hold check fires before amount / status / auth checks ─────
+// ÔöÇÔöÇ 11. Edge-case: hold check fires before amount / status / auth checks ÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 /// Hold must block `sweep_terminal_dust` before the zero-amount guard fires.
 #[test]
@@ -575,7 +574,7 @@ fn hold_blocks_settle_before_status_check_on_open_escrow() {
     let (client, admin, sme) = setup(&env);
     init_open(&client, &env, &admin, &sme, "LHS003");
     client.set_legal_hold(&true);
-    // Escrow is open (status 0) — "Escrow must be funded" would fire next,
+    // Escrow is open (status 0) ÔÇö "Escrow must be funded" would fire next,
     // but hold must panic first.
     client.settle();
 }
@@ -593,7 +592,7 @@ fn hold_blocks_withdraw_before_status_check_on_open_escrow() {
 
 /// Hold must block `fund` before the status guard fires (escrow already funded).
 /// Note: the `amount > 0` check fires before the hold check in `fund_impl`,
-/// so zero-amount is NOT a valid test — use a fully-funded escrow instead.
+/// so zero-amount is NOT a valid test ÔÇö use a fully-funded escrow instead.
 #[test]
 #[should_panic]
 fn hold_blocks_fund_before_status_check_on_funded_escrow() {
@@ -602,12 +601,12 @@ fn hold_blocks_fund_before_status_check_on_funded_escrow() {
     let investor = Address::generate(&env);
     init_funded(&client, &env, &admin, &sme, &investor, "LHF003");
     client.set_legal_hold(&true);
-    // Escrow is funded (status 1) — "Escrow not open for funding" would fire next,
+    // Escrow is funded (status 1) ÔÇö "Escrow not open for funding" would fire next,
     // but hold must panic first.
     client.fund(&investor, &1i128);
 }
 
-// ── 12. Idempotent toggling ──────────────────────────────────────────────────
+// ÔöÇÔöÇ 12. Idempotent toggling ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 #[test]
 fn set_legal_hold_true_when_already_true_is_idempotent() {
@@ -626,14 +625,14 @@ fn clear_legal_hold_when_already_false_is_idempotent() {
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
     init_open(&client, &env, &admin, &sme, "LHI002");
-    // Hold defaults to false — clear must not panic.
+    // Hold defaults to false ÔÇö clear must not panic.
     client.clear_legal_hold();
     assert!(!client.get_legal_hold());
     client.clear_legal_hold();
     assert!(!client.get_legal_hold());
 }
 
-// ── 13. Non-gated operations are NOT blocked by hold ─────────────────────────
+// ÔöÇÔöÇ 13. Non-gated operations are NOT blocked by hold ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 /// `update_maturity`, admin handover, and getters must all work under hold.
 #[test]
@@ -665,7 +664,7 @@ fn non_risk_operations_not_blocked_by_hold() {
     assert_eq!(client.get_pending_admin(), None);
 }
 
-// ── 14. Re-entrancy / double-spend: claim idempotent after hold cleared ───────
+// ÔöÇÔöÇ 14. Re-entrancy / double-spend: claim idempotent after hold cleared ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 /// After clearing a hold, the idempotent claim guard must still prevent
 /// double-spend (the `is_claimed` marker survives the hold toggle).
@@ -690,7 +689,7 @@ fn claim_after_hold_cleared_still_idempotent() {
     assert!(client.is_investor_claimed(&investor));
 }
 
-// ── 15. Multiple gated operations blocked by one hold toggle ──────────────────
+// ÔöÇÔöÇ 15. Multiple gated operations blocked by one hold toggle ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
 
 /// A single hold (set once) must block all risk-bearing entrypoints that the
 /// escrow state would otherwise permit. We verify this across three separate

--- a/escrow/src/tests/legal_hold.rs
+++ b/escrow/src/tests/legal_hold.rs
@@ -1,4 +1,4 @@
-﻿//! Legal-hold matrix tests.
+//! Legal-hold matrix tests.
 //!
 //! Each risk-bearing function gets two focused tests:
 //!   `*_blocked_under_hold`  ÔÇö hold=true  ÔåÆ must panic with the exact contract message
@@ -52,6 +52,7 @@ fn init_open(
         &None,
         &None,
         &None,
+        &None,
     );
     (token, treasury)
 }
@@ -83,6 +84,7 @@ fn init_open_with_clear_delay(
         &None,
         &legal_hold_clear_delay,
         &None,
+        &None,
     );
     (token, treasury)
 }
@@ -112,6 +114,7 @@ fn init_funded_with_real_token<'a>(
         &token_id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -162,6 +165,7 @@ fn init_settled<'a>(
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,

--- a/escrow/src/tests/legal_hold.rs
+++ b/escrow/src/tests/legal_hold.rs
@@ -51,8 +51,9 @@ fn init_open(
         &None,
         &None,
         &None,
+        &None,
     );
-    (token, treasury)
+(token, treasury)
 }
 
 /// Initialise an open escrow with a configured legal-hold clear delay.
@@ -82,8 +83,9 @@ fn init_open_with_clear_delay(
         &None,
         &legal_hold_clear_delay,
         &None,
+        &None,
     );
-    (token, treasury)
+(token, treasury)
 }
 
 /// Initialise with a real SAC token, fund to target, and mint `TARGET` tokens
@@ -117,8 +119,9 @@ fn init_funded_with_real_token<'a>(
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(investor, &TARGET);
+client.fund(investor, &TARGET);
     sac_admin.mint(&escrow_id, &TARGET);
     (client, escrow_id)
 }
@@ -166,8 +169,9 @@ fn init_settled<'a>(
         &None,
         &None,
         &None,
+        &None,
     );
-    client.fund(investor, &TARGET);
+client.fund(investor, &TARGET);
     client.settle();
     (client, escrow_id, token, treasury)
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -1,4 +1,4 @@
-﻿//! Settlement and withdrawal tests for the LiquiFact escrow contract.
+//! Settlement and withdrawal tests for the LiquiFact escrow contract.
 //!
 //! Covers the full `withdraw` surface (happy path, wrong-status guards, legal-hold
 //! block, idempotency, event emission, and terminal status assertion) as well as
@@ -70,6 +70,7 @@ fn setup_funded_with_token<'a>(
         &token_id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -306,6 +307,7 @@ fn test_claim_investor_twice_is_idempotent() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -342,6 +344,7 @@ fn test_claim_by_non_investor_panics() {
         &None,
         &None,
         &None,
+        &None,
     );
     // Escrow settled but stranger never funded
     let investor = Address::generate(&env);
@@ -367,6 +370,7 @@ fn test_clashing_investors_have_independent_claims() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -455,6 +459,7 @@ fn test_claim_blocked_until_commitment_ledger_time() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund_with_commitment(&inv, &1_000i128, &500u64);
     client.settle();
@@ -480,6 +485,7 @@ fn test_claim_succeeds_after_commitment_and_settle() {
         &tok,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -516,6 +522,7 @@ fn test_claim_gating_exact_timestamp() {
         &tok,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -572,6 +579,7 @@ fn test_claim_gating_with_multiple_investors() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     client.fund_with_commitment(&inv1, &1_000i128, &100u64); // Expiry 1100
@@ -611,6 +619,7 @@ fn test_cost_baseline_settle() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -667,6 +676,7 @@ fn settle_with_maturity_zero_succeeds_immediately() {
         &None,
         &None,
         &None,
+        &None,
     );
 
     assert!(
@@ -706,6 +716,7 @@ fn settle_one_second_before_maturity_traps_and_preserves_state() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -760,6 +771,7 @@ fn settle_at_maturity_succeeds() {
         &token,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -909,6 +921,7 @@ fn test_sweep_terminal_dust_after_settle_transfers_to_treasury() {
         &None,
         &None,
         &None,
+        &None,
     );
     let investor = Address::generate(&env);
     client.fund(&investor, &1_000i128);
@@ -943,6 +956,7 @@ fn test_sweep_terminal_dust_after_withdraw_and_ledger_tick() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -986,6 +1000,7 @@ fn test_sweep_rejected_when_open() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1009,6 +1024,7 @@ fn test_sweep_blocked_under_legal_hold() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -1046,6 +1062,7 @@ fn test_sweep_rejects_amount_above_dust_cap() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &1_000i128);
     // status == 1 (funded), not settled — must panic
@@ -1070,6 +1087,7 @@ fn test_sweep_caps_at_contract_balance() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -1103,6 +1121,7 @@ fn test_sweep_requires_treasury_auth() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1143,6 +1162,7 @@ fn claim_investor_payout_succeeds_after_settle() {
         &token.id,
         &None,
         &treasury,
+        &None,
         &None,
         &None,
         &None,
@@ -1336,6 +1356,7 @@ fn test_is_investor_claimed_false_before_any_claim() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1366,6 +1387,7 @@ fn test_is_investor_claimed_returns_false_for_unfunded_address() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor, &1_000i128);
     client.settle();
@@ -1388,6 +1410,7 @@ fn test_claim_marker_persists_after_claim() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -1425,6 +1448,7 @@ fn test_claim_marker_isolated_per_investor() {
         &None,
         &None,
         &None,
+        &None,
     );
     client.fund(&investor_a, &1_000i128);
     client.fund(&investor_b, &1_000i128);
@@ -1453,6 +1477,7 @@ fn test_claim_marker_all_investors_independent() {
         &Address::generate(&env),
         &None,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
         &None,
@@ -1778,6 +1803,7 @@ fn settled_at_recorded_with_maturity() {
         &maturity,
         &token_id,
         &Address::generate(&env),
+        &None,
         &None,
         &None,
     );

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -1661,3 +1661,124 @@ fn test_funding_blocked_after_partial_settle() {
     let late_investor = Address::generate(&env);
     client.fund(&late_investor, &1_000i128);
 }
+
+// ── get_settled_at tests ──────────────────────────────────────────────────────
+
+/// `get_settled_at` returns `None` before the escrow is settled (pre-settle state).
+#[test]
+fn settled_at_is_none_before_settle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    // Not yet funded — should be None.
+    assert!(client.get_settled_at().is_none(), "settled_at must be None before settle");
+
+    // Fund to target (status 1) — still None.
+    fund_to_target(&client, &env);
+    assert!(client.get_settled_at().is_none(), "settled_at must be None after funding, before settle");
+}
+
+/// `get_settled_at` returns `Some(timestamp)` equal to the ledger time at `settle()`.
+#[test]
+fn settled_at_recorded_at_settle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    fund_to_target(&client, &env);
+
+    let settle_ts: u64 = 9_999;
+    env.ledger().with_mut(|l| l.timestamp = settle_ts);
+    client.settle();
+
+    let stored = client.get_settled_at().expect("settled_at must be Some after settle");
+    assert_eq!(stored, settle_ts, "settled_at must equal the ledger timestamp at settle()");
+}
+
+/// `get_settled_at` value is stable — subsequent reads return the same timestamp.
+#[test]
+fn settled_at_is_stable_after_settle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    fund_to_target(&client, &env);
+
+    let settle_ts: u64 = 42_000;
+    env.ledger().with_mut(|l| l.timestamp = settle_ts);
+    client.settle();
+
+    // Advance ledger — stored value must not change.
+    env.ledger().with_mut(|l| l.timestamp = settle_ts + 10_000);
+    let stored = client.get_settled_at().expect("settled_at must remain Some");
+    assert_eq!(stored, settle_ts, "settled_at must not change after additional ledger advancement");
+}
+
+/// `settle()` with maturity = 0 (no time-lock) still records the correct timestamp.
+#[test]
+fn settled_at_recorded_no_maturity_escrow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    // default_init uses maturity=0 (no lock).
+    default_init(&client, &env, &admin, &sme);
+    fund_to_target(&client, &env);
+
+    let ts: u64 = 1_234_567;
+    env.ledger().with_mut(|l| l.timestamp = ts);
+    client.settle();
+
+    assert_eq!(
+        client.get_settled_at(),
+        Some(ts),
+        "settled_at must be recorded even when maturity == 0"
+    );
+}
+
+/// `settle()` with a positive maturity records the timestamp at the moment the call succeeds.
+#[test]
+fn settled_at_recorded_with_maturity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+
+    let maturity: u64 = 5_000;
+    // Initialize with a maturity lock.
+    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_id = sac.address();
+    let (admin_addr, sme_addr) = free_addresses(&env);
+    client.init(
+        &admin_addr,
+        &sme_addr,
+        &100_000i128,
+        &TARGET,
+        &500i64,
+        &maturity,
+        &token_id,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let investor = Address::generate(&env);
+    install_stellar_asset_token(&env, &sac, &investor, TARGET);
+    client.fund(&investor, &TARGET);
+
+    // Advance ledger past maturity.
+    let settle_ts = maturity + 100;
+    env.ledger().with_mut(|l| l.timestamp = settle_ts);
+    client.settle();
+
+    assert_eq!(
+        client.get_settled_at(),
+        Some(settle_ts),
+        "settled_at must equal the ledger timestamp when settle() succeeds with maturity gate"
+    );
+}

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -45,7 +45,11 @@ fn fund_to_target(client: &super::LiquifactEscrowClient<'_>, env: &Env) -> Addre
 /// actually transfer them.  Returns `(client, sme, sac_admin_client)`.
 fn setup_funded_with_token<'a>(
     env: &'a Env,
-) -> (super::LiquifactEscrowClient<'a>, Address, StellarAssetClient<'a>) {
+) -> (
+    super::LiquifactEscrowClient<'a>,
+    Address,
+    StellarAssetClient<'a>,
+) {
     let sac = env.register_stellar_asset_contract_v2(Address::generate(env));
     let token_id = sac.address();
     let sac_admin = StellarAssetClient::new(env, &token_id);
@@ -1673,11 +1677,17 @@ fn settled_at_is_none_before_settle() {
     default_init(&client, &env, &admin, &sme);
 
     // Not yet funded — should be None.
-    assert!(client.get_settled_at().is_none(), "settled_at must be None before settle");
+    assert!(
+        client.get_settled_at().is_none(),
+        "settled_at must be None before settle"
+    );
 
     // Fund to target (status 1) — still None.
     fund_to_target(&client, &env);
-    assert!(client.get_settled_at().is_none(), "settled_at must be None after funding, before settle");
+    assert!(
+        client.get_settled_at().is_none(),
+        "settled_at must be None after funding, before settle"
+    );
 }
 
 /// `get_settled_at` returns `Some(timestamp)` equal to the ledger time at `settle()`.
@@ -1693,8 +1703,13 @@ fn settled_at_recorded_at_settle() {
     env.ledger().with_mut(|l| l.timestamp = settle_ts);
     client.settle();
 
-    let stored = client.get_settled_at().expect("settled_at must be Some after settle");
-    assert_eq!(stored, settle_ts, "settled_at must equal the ledger timestamp at settle()");
+    let stored = client
+        .get_settled_at()
+        .expect("settled_at must be Some after settle");
+    assert_eq!(
+        stored, settle_ts,
+        "settled_at must equal the ledger timestamp at settle()"
+    );
 }
 
 /// `get_settled_at` value is stable — subsequent reads return the same timestamp.
@@ -1712,8 +1727,13 @@ fn settled_at_is_stable_after_settle() {
 
     // Advance ledger — stored value must not change.
     env.ledger().with_mut(|l| l.timestamp = settle_ts + 10_000);
-    let stored = client.get_settled_at().expect("settled_at must remain Some");
-    assert_eq!(stored, settle_ts, "settled_at must not change after additional ledger advancement");
+    let stored = client
+        .get_settled_at()
+        .expect("settled_at must remain Some");
+    assert_eq!(
+        stored, settle_ts,
+        "settled_at must not change after additional ledger advancement"
+    );
 }
 
 /// `settle()` with maturity = 0 (no time-lock) still records the correct timestamp.

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -1780,11 +1780,6 @@ fn settled_at_recorded_with_maturity() {
         &Address::generate(&env),
         &None,
         &None,
-        &None,
-        &None,
-        &None,
-        &None,
-        &None,
     );
 
     let investor = Address::generate(&env);
@@ -1802,3 +1797,4 @@ fn settled_at_recorded_with_maturity() {
         "settled_at must equal the ledger timestamp when settle() succeeds with maturity gate"
     );
 }
+

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -1,4 +1,4 @@
-//! Settlement and withdrawal tests for the LiquiFact escrow contract.
+﻿//! Settlement and withdrawal tests for the LiquiFact escrow contract.
 //!
 //! Covers the full `withdraw` surface (happy path, wrong-status guards, legal-hold
 //! block, idempotency, event emission, and terminal status assertion) as well as
@@ -1797,4 +1797,3 @@ fn settled_at_recorded_with_maturity() {
         "settled_at must equal the ledger timestamp when settle() succeeds with maturity gate"
     );
 }
-


### PR DESCRIPTION
## Summary

Persists the ledger timestamp of settlement for audit and claim accounting, addressing issue #395.

## Changes

### escrow/src/lib.rs
- `DataKey::SettledAt` — new write-once optional storage key (`u64`)
- `settle()` — writes `env.ledger().timestamp()` to `DataKey::SettledAt` at the status 1→2 transition (set exactly once; never overwritten)
- `get_settled_at(env) -> Option<u64>` — pure read view; returns `None` before settlement or on legacy instances (ADR-007 additive-key policy)

### escrow/src/tests/settlement.rs
5 new tests:
- `settled_at_is_none_before_settle` — `None` before funding and after funding before settle
- `settled_at_recorded_at_settle` — stored value matches ledger timestamp at settle call
- `settled_at_is_stable_after_settle` — value unchanged after further ledger advancement
- `settled_at_recorded_no_maturity_escrow` — timestamp recorded when maturity == 0
- `settled_at_recorded_with_maturity` — timestamp recorded when maturity gate is used

### docs/escrow-data-model.md
- Added `SettledAt` to the optional scalar keys table

### docs/escrow-ledger-time.md
- Added §4 Settlement Timestamp with storage semantics, view function table, use cases, and security notes

## Security Notes
- **Write-once:** `DataKey::SettledAt` is set only during the 1→2 transition; no path to overwrite or delete it
- **Pure read:** `get_settled_at` has no mutation and requires no auth
- **Legacy-safe:** absent key returns `None` — no migration required (ADR-007)
- **Event-pruning-safe:** persists on-chain even after `EscrowSettled` event is pruned

Closes #395