### PR TITLE
Add settlement pool read view

### DIFF
--- a/docs/escrow-pro-rata.md
+++ b/docs/escrow-pro-rata.md
@@ -83,3 +83,25 @@ formula to guarantee identical rounding.
 
 See `docs/escrow-read-api.md` → `compute_investor_payout` for the full parameter, return-value,
 and authorization documentation.
+
+## On-Chain Aggregate View: `get_settlement_pool`
+
+The contract also exposes the aggregate base-yield repayment pool:
+
+```
+LiquifactEscrow::get_settlement_pool() -> i128
+```
+
+This view returns `0` until `DataKey::FundingCloseSnapshot` exists. After funding closes, it returns:
+
+```text
+coupon          = total_principal * escrow.yield_bps / 10_000  (floor)
+settlement_pool = total_principal + coupon
+```
+
+`get_settlement_pool` uses the escrow base `yield_bps` only. It is the SME-facing aggregate amount
+owed at settlement and is not the sum of investor-specific tiered payouts. Tier-specific effective
+yields remain investor-level accounting and are reflected by `compute_investor_payout(investor)`.
+
+The view uses the same floor rounding and checked arithmetic guard as the payout formula, raising
+`EscrowError::ComputePayoutArithmeticOverflow` on overflow instead of returning a divergent value.

--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -132,6 +132,29 @@ Returns the pro-rata denominator snapshot captured when the escrow first became 
 
 ---
 
+## `get_settlement_pool() -> i128`
+
+**Storage keys:** `DataKey::FundingCloseSnapshot`, `DataKey::Escrow`
+
+Returns the aggregate repayment pool the SME owes at settlement, using the escrow base yield:
+
+```text
+coupon          = total_principal * escrow.yield_bps / 10_000  (floor)
+settlement_pool = total_principal + coupon
+```
+
+Returns `0` until `DataKey::FundingCloseSnapshot` exists. Once the snapshot is present, the
+view uses the snapshot `total_principal` and the base `InvoiceEscrow::yield_bps`. It does not
+apply investor-specific tier yields; tier-specific effective yields are per-investor accounting
+and remain exposed through `compute_investor_payout(investor)`.
+
+- **Pure Read** - no authorization required and no state writes.
+- **Rounding** - matches the on-chain payout formula by flooring integer division.
+- **Overflow safety** - uses checked arithmetic and raises
+  `EscrowError::ComputePayoutArithmeticOverflow` on overflow.
+
+---
+
 ## `get_investor_yield_bps(investor: Address) → i64`
 
 **Storage key:** `DataKey::InvestorEffectiveYield(investor)`

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1668,6 +1668,47 @@ impl LiquifactEscrow {
         env.storage().instance().get(&DataKey::FundingCloseSnapshot)
     }
 
+    /// Aggregate settlement pool owed by the SME at the escrow base yield.
+    ///
+    /// Returns `0` until [`DataKey::FundingCloseSnapshot`] exists. Once funding has
+    /// closed, this returns:
+    ///
+    /// ```text
+    /// coupon          = total_principal * escrow.yield_bps / 10_000  (floor)
+    /// settlement_pool = total_principal + coupon
+    /// ```
+    ///
+    /// This view intentionally uses [`InvoiceEscrow::yield_bps`], not per-investor
+    /// tier yields. Tier-specific effective yields are investor-level accounting and
+    /// remain exposed through [`LiquifactEscrow::compute_investor_payout`].
+    ///
+    /// # Overflow safety
+    ///
+    /// Uses the same checked arithmetic and
+    /// [`EscrowError::ComputePayoutArithmeticOverflow`] guard as
+    /// [`LiquifactEscrow::compute_investor_payout`].
+    ///
+    /// # Authorization
+    ///
+    /// None - pure read; no auth required.
+    pub fn get_settlement_pool(env: Env) -> i128 {
+        let Some(snap) = env
+            .storage()
+            .instance()
+            .get::<DataKey, FundingCloseSnapshot>(&DataKey::FundingCloseSnapshot)
+        else {
+            return 0;
+        };
+
+        let total_principal = snap.total_principal;
+        if total_principal <= 0 {
+            return 0;
+        }
+
+        let escrow = Self::get_escrow(env.clone());
+        Self::settlement_pool_for_yield(&env, total_principal, escrow.yield_bps)
+    }
+
     /// Effective yield (bps) for this investor after their **first** deposit; later [`LiquifactEscrow::fund`]
     /// calls add principal at this rate. Defaults to [`InvoiceEscrow::yield_bps`] when unset (legacy positions).
     ///
@@ -2729,15 +2770,8 @@ impl LiquifactEscrow {
                 .unwrap_or(escrow.yield_bps);
 
         // coupon = total_principal × effective_yield_bps / 10_000  (floor)
-        let coupon = total_principal
-            .checked_mul(effective_yield_bps as i128)
-            .unwrap_or_else(|| fail(&env, EscrowError::ComputePayoutArithmeticOverflow))
-            .checked_div(10_000)
-            .unwrap_or_else(|| fail(&env, EscrowError::ComputePayoutArithmeticOverflow));
-
-        let settle_pool = total_principal
-            .checked_add(coupon)
-            .unwrap_or_else(|| fail(&env, EscrowError::ComputePayoutArithmeticOverflow));
+        let settle_pool =
+            Self::settlement_pool_for_yield(&env, total_principal, effective_yield_bps);
 
         // gross_payout = contribution × settle_pool / total_principal  (floor)
         contribution
@@ -2745,6 +2779,22 @@ impl LiquifactEscrow {
             .unwrap_or_else(|| fail(&env, EscrowError::ComputePayoutArithmeticOverflow))
             .checked_div(total_principal)
             .unwrap_or_else(|| fail(&env, EscrowError::ComputePayoutArithmeticOverflow))
+    }
+
+    fn settlement_pool_for_yield(env: &Env, total_principal: i128, yield_bps: i64) -> i128 {
+        if total_principal <= 0 {
+            return 0;
+        }
+
+        let coupon = total_principal
+            .checked_mul(yield_bps as i128)
+            .unwrap_or_else(|| fail(env, EscrowError::ComputePayoutArithmeticOverflow))
+            .checked_div(10_000)
+            .unwrap_or_else(|| fail(env, EscrowError::ComputePayoutArithmeticOverflow));
+
+        total_principal
+            .checked_add(coupon)
+            .unwrap_or_else(|| fail(env, EscrowError::ComputePayoutArithmeticOverflow))
     }
 
     pub fn update_maturity(env: Env, new_maturity: u64) -> InvoiceEscrow {

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -2,7 +2,10 @@ use super::{
     free_addresses, install_stellar_asset_token, setup, MAX_ATTESTATION_APPEND_ENTRIES,
     SCHEMA_VERSION,
 };
-use crate::{CollateralCommitmentSnapshot, DataKey, EscrowCloseSnapshot, EscrowError, YieldTier};
+use crate::{
+    CollateralCommitmentSnapshot, DataKey, EscrowCloseSnapshot, EscrowError, FundingCloseSnapshot,
+    YieldTier,
+};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     Address, BytesN, Env, Error, InvokeError, Vec as SorobanVec,
@@ -2416,6 +2419,205 @@ fn test_record_sme_collateral_commitment_semantics() {
 // ──────────────────────────────────────────────────────────────────────────────
 // `is_settleable` view — readiness across status/maturity/hold combinations
 // ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn get_settlement_pool_returns_zero_before_funding_snapshot() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "POOLZERO"),
+        &sme,
+        &10_000,
+        &500,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    assert_eq!(client.get_settlement_pool(), 0);
+}
+
+#[test]
+fn get_settlement_pool_returns_principal_plus_floor_base_coupon() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+    let investor = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "POOLBASE"),
+        &sme,
+        &10_001,
+        &333,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &10_001);
+
+    assert_eq!(client.get_settlement_pool(), 10_334);
+}
+
+#[test]
+fn get_settlement_pool_uses_base_yield_not_investor_tier_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+    let investor = Address::generate(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 1_000,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "POOLTYR"),
+        &sme,
+        &10_000,
+        &500,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund_with_commitment(&investor, &10_000, &100);
+
+    assert_eq!(client.get_investor_yield_bps(&investor), 1_000);
+    assert_eq!(client.compute_investor_payout(&investor), 11_000);
+    assert_eq!(client.get_settlement_pool(), 10_500);
+}
+
+#[test]
+fn get_settlement_pool_allows_zero_base_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+    let investor = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "POOLZBPS"),
+        &sme,
+        &10_000,
+        &0,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &10_000);
+
+    assert_eq!(client.get_settlement_pool(), 10_000);
+}
+
+#[test]
+fn get_settlement_pool_allows_max_base_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+    let investor = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "POOLMAX"),
+        &sme,
+        &10_000,
+        &10_000,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client.fund(&investor, &10_000);
+
+    assert_eq!(client.get_settlement_pool(), 20_000);
+}
+
+#[test]
+fn get_settlement_pool_overflow_uses_compute_payout_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "POOLOVF"),
+        &sme,
+        &1,
+        &10_000,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &DataKey::FundingCloseSnapshot,
+            &FundingCloseSnapshot {
+                total_principal: i128::MAX / 2 + 1,
+                funding_target: 1,
+                closed_at_ledger_timestamp: env.ledger().timestamp(),
+                closed_at_ledger_sequence: env.ledger().sequence(),
+            },
+        );
+    });
+
+    assert_contract_error(
+        client.try_get_settlement_pool(),
+        EscrowError::ComputePayoutArithmeticOverflow,
+    );
+}
 
 /// Helper: initialise a standard escrow for is_settleable tests.
 fn init_settleable_test(


### PR DESCRIPTION
## Summary
- add `get_settlement_pool()` as a pure read view for the SME aggregate base-yield repayment pool
- reuse the checked settlement-pool coupon math from `compute_investor_payout`
- cover no-snapshot, floor rounding, base-vs-tier yield, zero yield, max yield, and overflow behavior
- document the aggregate view in the pro-rata math and read API docs

Fixes #385

## Testing
- `git diff --check`
- `rustfmt --check escrow/src/tests/coverage.rs`
- Attempted: `cargo test -p liquifact_escrow get_settlement_pool -- --nocapture`
  - blocked before running the target tests by existing compile issues outside this change, including duplicate `EscrowError` discriminant `164`, missing `is_settleable` generated client methods in existing coverage tests, a lifetime issue in `integration.rs`, and stale `properties.rs` `init` call arities
- Attempted: `cargo fmt --all -- --check`
  - blocked by pre-existing formatting diffs in unrelated files/sections

## Security notes
- Pure read; no authorization required and no state writes.
- Uses the escrow base `yield_bps` for the aggregate SME repayment pool; investor-specific tier yields remain per-investor accounting through `compute_investor_payout`.
- Uses checked multiplication/addition and the existing `ComputePayoutArithmeticOverflow` guard to avoid silent arithmetic divergence.
