### PR TITLE
feat: add get_remaining_funding_capacity read view with tests

### DIFF
--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -56,6 +56,22 @@ Returns the full escrow snapshot. Panics with `"Escrow not initialized"` before 
 
 ---
 
+## `get_remaining_funding_capacity() → i128`
+
+**Storage key:** `DataKey::Escrow`
+
+Returns the remaining funding capacity before the funding target is reached.
+
+- **Calculation**: `funding_target.saturating_sub(funded_amount)` clamped at `0` (via `.max(0)`) so it never goes negative when over-funded.
+- **Informational only**: This view is for frontend guidance. The `fund` method may still accept deposits that over-fund past the target while the escrow status is `0` (Open).
+- **No authorization**: Pure read; no auth or signature required.
+- **Complexity**:
+  - Time Complexity: $O(1)$ read from storage.
+  - Space Complexity: $O(1)$ in-memory calculation.
+- Panics with `"Escrow not initialized"` before `init`.
+
+---
+
 ## `get_version() → u32`
 
 **Storage key:** `DataKey::Version`

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -365,7 +365,7 @@ pub enum EscrowError {
     NoPendingAdmin = 163,
     /// The contract's funding-token balance is less than `funded_amount` at withdraw time.
     /// Funds must be custodied in this contract before the SME can pull them.
-    InsufficientContractBalance = 164,
+    InsufficientContractBalance = 165,
 }
 
 #[inline(always)]
@@ -1322,6 +1322,29 @@ impl LiquifactEscrow {
             .instance()
             .get(&DataKey::Escrow)
             .unwrap_or_else(|| fail(&env, EscrowError::EscrowNotInitialized))
+    }
+
+    /// Returns the remaining funding capacity before the funding target is reached.
+    ///
+    /// The remaining capacity is calculated as `funding_target - funded_amount`.
+    /// If the escrow is over-funded (i.e., `funded_amount > funding_target`), the return value
+    /// is clamped to `0` via `saturating_sub` to ensure it never goes negative.
+    ///
+    /// This view is informational only. The `fund` method may still accept deposits
+    /// that over-fund past the target as long as the escrow status is `0` (Open).
+    ///
+    /// # Errors
+    /// Panics with [`EscrowError::EscrowNotInitialized`] if the escrow has not been initialized.
+    ///
+    /// # Complexity
+    /// - Time Complexity: O(1) read from storage.
+    /// - Space Complexity: O(1) in-memory logic.
+    pub fn get_remaining_funding_capacity(env: Env) -> i128 {
+        let escrow = Self::get_escrow(env);
+        escrow
+            .funding_target
+            .saturating_sub(escrow.funded_amount)
+            .max(0)
     }
 
     /// Rotate the beneficiary (SME) address that receives liquidity on

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2224,11 +2224,7 @@ impl LiquifactEscrow {
         let n = entries.len();
 
         ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
-        ensure(
-            &env,
-            n <= MAX_FUND_BATCH,
-            EscrowError::FundingBatchTooLarge,
-        );
+        ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
 
         let mut escrow = Self::get_escrow(env.clone());
 

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -777,8 +777,7 @@ fn test_update_funding_target_fails_when_settled() {
 fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
     client.withdraw(); // status → 3 (withdrawn)
     client.update_funding_target(&6_000i128);
 }
@@ -984,8 +983,7 @@ fn test_update_maturity_fails_when_settled() {
 fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
     client.withdraw(); // status → 3
     client.update_maturity(&2000u64);
 }

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -3263,3 +3263,70 @@ fn test_fund_batch_preserves_event_semantics() {
     // Each event corresponds to a fund operation
     // (Detailed event field verification depends on EscrowFunded structure)
 }
+
+#[test]
+fn test_remaining_funding_capacity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    // 1. Uninitialized state should panic
+    let uninitialized_client = deploy(&env);
+    let uninitialized_res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        uninitialized_client.get_remaining_funding_capacity();
+    }));
+    assert!(uninitialized_res.is_err(), "uninitialized capacity check should panic");
+
+    // 2. Initialized state (zero funded)
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "CAPTEST"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert_eq!(client.get_remaining_funding_capacity(), TARGET);
+
+    // 3. Partially funded state
+    client.fund(&investor, &(TARGET / 4));
+    assert_eq!(client.get_remaining_funding_capacity(), TARGET - (TARGET / 4));
+
+    // 4. Exactly funded state
+    client.fund(&investor, &(3 * TARGET / 4));
+    assert_eq!(client.get_remaining_funding_capacity(), 0);
+
+    // 5. Overfunded state
+    let overfund_client = deploy(&env);
+    overfund_client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "CAPTEST2"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    overfund_client.fund(&investor, &1_500i128);
+    assert_eq!(overfund_client.get_remaining_funding_capacity(), 0);
+}
+

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -3277,7 +3277,10 @@ fn test_remaining_funding_capacity() {
     let uninitialized_res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         uninitialized_client.get_remaining_funding_capacity();
     }));
-    assert!(uninitialized_res.is_err(), "uninitialized capacity check should panic");
+    assert!(
+        uninitialized_res.is_err(),
+        "uninitialized capacity check should panic"
+    );
 
     // 2. Initialized state (zero funded)
     client.init(
@@ -3301,7 +3304,10 @@ fn test_remaining_funding_capacity() {
 
     // 3. Partially funded state
     client.fund(&investor, &(TARGET / 4));
-    assert_eq!(client.get_remaining_funding_capacity(), TARGET - (TARGET / 4));
+    assert_eq!(
+        client.get_remaining_funding_capacity(),
+        TARGET - (TARGET / 4)
+    );
 
     // 4. Exactly funded state
     client.fund(&investor, &(3 * TARGET / 4));
@@ -3329,4 +3335,3 @@ fn test_remaining_funding_capacity() {
     overfund_client.fund(&investor, &1_500i128);
     assert_eq!(overfund_client.get_remaining_funding_capacity(), 0);
 }
-

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -581,10 +581,7 @@ fn test_get_funding_token_before_init_fails_with_typed_error() {
 fn test_get_treasury_before_init_fails_with_typed_error() {
     let env = Env::default();
     let client = deploy(&env);
-    assert_contract_error(
-        client.try_get_treasury(),
-        EscrowError::TreasuryNotSet,
-    );
+    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
 }
 
 #[test]

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -890,12 +890,14 @@ fn withdraw_transfers_funded_amount_to_sme() {
     env.mock_all_auths();
 
     let target = 50_000_000i128;
-    let (client, escrow_id, token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_BAL001");
+    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
 
     let sme_before = token.balance(&sme);
     let contract_before = token.balance(&escrow_id);
-    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
+    assert_eq!(
+        contract_before, target,
+        "escrow must hold exactly funded_amount before withdraw"
+    );
 
     client.withdraw();
 
@@ -911,7 +913,11 @@ fn withdraw_transfers_funded_amount_to_sme() {
         contract_after, 0,
         "escrow contract balance must be zero after disbursement"
     );
-    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
+    assert_eq!(
+        client.get_escrow().status,
+        3u32,
+        "status must be 3 after withdraw"
+    );
 }
 
 /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
@@ -921,8 +927,7 @@ fn withdraw_updates_distributed_principal() {
     env.mock_all_auths();
 
     let target = 20_000_000i128;
-    let (client, _escrow_id, _token, _sme) =
-        setup_withdraw_with_token(&env, target, "WD_DP001");
+    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
 
     client.withdraw();
 
@@ -1058,8 +1063,7 @@ fn withdraw_event_includes_recipient() {
     env.mock_all_auths();
 
     let target = 5_000_000i128;
-    let (client, escrow_id, _token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_EV001");
+    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
 
     client.withdraw();
 
@@ -1074,9 +1078,9 @@ fn withdraw_event_includes_recipient() {
     .to_xdr(&env, &escrow_id);
 
     let all_events = env.events().all().filter_by_contract(&escrow_id);
-    let found = all_events
-        .events()
-        .iter()
-        .any(|e| *e == expected_xdr);
-    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
+    let found = all_events.events().iter().any(|e| *e == expected_xdr);
+    assert!(
+        found,
+        "SmeWithdrew event with correct recipient and amount must be emitted"
+    );
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -45,7 +45,11 @@ fn fund_to_target(client: &super::LiquifactEscrowClient<'_>, env: &Env) -> Addre
 /// actually transfer them.  Returns `(client, sme, sac_admin_client)`.
 fn setup_funded_with_token<'a>(
     env: &'a Env,
-) -> (super::LiquifactEscrowClient<'a>, Address, StellarAssetClient<'a>) {
+) -> (
+    super::LiquifactEscrowClient<'a>,
+    Address,
+    StellarAssetClient<'a>,
+) {
     let sac = env.register_stellar_asset_contract_v2(Address::generate(env));
     let token_id = sac.address();
     let sac_admin = StellarAssetClient::new(env, &token_id);


### PR DESCRIPTION
Closes #348 

## PR Description
This Pull Request implements the remaining-funding-capacity read view for the open funding window, resolving the issue.
### Problem
Previously, frontend clients that needed to display or check the remaining capacity for an invoice escrow had to read `InvoiceEscrow::funding_target` and `funded_amount` separately from the contract's standard getters. They then had to perform client-side subtraction and handle saturating edge cases manually. This often led to incorrect handling when the escrow was over-funded (i.e. `funded_amount > funding_target`), where client-side calculations could result in invalid negative numbers.
### Solution
This PR adds a pure on-chain read view `get_remaining_funding_capacity(env) -> i128` to provide an authoritative, correct, and single-query source of truth for the remaining headroom. 
- The view retrieves the current `InvoiceEscrow` snapshot from storage and calculates:
  $$\text{remaining\_capacity} = \max(0, \text{funding\_target} - \text{funded\_amount})$$
- We utilize Rust's primitive `i128::saturating_sub` and `.max(0)` to guarantee that the capacity clamps cleanly at zero and never goes negative if the escrow is over-funded.
- The view performs no storage modifications, requires no caller authorization, and is designed with constant $\mathcal{O}(1)$ time and space complexity.
- Rust Doc comments have been added to clarify that this view is purely informational; the escrow contract's `fund` operations may still accept deposits that over-fund past the target as long as the status is `0` (Open).
This PR also includes a fix for a duplicate error discriminant (`164`) in `lib.rs` by remapping `EscrowError::InsufficientContractBalance` to `165`, resolving compile errors.
## Changed
*   **[escrow/src/lib.rs](escrow/src/lib.rs)**:
    *   Implemented `get_remaining_funding_capacity` read-only view.
    *   Changed duplicate discriminant for `EscrowError::InsufficientContractBalance` from `164` to `165` to fix Rust compilation errors.
*   **[escrow/src/tests/funding.rs](escrow/src/tests/funding.rs)** :
    *   Added the `test_remaining_funding_capacity` unit test verifying functionality at:
        *   Uninitialized state (expects panic).
        *   Initialized zero-funded state.
        *   Partially funded state.
        *   Exactly funded state.
        *   Over-funded state (expects `0` capacity).
*   **[docs/escrow-read-api.md](docs/escrow-read-api.md)**:
    *   Added documentation for `get_remaining_funding_capacity` view specifying behaviors, calculation rules, informational limits, and $\mathcal{O}(1)$ complexity metrics.
## Testing
To verify the changes and compile/run the test suites:
*   Run cargo tests for the package:
    ```bash
    cargo test -p liquifact_escrow
    ```
*   Or run the workspace integration tests:
    ```bash
    bash test_compile.sh
    ```