### PR TITLE
Document investor allowlist storage semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ cargo clippy --all-targets -- -D warnings
 | `sweep_terminal_dust` | Treasury sweeps rounding residue from a terminal escrow. |
 | `migrate` | Schema version gate — **typed errors on all paths** in the current release (codes 90–92). |
 | `set_legal_hold` | Admin activates/clears compliance hold. |
+| `set_allowlist_active` | Admin enables or disables the investor funding gate. |
+| `set_investor_allowlisted` | Admin writes one investor allowlist entry. |
+| `set_investors_allowlisted` | Admin writes a bounded batch of investor allowlist entries. |
 | `bind_primary_attestation_hash` | Admin sets a single-write 32-byte digest. |
 | `append_attestation_digest` | Admin appends to bounded audit log. |
 | `record_sme_collateral_commitment` | SME records collateral pledge (metadata only). |
@@ -169,12 +172,20 @@ cargo clippy --all-targets -- -D warnings
 
 ## Storage guardrails
 
-The escrow stores per-investor contribution entries inside the contract
-instance. That map is intentionally bounded.
+The escrow stores scalar state in contract instance storage and per-investor
+accounting or allowlist entries in persistent storage. Each persistent investor
+key has its own TTL, so operators should use `bump_ttl` for long-dated escrows
+that need contribution, claim, or allowlist state to remain live.
 
 - Supported investor cardinality: configured via `max_unique_investors` at
   `init` (optional cap); no hard-coded global max since investor cardinality
   is escrow-specific.
+- Investor allowlist membership: stored as per-address persistent keys. Missing,
+  archived, or explicit `false` entries all read as not allowlisted, but the
+  allowlist is enforced only while `AllowlistActive` is true. See
+  [`docs/escrow-allowlist.md`](docs/escrow-allowlist.md).
+- Allowlist batch mutation: capped at `MAX_INVESTOR_ALLOWLIST_BATCH = 32`; each
+  address is equivalent to one `set_investor_allowlisted` write.
 - Attestation append log: bounded at `MAX_ATTESTATION_APPEND_ENTRIES = 32`.
 - Dust sweep: capped at `MAX_DUST_SWEEP_AMOUNT = 100_000_000` base units per
   call.

--- a/docs/escrow-allowlist.md
+++ b/docs/escrow-allowlist.md
@@ -1,0 +1,119 @@
+# Escrow Investor Allowlist
+
+The investor allowlist is an optional funding gate for an escrow. It lets the
+admin restrict `fund` and `fund_with_commitment` to addresses that have an
+explicit per-address allowlist entry.
+
+The authoritative code paths are in `escrow/src/lib.rs`:
+
+- `set_allowlist_active`
+- `is_allowlist_active`
+- `set_investor_allowlisted`
+- `set_investors_allowlisted`
+- `is_investor_allowlisted`
+- `fund_impl`
+- `bump_ttl`
+
+## Storage Model
+
+The allowlist uses two storage families:
+
+| Key | Storage class | Type | Default when absent |
+|---|---|---|---|
+| `DataKey::AllowlistActive` | instance | `bool` | `false` |
+| `DataKey::InvestorAllowlisted(Address)` | persistent | `bool` | `false` |
+
+`AllowlistActive` is a single contract-wide instance-storage flag. It controls
+whether the funding gate is enforced. Missing or unset instance storage reads as
+inactive, so a newly initialized escrow accepts funders unless the admin enables
+the gate.
+
+`InvestorAllowlisted(Address)` is stored in persistent storage, one key per
+address. Each address has an independent persistent-storage TTL. This keeps the
+instance footprint bounded, but it also means membership entries can be archived
+independently under Soroban rent/archival rules. If an entry is absent or has
+expired/been archived and is not restored, `is_investor_allowlisted` returns
+`false`.
+
+See `docs/escrow-data-model.md` for the complete `DataKey` reference and
+`docs/escrow-gas-storage-notes.md` for storage/rent background.
+
+## Funding Gate Semantics
+
+The gate is checked inside `fund_impl`, which is shared by `fund` and
+`fund_with_commitment`.
+
+| `AllowlistActive` | Investor entry | Funding result |
+|---|---|---|
+| absent or `false` | absent, `false`, or `true` | allowed |
+| `true` | `true` | allowed |
+| `true` | absent or `false` | rejected with `InvestorNotAllowlisted` |
+
+Important implications:
+
+- Disabling the allowlist does not delete membership entries.
+- Re-enabling the allowlist reuses any persistent membership entries that still
+  exist.
+- Removing an investor writes `false` to that investor's persistent entry.
+- A missing persistent entry is not distinguishable from an explicit `false`
+  through the public read API; both are not allowlisted.
+
+## Mutating Membership
+
+`set_investor_allowlisted(env, investor, allowed)` writes exactly one
+`InvestorAllowlisted(investor)` persistent key and emits one
+`InvestorAllowlistChanged` event with `name = al_set`.
+
+`set_investors_allowlisted(env, investors, allowed)` performs the same write and
+event emission for every address in the supplied vector. It requires admin
+authorization once, rejects an empty vector with `InvestorBatchEmpty`, and
+rejects vectors longer than `MAX_INVESTOR_ALLOWLIST_BATCH`.
+
+The current batch bound is:
+
+```rust
+MAX_INVESTOR_ALLOWLIST_BATCH = 32
+```
+
+For every address in the vector, the batch call is equivalent to calling
+`set_investor_allowlisted` individually with the same `allowed` flag:
+
+- the same persistent key is written;
+- the same boolean value is stored;
+- one `InvestorAllowlistChanged` event is emitted per address;
+- the final allowlist membership state is the same.
+
+The contract does not currently de-duplicate addresses inside the batch. If the
+same address appears more than once, the later write wins, and each occurrence
+still emits its event. Callers should prefer de-duplicated batches for clearer
+operator logs.
+
+## TTL And Archival Operations
+
+`bump_ttl(env, allowlisted)` is permissionless and only extends TTLs; it never
+shortens TTL and does not mutate the stored values.
+
+For each address passed in `allowlisted`, `bump_ttl` extends:
+
+- `InvestorAllowlisted(Address)`
+- `InvestorContribution(Address)`
+- `InvestorEffectiveYield(Address)`
+- `InvestorClaimNotBefore(Address)`
+- `InvestorClaimed(Address)`
+
+Operators should include active allowlist members when bumping TTL for
+long-dated escrows. If the allowlist is active and an investor's persistent
+allowlist key is archived or missing, funding by that address will fail until
+the entry is restored or written again by the admin.
+
+## Security Notes
+
+- The allowlist gate is deny-by-default only when `AllowlistActive` is `true`.
+- The inactive state is intentionally permissive so deployments can operate
+  without allowlist administration.
+- Admin authorization protects all allowlist writes and the active/inactive
+  toggle.
+- Persistent membership keys should be treated as part of the escrow's funding
+  policy state, not as transient UI cache.
+- Indexers should track both `AllowlistEnabledChanged` (`al_ena`) and
+  `InvestorAllowlistChanged` (`al_set`) to reconstruct the effective gate.

--- a/docs/escrow-data-model.md
+++ b/docs/escrow-data-model.md
@@ -16,6 +16,8 @@ The contract uses `env.storage().persistent()` for per-address entries:
 `DataKey::InvestorClaimNotBefore(Address)`, `DataKey::InvestorClaimed(Address)`, and
 `DataKey::InvestorAllowlisted(Address)`. These are naturally modeled as independent persistent keys
 with per-address TTLs (see Stellar/Soroban storage guidance on instance vs persistent storage).
+See [`escrow-allowlist.md`](escrow-allowlist.md) for the allowlist-specific funding gate,
+batch mutation, and TTL semantics.
 
 Consequence: the total serialised size of all instance entries must stay within Soroban's
 contract-data entry limit. Per-investor accounting no longer grows the instance footprint; investor
@@ -81,7 +83,9 @@ These entries also live in **persistent** storage (not instance storage).
 
 When `AllowlistActive` is enabled (instance storage flag), `fund_impl` gates `fund` and
 `fund_with_commitment` by asserting `InvestorAllowlisted(investor) == true`. Only the admin may
-mutate allowlist membership.
+mutate allowlist membership. When the flag is absent or `false`, funding remains open even if the
+investor has no allowlist entry. Missing, archived, or explicit `false` persistent entries all read
+as not allowlisted once the gate is active.
 
 ---
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -143,6 +143,10 @@ pub const MAX_ATTESTATION_APPEND_ENTRIES: u32 = 32;
 
 /// Upper bound on batch allowlist mutation entries to keep storage/CPU bounded.
 /// Mirrors the spirit of `MAX_ATTESTATION_APPEND_ENTRIES` to limit per-call work.
+///
+/// Each batch element performs one persistent `InvestorAllowlisted(Address)` write
+/// and emits one `InvestorAllowlistChanged` event, matching repeated single-address
+/// allowlist mutations.
 pub const MAX_INVESTOR_ALLOWLIST_BATCH: u32 = 32;
 
 /// Upper bound on [`LiquifactEscrow::fund_batch`] entries to keep storage/CPU bounded.
@@ -1882,8 +1886,12 @@ impl LiquifactEscrow {
         .publish(&env);
     }
 
-    /// Enable or disable the investor allowlist. When enabled, only addresses with
-    /// [`DataKey::InvestorAllowlisted`] set to true may fund the escrow.
+    /// Enable or disable the investor allowlist.
+    ///
+    /// The flag lives in instance storage and defaults to `false` when absent. When
+    /// active, [`LiquifactEscrow::fund`] and [`LiquifactEscrow::fund_with_commitment`]
+    /// require the caller's persistent [`DataKey::InvestorAllowlisted`] entry to be
+    /// `true`. Disabling the flag does not delete persistent membership entries.
     pub fn set_allowlist_active(env: Env, active: bool) {
         let escrow = Self::load_escrow_require_admin(&env);
         env.storage()
@@ -1897,6 +1905,10 @@ impl LiquifactEscrow {
         .publish(&env);
     }
 
+    /// Return whether the investor allowlist funding gate is active.
+    ///
+    /// Missing instance storage reads as `false`, so newly initialized escrows are
+    /// permissive until the admin enables the gate.
     pub fn is_allowlist_active(env: Env) -> bool {
         env.storage()
             .instance()
@@ -1904,7 +1916,12 @@ impl LiquifactEscrow {
             .unwrap_or(false)
     }
 
-    /// Add or remove an investor from the allowlist.
+    /// Add or remove one investor from the allowlist.
+    ///
+    /// Membership is a per-address persistent-storage entry. Missing, archived, or
+    /// explicit `false` entries all make [`LiquifactEscrow::is_investor_allowlisted`]
+    /// return `false`. Operators should include active allowlist members when calling
+    /// [`LiquifactEscrow::bump_ttl`] for long-dated escrows.
     pub fn set_investor_allowlisted(env: Env, investor: Address, allowed: bool) {
         let escrow = Self::load_escrow_require_admin(&env);
         env.storage()
@@ -1928,6 +1945,8 @@ impl LiquifactEscrow {
     ///
     /// Invariant: the end state and emitted events are identical to calling
     /// `set_investor_allowlisted` individually for each element in `investors`.
+    /// Duplicate addresses are not de-duplicated; each occurrence emits an event and
+    /// the last write determines the final stored value.
     ///
     /// # Errors
     /// Emits typed [`EscrowError`] codes when the escrow is uninitialized, the batch is empty, or
@@ -1960,6 +1979,10 @@ impl LiquifactEscrow {
         }
     }
 
+    /// Return whether one investor currently has an allowlist membership entry.
+    ///
+    /// The public read API intentionally treats missing, archived, and explicit `false`
+    /// entries the same: all return `false`.
     pub fn is_investor_allowlisted(env: Env, investor: Address) -> bool {
         env.storage()
             .persistent()
@@ -2768,6 +2791,12 @@ impl LiquifactEscrow {
         escrow
     }
 
+    /// Extend instance and per-investor persistent TTLs without mutating values.
+    ///
+    /// Pass active allowlist members in `allowlisted` to keep their persistent
+    /// membership entries live for long-dated escrows. This entrypoint is
+    /// permissionless and only extends TTL; it never shortens TTL or writes policy
+    /// state.
     pub fn bump_ttl(env: Env, allowlisted: Vec<Address>) {
         // Permissionless TTL extension.
         //

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -419,6 +419,61 @@ fn test_batch_add_and_remove_from_allowlist() {
 }
 
 #[test]
+fn test_batch_allowlist_matches_single_writes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let batch_client = deploy(&env);
+    let single_client = deploy(&env);
+    init(&env, &batch_client);
+    init(&env, &single_client);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let mut investors: SorobanVec<Address> = SorobanVec::new(&env);
+    investors.push_back(a.clone());
+    investors.push_back(b.clone());
+    investors.push_back(c.clone());
+
+    batch_client.set_investors_allowlisted(&investors, &true);
+    single_client.set_investor_allowlisted(&a, &true);
+    single_client.set_investor_allowlisted(&b, &true);
+    single_client.set_investor_allowlisted(&c, &true);
+
+    assert_eq!(
+        batch_client.is_investor_allowlisted(&a),
+        single_client.is_investor_allowlisted(&a)
+    );
+    assert_eq!(
+        batch_client.is_investor_allowlisted(&b),
+        single_client.is_investor_allowlisted(&b)
+    );
+    assert_eq!(
+        batch_client.is_investor_allowlisted(&c),
+        single_client.is_investor_allowlisted(&c)
+    );
+
+    batch_client.set_investors_allowlisted(&investors, &false);
+    single_client.set_investor_allowlisted(&a, &false);
+    single_client.set_investor_allowlisted(&b, &false);
+    single_client.set_investor_allowlisted(&c, &false);
+
+    assert_eq!(
+        batch_client.is_investor_allowlisted(&a),
+        single_client.is_investor_allowlisted(&a)
+    );
+    assert_eq!(
+        batch_client.is_investor_allowlisted(&b),
+        single_client.is_investor_allowlisted(&b)
+    );
+    assert_eq!(
+        batch_client.is_investor_allowlisted(&c),
+        single_client.is_investor_allowlisted(&c)
+    );
+}
+
+#[test]
 #[should_panic]
 fn test_batch_rejects_empty_vector() {
     let env = Env::default();


### PR DESCRIPTION
## Summary
- add a dedicated investor allowlist document covering active/inactive gate behavior, persistent per-address storage, TTL/archival, and batch semantics
- cross-link the allowlist model from the README and escrow data model
- clarify allowlist rustdocs and add a batch-vs-single write equivalence test

Fixes #415

## Testing
- `git diff --cached --check`
- `rustfmt --check escrow/src/test_allowlist_tests.rs`
- Attempted: `cargo fmt --check` (the current tree reports pre-existing formatting diffs outside this PR, including `escrow/src/tests/admin.rs`, `escrow/src/tests/integration.rs`, and `escrow/src/tests/settlement.rs`)
- Attempted: `cargo test -p liquifact_escrow test_batch_allowlist_matches_single_writes -- --exact` (blocked before this test can run by existing compile errors outside this change, including duplicate `EscrowError` discriminant 164, missing `is_settleable` client methods in coverage tests, outdated `init` argument counts in property tests, and missing event testutils imports)

## Security notes
- Documents that the allowlist is deny-by-default only while active; inactive escrows remain permissive.
- Documents persistent allowlist TTL/archival behavior and `bump_ttl` requirements for long-dated escrows.
