### PR TITLE
feat: Add end-to-end lifecycle tests for the cancel and refund path

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2201,11 +2201,7 @@ impl LiquifactEscrow {
         let n = entries.len();
 
         ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
-        ensure(
-            &env,
-            n <= MAX_FUND_BATCH,
-            EscrowError::FundingBatchTooLarge,
-        );
+        ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
 
         let mut escrow = Self::get_escrow(env.clone());
 

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -777,8 +777,7 @@ fn test_update_funding_target_fails_when_settled() {
 fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
     client.withdraw(); // status → 3 (withdrawn)
     client.update_funding_target(&6_000i128);
 }
@@ -984,8 +983,7 @@ fn test_update_maturity_fails_when_settled() {
 fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
     client.withdraw(); // status → 3
     client.update_maturity(&2000u64);
 }

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -581,10 +581,7 @@ fn test_get_funding_token_before_init_fails_with_typed_error() {
 fn test_get_treasury_before_init_fails_with_typed_error() {
     let env = Env::default();
     let client = deploy(&env);
-    assert_contract_error(
-        client.try_get_treasury(),
-        EscrowError::TreasuryNotSet,
-    );
+    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
 }
 
 #[test]

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -882,6 +882,101 @@ fn setup_withdraw_with_token(
     (client, escrow_id, token, sme)
 }
 
+/// Cancel -> partial refund -> sweep liability-floor lifecycle.
+///
+/// Steps:
+/// 1. Init escrow with a real SAC token and fund by multiple investors (remain Open).
+/// 2. Mint `funded_amount + extra_dust` into the contract to simulate stray tokens.
+/// 3. Admin `cancel_funding` -> status 4 (cancelled).
+/// 4. One investor calls `refund` (distributed_principal increments).
+/// 5. Attempt a sweep larger than the extra dust fails (liability floor enforced).
+/// 6. Sweep up to the extra dust succeeds and transfers to treasury.
+/// 7. Double-refund of same investor panics with `NoContributionToRefund` behavior.
+#[test]
+fn test_cancel_refund_sweep_liability_floor() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let sac = install_stellar_asset_token(&env);
+    use crate::LiquifactEscrow;
+
+    // Deploy escrow instance bound to the SAC token
+    let escrow_id = env.register(LiquifactEscrow, ());
+    let client = LiquifactEscrowClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    // Small target so test numbers are easy to reason about
+    let target = 1_000_000i128;
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "CANREF001"),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &sac.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Two investors fund while escrow remains OPEN (status 0)
+    let inv1 = Address::generate(&env);
+    let inv2 = Address::generate(&env);
+    let a1 = 200_000i128;
+    let a2 = 300_000i128;
+    client.fund(&inv1, &a1);
+    client.fund(&inv2, &a2);
+    let total = a1 + a2;
+    assert_eq!(client.get_escrow().funded_amount, total);
+
+    // Mint funded_amount + extra dust into the escrow contract
+    let extra = 50_000i128;
+    sac.stellar.mint(&escrow_id, &(total + extra));
+
+    // Cancel funding (admin)
+    client.cancel_funding();
+    assert_eq!(client.get_escrow().status, 4u32);
+
+    // Refund inv1: should succeed, mark refunded, and increment DistributedPrincipal
+    client.refund(&inv1);
+    assert!(client.is_investor_refunded(&inv1));
+    assert_eq!(client.get_distributed_principal(), a1);
+
+    // Double-refund for inv1 must panic (no contribution to refund)
+    let dup_refund = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.refund(&inv1);
+    }));
+    assert!(dup_refund.is_err(), "double-refund must panic");
+
+    // Attempt sweep larger than allowed extra must fail (liability floor)
+    let too_large = extra + 1i128;
+    let sweep_fail = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.sweep_terminal_dust(&too_large);
+    }));
+    assert!(
+        sweep_fail.is_err(),
+        "sweep exceeding extra dust must be blocked"
+    );
+
+    // Sweep exactly the extra dust should succeed and transfer to treasury
+    let swept = client.sweep_terminal_dust(&extra);
+    assert_eq!(swept, extra);
+    assert_eq!(sac.token.balance(&treasury), extra);
+
+    // Refund remaining investor to complete distributed principal accounting
+    client.refund(&inv2);
+    assert!(client.is_investor_refunded(&inv2));
+    assert_eq!(client.get_distributed_principal(), total);
+}
+
 /// SME receives exactly `funded_amount` tokens and the escrow contract balance
 /// drops to zero after a successful `withdraw`.
 #[test]
@@ -890,12 +985,14 @@ fn withdraw_transfers_funded_amount_to_sme() {
     env.mock_all_auths();
 
     let target = 50_000_000i128;
-    let (client, escrow_id, token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_BAL001");
+    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
 
     let sme_before = token.balance(&sme);
     let contract_before = token.balance(&escrow_id);
-    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
+    assert_eq!(
+        contract_before, target,
+        "escrow must hold exactly funded_amount before withdraw"
+    );
 
     client.withdraw();
 
@@ -911,7 +1008,11 @@ fn withdraw_transfers_funded_amount_to_sme() {
         contract_after, 0,
         "escrow contract balance must be zero after disbursement"
     );
-    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
+    assert_eq!(
+        client.get_escrow().status,
+        3u32,
+        "status must be 3 after withdraw"
+    );
 }
 
 /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
@@ -921,8 +1022,7 @@ fn withdraw_updates_distributed_principal() {
     env.mock_all_auths();
 
     let target = 20_000_000i128;
-    let (client, _escrow_id, _token, _sme) =
-        setup_withdraw_with_token(&env, target, "WD_DP001");
+    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
 
     client.withdraw();
 
@@ -1058,8 +1158,7 @@ fn withdraw_event_includes_recipient() {
     env.mock_all_auths();
 
     let target = 5_000_000i128;
-    let (client, escrow_id, _token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_EV001");
+    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
 
     client.withdraw();
 
@@ -1074,9 +1173,9 @@ fn withdraw_event_includes_recipient() {
     .to_xdr(&env, &escrow_id);
 
     let all_events = env.events().all().filter_by_contract(&escrow_id);
-    let found = all_events
-        .events()
-        .iter()
-        .any(|e| *e == expected_xdr);
-    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
+    let found = all_events.events().iter().any(|e| *e == expected_xdr);
+    assert!(
+        found,
+        "SmeWithdrew event with correct recipient and amount must be emitted"
+    );
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -45,7 +45,11 @@ fn fund_to_target(client: &super::LiquifactEscrowClient<'_>, env: &Env) -> Addre
 /// actually transfer them.  Returns `(client, sme, sac_admin_client)`.
 fn setup_funded_with_token<'a>(
     env: &'a Env,
-) -> (super::LiquifactEscrowClient<'a>, Address, StellarAssetClient<'a>) {
+) -> (
+    super::LiquifactEscrowClient<'a>,
+    Address,
+    StellarAssetClient<'a>,
+) {
     let sac = env.register_stellar_asset_contract_v2(Address::generate(env));
     let token_id = sac.address();
     let sac_admin = StellarAssetClient::new(env, &token_id);


### PR DESCRIPTION
The implementation is complete  as i added an end-to-end lifecycle test and attempted local validation.

Changed: integration.rs — added test_cancel_refund_sweep_liability_floor() covering fund → cancel → partial refund → sweep lifecycle, double-refund behavior, DistributedPrincipal accumulation, and liability-floor assertions.
What I ran: cargo fmt --all, cargo build, cargo test -p escrow

Closes #327 