### PR TITLE
Emit event for deprecated transfer_admin shim

### DIFF
--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -33,7 +33,7 @@ short routing symbol passed with `symbol_short!(...)`, such as `funded` or
 
 ## Event Catalog
 
-The current contract defines 19 event structs.
+The current contract defines 20 event structs.
 
 | Rust event | `name` symbol | Entrypoint(s) |
 |---|---:|---|
@@ -44,6 +44,7 @@ The current contract defines 19 event structs.
 | `MaturityUpdatedEvent` | `maturity` | `update_maturity` |
 | `AdminTransferredEvent` | `admin` | `accept_admin` |
 | `AdminProposedEvent` | `adm_prop` | `propose_admin`, `transfer_admin` |
+| `DeprecatedTransferAdminUsed` | `adm_shim` | `transfer_admin` |
 | `BeneficiaryRotated` | `ben_rot` | `rotate_beneficiary` |
 | `FundingTargetUpdated` | `fund_tgt` | `update_funding_target` |
 | `LegalHoldChanged` | `legalhld` | `set_legal_hold`, `clear_legal_hold` |
@@ -184,7 +185,8 @@ Data:
 
 Emitted after successful `propose_admin`. The deprecated `transfer_admin`
 shim delegates to `propose_admin`, so it emits this event rather than
-`AdminTransferredEvent`.
+`AdminTransferredEvent`; shim calls also emit `DeprecatedTransferAdminUsed`
+so operators can identify legacy integrations.
 
 Topics:
 
@@ -200,6 +202,26 @@ Data:
 |---|---|
 | `current_admin` | `Address` |
 | `pending_admin` | `Address` |
+
+### `DeprecatedTransferAdminUsed`
+
+Emitted after a successful call to the deprecated `transfer_admin` shim.
+The handover behavior is still the two-step `propose_admin` flow; this
+additional event is an observability signal for indexers and operators.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `deprecated_transfer_admin_used` |
+| 1 | `name` | `Symbol` | `adm_shim` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `proposed_admin` | `Address` |
 
 ### `BeneficiaryRotated`
 

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -424,6 +424,9 @@ expose that entrypoint, so operators should use redeploy for new WASM.
 - Admin rotation is two-step: `propose_admin` requires the current admin's
   authorization, and `accept_admin` requires the proposed successor's
   authorization. Test both steps on Testnet before executing on Mainnet.
+- Treat any `DeprecatedTransferAdminUsed` (`adm_shim`) event as a migration
+  signal: the caller is still using the deprecated `transfer_admin` shim, which
+  only proposes a pending admin and still requires a separate `accept_admin`.
 
 ### `migrate()` is not a no-op
 

--- a/docs/audit-handoff-escrow.md
+++ b/docs/audit-handoff-escrow.md
@@ -103,6 +103,7 @@ Read-only getters are never blocked. Only `admin` can set or clear the hold. The
 | `set_legal_hold(false)` / `clear_legal_hold` | `LegalHoldChanged` | `legalhld` | Resume operations; notify relevant parties |
 | `update_maturity` | `MaturityUpdatedEvent` | `maturity` | Update off-chain settlement schedule; re-notify investors if material |
 | `propose_admin` | `AdminProposedEvent` | `adm_prop` | Notify proposed successor; keep current admin active until acceptance |
+| `transfer_admin` | `AdminProposedEvent` + `DeprecatedTransferAdminUsed` | `adm_prop` + `adm_shim` | Treat as deprecated shim usage; notify proposed successor and flag caller migration |
 | `accept_admin` | `AdminTransferredEvent` | `admin` | Update key registry and access control records; confirm pending proposal cleared |
 | `update_funding_target` | `FundingTargetUpdated` | `fund_tgt` | Update off-chain target display; re-evaluate investor communications |
 | `record_sme_collateral_commitment` | `CollateralRecordedEvt` | `coll_rec` | Store in compliance/risk system; **do not treat as enforced on-chain lock** |

--- a/docs/escrow-indexer.md
+++ b/docs/escrow-indexer.md
@@ -32,6 +32,8 @@ Contract event names (`symbol_short`) emitted by `escrow/src/lib.rs`:
 - `inv_claim` - investor payout claimed
 - `dust_sw` - treasury dust sweep
 - `legalhld` - legal hold changed
+- `adm_prop` - pending admin proposed
+- `adm_shim` - deprecated `transfer_admin` shim used
 - `admin` - admin transferred
 - `maturity` - maturity updated
 - `fund_tgt` - funding target updated

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -727,6 +727,16 @@ pub struct AdminProposedEvent {
     pub pending_admin: Address,
 }
 
+/// Emitted when the deprecated `transfer_admin` shim is used.
+#[contractevent]
+pub struct DeprecatedTransferAdminUsed {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub proposed_admin: Address,
+}
+
 #[contractevent]
 pub struct FundingTargetUpdated {
     #[topic]
@@ -2886,10 +2896,22 @@ impl LiquifactEscrow {
     /// This function now only proposes `new_admin` by delegating to
     /// [`LiquifactEscrow::propose_admin`]. The proposed address must still call
     /// [`LiquifactEscrow::accept_admin`] before admin authority changes.
+    ///
+    /// Emits [`DeprecatedTransferAdminUsed`] in addition to [`AdminProposedEvent`]
+    /// so indexers can detect integrations that still call the legacy shim.
     #[deprecated(note = "use propose_admin followed by accept_admin")]
     pub fn transfer_admin(env: Env, new_admin: Address) -> InvoiceEscrow {
-        Self::propose_admin(env.clone(), new_admin);
-        Self::get_escrow(env)
+        let proposed_admin = Self::propose_admin(env.clone(), new_admin);
+        let escrow = Self::get_escrow(env.clone());
+
+        DeprecatedTransferAdminUsed {
+            name: symbol_short!("adm_shim"),
+            invoice_id: escrow.invoice_id.clone(),
+            proposed_admin,
+        }
+        .publish(&env);
+
+        escrow
     }
 
     /// Transition an **open** escrow (status 0) to **cancelled** (status 4).

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::{AdminProposedEvent, EscrowCloseSnapshot, FundingTargetUpdated};
+use crate::{
+    AdminProposedEvent, DeprecatedTransferAdminUsed, EscrowCloseSnapshot, FundingTargetUpdated,
+};
 use soroban_sdk::Event;
 
 // Admin/governance operations: target changes, maturity changes, admin handover,
@@ -172,6 +174,43 @@ fn test_transfer_admin_deprecated_shim_only_proposes() {
     let unchanged = client.transfer_admin(&new_admin);
     assert_eq!(unchanged.admin, admin);
     assert_eq!(client.get_pending_admin(), Some(new_admin));
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_transfer_admin_deprecated_shim_emits_proposal_and_deprecation_events() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    let new_admin = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+    let invoice_id = client.get_escrow().invoice_id;
+
+    client.transfer_admin(&new_admin);
+
+    let events = env.events().all().events();
+    assert!(events.len() >= 2);
+    assert_eq!(
+        events[events.len() - 2].clone(),
+        AdminProposedEvent {
+            name: symbol_short!("adm_prop"),
+            invoice_id: invoice_id.clone(),
+            current_admin: admin,
+            pending_admin: new_admin.clone(),
+        }
+        .to_xdr(&env, &contract_id)
+    );
+    assert_eq!(
+        events[events.len() - 1].clone(),
+        DeprecatedTransferAdminUsed {
+            name: symbol_short!("adm_shim"),
+            invoice_id,
+            proposed_admin: new_admin,
+        }
+        .to_xdr(&env, &contract_id)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `DeprecatedTransferAdminUsed` and emit it from the deprecated `transfer_admin` shim
- keep the existing two-step handover behavior by delegating to `propose_admin`
- cover the new event emission in admin tests and update event/operator/indexer docs

Fixes #386

## Testing
- `git diff --check`
- Not run locally: `cargo test -p liquifact_escrow test_transfer_admin_deprecated_shim_emits_proposal_and_deprecation_events -- --nocapture` is blocked on this Windows machine by Application Control preventing Cargo-generated build script/proc-macro executables from running.
