### PR TITLE
feat: add admin unrevoke_attestation_digest entrypoint

### DIFF
--- a/docs/escrow-attestations.md
+++ b/docs/escrow-attestations.md
@@ -77,6 +77,30 @@ be flagged as superseded while the full history stays on-chain.
 **Panics** if `index >= log.len()` (out of range) or if the index has already been revoked
 (double-revocation guard).
 
+### `unrevoke_attestation_digest(index: u32)`
+
+| Property | Value |
+|---|---|
+| Auth | `InvoiceEscrow::admin` |
+| Write policy | Clears `DataKey::AttestationRevoked(index)` — errors if not currently revoked |
+| Storage key | `DataKey::AttestationRevoked(u32)` (removed) |
+| Event | `AttestationDigestUnrevoked { invoice_id, index }` |
+| Typed errors | `AttestationIndexOutOfRange` (52), `AttestationNotRevoked` (53) |
+
+Clears the revocation marker set by `revoke_attestation_digest`. Use this to correct a
+fat-finger revocation before indexers process the erroneous tombstone.
+
+**Guard ordering (ADR-002):** range check → revocation-state check → `require_auth` →
+storage mutation. This means range and state errors are surfaced even to unauthenticated
+callers, consistent with the existing revoke path.
+
+The append log entry and its digest are unaffected. After a successful unrevoke,
+`is_attestation_revoked(index)` returns `false` and the entry is once again treated as
+active by indexers.
+
+**Errors** with `AttestationIndexOutOfRange` (52) if `index >= log.len()`, or
+`AttestationNotRevoked` (53) if the index is not currently revoked.
+
 ---
 
 ## KYC/KYB operational flows
@@ -229,6 +253,34 @@ Off-chain                              On-chain
 The original digest at index N remains in the append log for auditability. Indexers
 consume `AttestationDigestRevoked` events to compute the effective (non-revoked) chain.
 
+### Flow 6 — Correcting an erroneous revocation (unrevoke)
+
+If an admin fat-fingered the index on a `revoke_attestation_digest` call and revoked the
+wrong entry, `unrevoke_attestation_digest` clears the marker before indexers propagate the
+tombstone:
+
+```
+Off-chain                              On-chain
+─────────────────────────────────────────────────────────────────────
+1. Admin realises index N was revoked
+   by mistake (correct target was M).
+                                       2. Admin calls:
+                                          unrevoke_attestation_digest(N)
+                                          → AttestationDigestUnrevoked { index: N }
+
+                                       3. Admin calls (if still needed):
+                                          revoke_attestation_digest(M)
+                                          → AttestationDigestRevoked { index: M }
+
+4. Indexer sees AttestationDigestUnrevoked
+   for index N and removes the
+   superseded label. Entry N is active
+   again; entry M is now the tombstone.
+```
+
+The append log is never mutated. The unrevoke only removes the `DataKey::AttestationRevoked(N)`
+storage key; the digest at index N is unchanged.
+
 ## Security notes
 
 - **Admin key custody:** both entrypoints require `InvoiceEscrow::admin` auth. Production
@@ -255,10 +307,19 @@ consume `AttestationDigestRevoked` events to compute the effective (non-revoked)
 
 - **Double-revocation guard:** each index may be revoked at most once. A second call for the
   same index panics with `"attestation already revoked at index"`. Off-chain indexers can
-  safely assume that once `AttestationDigestRevoked` is observed, it is final.
+  safely assume that once `AttestationDigestRevoked` is observed, it is final unless an
+  `AttestationDigestUnrevoked` event follows.
 
 - **Out-of-range rejection:** revoking a non-existent index panics with `"attestation index
   out of range"`. The admin must read `get_attestation_append_log` to determine valid indices.
+
+- **Unrevoke is admin-only:** `unrevoke_attestation_digest` is gated by `require_auth` on
+  `InvoiceEscrow::admin`. ADR-002 guard ordering is preserved: range and state checks run
+  before auth so typed errors (`AttestationIndexOutOfRange` = 52, `AttestationNotRevoked` = 53)
+  are surfaced cleanly.
+
+- **Unrevoke is idempotent in round-trips:** revoke → unrevoke → revoke is valid. Each
+  transition is guarded, so double-unrevoke is rejected with `AttestationNotRevoked`.
 
 - **Token economics:** attestation entrypoints do not interact with token balances, funding
   state, or settlement flows. They are metadata-only. See
@@ -300,3 +361,11 @@ Attestation behavior is covered in [`escrow/src/test/attestations.rs`](../escrow
 | `test_revoke_non_admin_panics` | Non-admin revoke is rejected |
 | `test_revoke_preserves_log_entry` | Append log contents unchanged after revocation |
 | `test_revoke_does_not_affect_primary_hash` | Revocation leaves primary hash intact |
+| `test_unrevoke_restores_state` | Revoke then unrevoke: `is_attestation_revoked` returns `false` |
+| `test_unrevoke_preserves_log_entry` | Append log entry unchanged after unrevoke |
+| `test_unrevoke_not_revoked_panics` | Unrevoke of non-revoked index is rejected |
+| `test_unrevoke_out_of_range_panics` | Unrevoke on empty log is rejected |
+| `test_double_unrevoke_panics` | Second unrevoke rejected after first succeeds |
+| `test_unrevoke_non_admin_panics` | Non-admin unrevoke is rejected |
+| `test_revoke_unrevoke_revoke_round_trip` | Round-trip revoke → unrevoke → revoke succeeds |
+| `test_unrevoke_does_not_affect_other_indices` | Unrevoke of index 0 leaves index 1 revoked |

--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -28,7 +28,7 @@ Codes are grouped by domain so SDKs can map coarse categories without parsing va
 | Init / pricing | 1–13 | Initialization, invoice id, yield tiers, optional caps | 1, 13 |
 | Uninitialized metadata | 20–22 | Escrow or required addresses not configured | 20, 22 |
 | Dust sweep + SEP-41 safety | 30–42 | Terminal dust sweep and token transfer invariants | 30, 42 |
-| Attestation | 50–51 | Primary hash binding and append-only digest log | 50, 51 |
+| Attestation | 50–53 | Primary hash binding, append-only digest log, revocation and unrevocation | 50, 53 |
 | SME collateral | 60–62 | Off-chain collateral metadata record | 60, 62 |
 | Admin validation | 70–80 | Allowlist batch, funding target, investor cap, maturity, admin handover | 70, 80 |
 | Schema migration | 90–92 | `migrate` version checks | 90, 92 |
@@ -79,6 +79,8 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 42 | `SweepExceedsLiabilityFloor` | `sweep_terminal_dust` | `balance - sweep_amt < funded_amount - distributed_principal` | Reduce sweep; wait until liabilities refunded | typed |
 | 50 | `PrimaryAttestationAlreadyBound` | `bind_primary_attestation_hash` | primary hash already stored | Use `append_attestation_digest` for updates | typed |
 | 51 | `AttestationAppendLogCapacityReached` | `append_attestation_digest` | log length `>= MAX_ATTESTATION_APPEND_ENTRIES` | Archive off-chain; log is bounded | typed |
+| 52 | `AttestationIndexOutOfRange` | `revoke_attestation_digest`, `unrevoke_attestation_digest` | `index >= log.len()` | Read `get_attestation_append_log` for valid indices | typed |
+| 53 | `AttestationNotRevoked` | `unrevoke_attestation_digest` | index not currently revoked | Only call unrevoke on a revoked index | typed |
 | 60 | `CollateralAmountNotPositive` | `record_sme_collateral_commitment` | `amount <= 0` | Provide positive metadata amount | typed |
 | 61 | `CollateralAssetEmpty` | `record_sme_collateral_commitment` | asset symbol empty | Provide non-empty asset label | typed |
 | 62 | `CollateralTimestampBackwards` | `record_sme_collateral_commitment` | new timestamp `<` stored timestamp | Use monotonic timestamps | typed |
@@ -234,7 +236,7 @@ Recommended SDK category mappings:
 | 1–13 | Invalid initialization or pricing configuration |
 | 20–22 | Missing initialized escrow metadata |
 | 30–42 | Dust sweep or token integration failure |
-| 50–51 | Attestation failure |
+| 50–53 | Attestation failure |
 | 60–62 | Collateral metadata failure |
 | 70–80, 82–83 | Administrative validation or batch-funding bounds failure |
 | 90–92 | Migration failure |

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -245,6 +245,11 @@ pub enum EscrowError {
     PrimaryAttestationAlreadyBound = 50,
     /// [`LiquifactEscrow::append_attestation_digest`] exceeded [`MAX_ATTESTATION_APPEND_ENTRIES`].
     AttestationAppendLogCapacityReached = 51,
+    /// [`LiquifactEscrow::revoke_attestation_digest`] / [`LiquifactEscrow::unrevoke_attestation_digest`]
+    /// received an `index` that is out of bounds for the current append log.
+    AttestationIndexOutOfRange = 52,
+    /// [`LiquifactEscrow::unrevoke_attestation_digest`] called on an index that is not currently revoked.
+    AttestationNotRevoked = 53,
 
     /// [`LiquifactEscrow::record_sme_collateral_commitment`] received a non-positive amount.
     CollateralAmountNotPositive = 60,
@@ -849,6 +854,20 @@ pub struct AttestationDigestAppended {
 
 #[contractevent]
 pub struct AttestationDigestRevoked {
+    #[topic]
+    pub name: Symbol,
+    pub invoice_id: Symbol,
+    pub index: u32,
+}
+
+/// Emitted by [`LiquifactEscrow::unrevoke_attestation_digest`] when the revocation marker
+/// for a previously revoked append-log entry is cleared by admin.
+///
+/// # Fields
+/// - `invoice_id` — escrow identifier from [`InvoiceEscrow`].
+/// - `index` — 0-based position in the append log whose revocation was cleared.
+#[contractevent]
+pub struct AttestationDigestUnrevoked {
     #[topic]
     pub name: Symbol,
     pub invoice_id: Symbol,
@@ -1725,6 +1744,50 @@ impl LiquifactEscrow {
             .instance()
             .get(&DataKey::AttestationRevoked(index))
             .unwrap_or(false)
+    }
+
+    /// Clears the revocation marker for a previously revoked append-log entry.
+    ///
+    /// Use this to correct a mistaken revocation (fat-finger on a 0-based index)
+    /// without polluting the audit chain permanently.
+    ///
+    /// # Authorization
+    /// Requires `InvoiceEscrow::admin` auth.
+    ///
+    /// # Guard ordering (ADR-002)
+    /// Range check → revocation-state check → `require_auth` → storage mutation.
+    ///
+    /// # Errors
+    /// - [`EscrowError::AttestationIndexOutOfRange`] if `index >= log.len()`.
+    /// - [`EscrowError::AttestationNotRevoked`] if the index is not currently revoked.
+    pub fn unrevoke_attestation_digest(env: Env, index: u32) {
+        let log: Vec<BytesN<32>> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AttestationAppendLog)
+            .unwrap_or_else(|| Vec::new(&env));
+        ensure(&env, index < log.len(), EscrowError::AttestationIndexOutOfRange);
+        ensure(
+            &env,
+            env.storage()
+                .instance()
+                .has(&DataKey::AttestationRevoked(index)),
+            EscrowError::AttestationNotRevoked,
+        );
+
+        let escrow = Self::get_escrow(env.clone());
+        escrow.admin.require_auth();
+
+        env.storage()
+            .instance()
+            .remove(&DataKey::AttestationRevoked(index));
+
+        AttestationDigestUnrevoked {
+            name: symbol_short!("att_unrev"),
+            invoice_id: escrow.invoice_id.clone(),
+            index,
+        }
+        .publish(&env);
     }
 
     pub fn is_investor_claimed(env: Env, investor: Address) -> bool {

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -326,3 +326,105 @@ fn test_revoke_does_not_affect_primary_hash() {
     client.revoke_attestation_digest(&0);
     assert_eq!(client.get_primary_attestation_hash(), Some(primary));
 }
+
+// ---------------------------------------------------------------------------
+// unrevoke_attestation_digest — restoring a mistaken revocation
+// ---------------------------------------------------------------------------
+
+/// Happy path: revoke then unrevoke restores the non-revoked state.
+#[test]
+fn test_unrevoke_restores_state() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0xAA));
+    client.revoke_attestation_digest(&0);
+    assert!(client.is_attestation_revoked(&0));
+    client.unrevoke_attestation_digest(&0);
+    assert!(!client.is_attestation_revoked(&0));
+}
+
+/// After unrevoke, the append log entry is still present and unchanged.
+#[test]
+fn test_unrevoke_preserves_log_entry() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let d = digest(&env, 0xBB);
+    client.append_attestation_digest(&d);
+    client.revoke_attestation_digest(&0);
+    client.unrevoke_attestation_digest(&0);
+    let log = client.get_attestation_append_log();
+    assert_eq!(log.len(), 1);
+    assert_eq!(log.get(0).unwrap(), d);
+}
+
+/// Unrevoke of a non-revoked index must panic with AttestationNotRevoked.
+#[test]
+#[should_panic]
+fn test_unrevoke_not_revoked_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    // Index 0 exists but is NOT revoked — must panic.
+    client.unrevoke_attestation_digest(&0);
+}
+
+/// Unrevoke on an out-of-range index must panic with AttestationIndexOutOfRange.
+#[test]
+#[should_panic]
+fn test_unrevoke_out_of_range_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    // Empty log: index 0 is out of range.
+    client.unrevoke_attestation_digest(&0);
+}
+
+/// Double unrevoke: after the first unrevoke the index is no longer revoked,
+/// so a second unrevoke must panic (AttestationNotRevoked).
+#[test]
+#[should_panic]
+fn test_double_unrevoke_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x42));
+    client.revoke_attestation_digest(&0);
+    client.unrevoke_attestation_digest(&0);
+    client.unrevoke_attestation_digest(&0);
+}
+
+/// Non-admin caller must not be able to unrevoke.
+#[test]
+#[should_panic]
+fn test_unrevoke_non_admin_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0xFF));
+    client.revoke_attestation_digest(&0);
+    env.mock_auths(&[]);
+    client.unrevoke_attestation_digest(&0);
+}
+
+/// Revoke → unrevoke → revoke again is allowed (round-trip idempotency).
+#[test]
+fn test_revoke_unrevoke_revoke_round_trip() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x10));
+    client.revoke_attestation_digest(&0);
+    client.unrevoke_attestation_digest(&0);
+    client.revoke_attestation_digest(&0);
+    assert!(client.is_attestation_revoked(&0));
+}
+
+/// Unrevoke only affects the targeted index; adjacent indices are untouched.
+#[test]
+fn test_unrevoke_does_not_affect_other_indices() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    client.append_attestation_digest(&digest(&env, 0x02));
+    client.revoke_attestation_digest(&0);
+    client.revoke_attestation_digest(&1);
+    client.unrevoke_attestation_digest(&0);
+    assert!(!client.is_attestation_revoked(&0));
+    assert!(client.is_attestation_revoked(&1));
+}


### PR DESCRIPTION
## Summary

Implements `unrevoke_attestation_digest(env, index: u32)` to clear a mistaken attestation revocation, as specified in #382.

## Changes

### `escrow/src/lib.rs`
- **`EscrowError::AttestationIndexOutOfRange` (52):** typed error for out-of-range index on both revoke and unrevoke paths.
- **`EscrowError::AttestationNotRevoked` (53):** typed error emitted when `unrevoke_attestation_digest` is called on an index that is not currently revoked.
- **`AttestationDigestUnrevoked` contractevent:** carries `invoice_id` and `index`, emitted on successful unrevoke.
- **`unrevoke_attestation_digest(env, index)`:** admin-gated entrypoint following ADR-002 guard ordering — range check → state check → `require_auth` → `storage.remove` → event publish.

### `escrow/src/tests/attestations.rs`
8 new tests:
| Test | Coverage |
|---|---|
| `test_unrevoke_restores_state` | Happy path: revoke then unrevoke clears revocation |
| `test_unrevoke_preserves_log_entry` | Append log digest unchanged after unrevoke |
| `test_unrevoke_not_revoked_panics` | Rejects unrevoke of non-revoked index |
| `test_unrevoke_out_of_range_panics` | Rejects out-of-range index |
| `test_double_unrevoke_panics` | Rejects second unrevoke after first succeeds |
| `test_unrevoke_non_admin_panics` | Non-admin auth rejected |
| `test_revoke_unrevoke_revoke_round_trip` | Full round-trip succeeds |
| `test_unrevoke_does_not_affect_other_indices` | Adjacent indices isolated |

### Docs
- `docs/escrow-attestations.md`: new entrypoint table row, Flow 6 (erroneous revocation correction), updated security notes and test coverage table.
- `docs/escrow-error-messages.md`: attestation range updated to 50–53, codes 52/53 added to canonical table and client category mapping.

## Security notes

- **Admin-only:** `require_auth` on `InvoiceEscrow::admin` is required after range/state checks.
- **ADR-002 ordering preserved:** range and state checks run before auth, consistent with the existing revoke path, so typed errors surface cleanly.
- **No log mutation:** `unrevoke_attestation_digest` only removes `DataKey::AttestationRevoked(index)`; the append log entry and digest are untouched.
- **Idempotency guarded:** double-unrevoke emits `AttestationNotRevoked` (53); revoke→unrevoke→revoke round-trips work correctly.
- **Bounded index:** out-of-range index emits `AttestationIndexOutOfRange` (52) before any auth or storage access.

## Testing

Cargo is unavailable in this Codespace environment. The full CI suite (`cargo fmt --all -- --check`, `cargo clippy -p liquifact_escrow -- -D warnings`, `cargo build`, `cargo test`, `cargo llvm-cov`) must be run by CI on this branch before merge.

Closes #382