### PR TITLE
fix: preserve fund_batch closing semantics

### DIFF
--- a/docs/escrow-lifecycle.md
+++ b/docs/escrow-lifecycle.md
@@ -68,8 +68,10 @@ reducing transaction overhead for primary issuance workflows.
 
 **Funded-target snapshot:**
 - If any entry causes the escrow to transition to **funded** (status `0 → 1`),
-  `FundingCloseSnapshot` is recorded exactly once
+  `FundingCloseSnapshot` is recorded exactly once after the full closing batch is accepted
 - Remaining entries are processed even after the transition
+- `FundingCloseSnapshot.total_principal` records the final accepted batch principal, so payout
+  denominators include every investor accepted by that closing batch
 
 **Example:**
 ```rust

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -886,6 +886,14 @@ pub struct ContractUpgraded {
 #[contract]
 pub struct LiquifactEscrow;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FundingCloseMode {
+    /// Close and snapshot immediately when a single funding call reaches the target.
+    Immediate,
+    /// Let a batch accept all entries before writing the single close snapshot.
+    DeferBatchSnapshot,
+}
+
 /// Validates and converts a workspace-provided invoice identifier string into a Soroban [`Symbol`].
 ///
 /// ### Constraints
@@ -2156,7 +2164,7 @@ impl LiquifactEscrow {
     /// Emits typed [`EscrowError`] codes for invalid amount, legal hold, closed funding state,
     /// allowlist rejection, cap violations, and checked-arithmetic overflow.
     pub fn fund(env: Env, investor: Address, amount: i128) -> InvoiceEscrow {
-        Self::fund_impl(env, investor, amount, true, 0)
+        Self::fund_impl(env, investor, amount, true, 0, FundingCloseMode::Immediate)
     }
 
     /// First deposit only (per investor): optional longer lock and tier ladder from [`DataKey::YieldTierTable`].
@@ -2172,7 +2180,14 @@ impl LiquifactEscrow {
         amount: i128,
         committed_lock_secs: u64,
     ) -> InvoiceEscrow {
-        Self::fund_impl(env, investor, amount, false, committed_lock_secs)
+        Self::fund_impl(
+            env,
+            investor,
+            amount,
+            false,
+            committed_lock_secs,
+            FundingCloseMode::Immediate,
+        )
     }
 
     /// Batch funding entrypoint: record multiple investor principals in a single call.
@@ -2195,27 +2210,45 @@ impl LiquifactEscrow {
     ///
     /// # Funded-target snapshot
     /// If any entry causes the escrow to transition to **funded** (status 0 → 1),
-    /// [`DataKey::FundingCloseSnapshot`] is recorded exactly once. Remaining entries are
-    /// processed even after transition.
+    /// [`DataKey::FundingCloseSnapshot`] is recorded exactly once after the full closing
+    /// batch is accepted. Remaining entries are processed even after transition, and the
+    /// snapshot principal includes those accepted continuation entries.
     pub fn fund_batch(env: Env, entries: Vec<(Address, i128)>) -> InvoiceEscrow {
         let n = entries.len();
 
         ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
-        ensure(
-            &env,
-            n <= MAX_FUND_BATCH,
-            EscrowError::FundingBatchTooLarge,
-        );
+        ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
 
         let mut escrow = Self::get_escrow(env.clone());
+        ensure(
+            &env,
+            escrow.status == 0,
+            EscrowError::EscrowNotOpenForFunding,
+        );
 
         for i in 0..n {
             let (investor, amount) = entries.get(i).unwrap();
 
-            // Call fund_impl for each entry, but we need to reconstruct the escrow
-            // after each call. However, fund_impl returns the updated escrow,
-            // so we capture it for the next iteration.
-            escrow = Self::fund_impl(env.clone(), investor, amount, true, 0);
+            escrow = Self::fund_impl(
+                env.clone(),
+                investor,
+                amount,
+                true,
+                0,
+                FundingCloseMode::DeferBatchSnapshot,
+            );
+        }
+
+        if escrow.status == 1 && !env.storage().instance().has(&DataKey::FundingCloseSnapshot) {
+            let snap = FundingCloseSnapshot {
+                total_principal: escrow.funded_amount,
+                funding_target: escrow.funding_target,
+                closed_at_ledger_timestamp: env.ledger().timestamp(),
+                closed_at_ledger_sequence: env.ledger().sequence(),
+            };
+            env.storage()
+                .instance()
+                .set(&DataKey::FundingCloseSnapshot, &snap);
         }
 
         escrow
@@ -2227,6 +2260,7 @@ impl LiquifactEscrow {
         amount: i128,
         simple_fund: bool,
         committed_lock_secs: u64,
+        close_mode: FundingCloseMode,
     ) -> InvoiceEscrow {
         investor.require_auth();
 
@@ -2255,9 +2289,11 @@ impl LiquifactEscrow {
             !Self::legal_hold_active(&env),
             EscrowError::LegalHoldBlocksFunding,
         );
+        let batch_continuation =
+            matches!(close_mode, FundingCloseMode::DeferBatchSnapshot) && escrow.status == 1;
         ensure(
             &env,
-            escrow.status == 0,
+            escrow.status == 0 || batch_continuation,
             EscrowError::EscrowNotOpenForFunding,
         );
 
@@ -2377,7 +2413,9 @@ impl LiquifactEscrow {
 
         if escrow.status == 0 && escrow.funded_amount >= escrow.funding_target {
             escrow.status = 1;
-            if !env.storage().instance().has(&DataKey::FundingCloseSnapshot) {
+            if matches!(close_mode, FundingCloseMode::Immediate)
+                && !env.storage().instance().has(&DataKey::FundingCloseSnapshot)
+            {
                 let snap = FundingCloseSnapshot {
                     total_principal: escrow.funded_amount,
                     funding_target: escrow.funding_target,

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -2983,6 +2983,11 @@ fn test_fund_batch_equals_n_single_funds() {
     // Assert identical final state
     assert_eq!(result_batch.funded_amount, result_single.funded_amount);
     assert_eq!(result_batch.status, result_single.status);
+    assert_eq!(
+        client_a.get_unique_funder_count(),
+        client_b.get_unique_funder_count()
+    );
+    assert_eq!(client_a.get_unique_funder_count(), 5);
 
     // Verify contributions match
     for i in 0..5 {
@@ -3034,6 +3039,46 @@ fn test_fund_batch_per_investor_cap_rejection() {
 }
 
 #[test]
+#[should_panic(expected = "FundingBelowMinContribution")]
+fn test_fund_batch_min_contribution_floor_rejection() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv1 = Address::generate(&env);
+    let inv2 = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let target = 100_000i128;
+    let min_contribution = 10_000i128;
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FLOOR01"),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &Some(min_contribution),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((inv1.clone(), min_contribution));
+    entries.push_back((inv2.clone(), min_contribution - 1));
+
+    client.fund_batch(&entries);
+}
+
+#[test]
 fn test_fund_batch_mid_batch_funded_transition() {
     let env = Env::default();
     env.mock_all_auths();
@@ -3041,7 +3086,6 @@ fn test_fund_batch_mid_batch_funded_transition() {
     let admin = Address::generate(&env);
     let sme = Address::generate(&env);
     let (tok, tre) = free_addresses(&env);
-    let investor = Address::generate(&env);
 
     let target = 100_000i128;
     client.init(
@@ -3069,26 +3113,68 @@ fn test_fund_batch_mid_batch_funded_transition() {
     let mut entries = SorobanVec::new(&env);
     // inv1 brings total to 40k (still open)
     entries.push_back((inv1.clone(), 40_000i128));
-    // inv2 brings total to 95k (still open)
-    entries.push_back((inv2.clone(), 55_000i128));
-    // inv3 brings total to 105k (crosses funded threshold)
-    entries.push_back((inv3.clone(), 10_000i128));
+    // inv2 brings total to 105k (crosses funded threshold mid-batch)
+    entries.push_back((inv2.clone(), 65_000i128));
+    // inv3 is still part of the same accepted closing batch.
+    entries.push_back((inv3.clone(), 15_000i128));
 
     let result = client.fund_batch(&entries);
 
     // Verify transition occurred
     assert_eq!(result.status, 1, "status should be funded (1) after batch");
-    assert_eq!(result.funded_amount, 105_000i128);
+    assert_eq!(result.funded_amount, 120_000i128);
 
     // Verify all entries were processed
     assert_eq!(client.get_contribution(&inv1), 40_000i128);
-    assert_eq!(client.get_contribution(&inv2), 55_000i128);
-    assert_eq!(client.get_contribution(&inv3), 10_000i128);
+    assert_eq!(client.get_contribution(&inv2), 65_000i128);
+    assert_eq!(client.get_contribution(&inv3), 15_000i128);
+    assert_eq!(client.get_unique_funder_count(), 3);
 
-    // Verify snapshot was captured
+    // Verify snapshot was captured once with the final accepted batch principal.
     let snap = client.get_funding_close_snapshot();
     assert!(snap.is_some());
-    assert_eq!(snap.unwrap().total_principal, 105_000i128);
+    let snap = snap.unwrap();
+    assert_eq!(snap.total_principal, 120_000i128);
+    assert_eq!(snap.funding_target, target);
+}
+
+#[test]
+#[should_panic(expected = "EscrowNotOpenForFunding")]
+fn test_fund_batch_rejects_new_batch_after_funded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let target = 100_000i128;
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "POSTB001"),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let closer = Address::generate(&env);
+    client.fund(&closer, &target);
+
+    let late_investor = Address::generate(&env);
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((late_investor, 1_000i128));
+
+    client.fund_batch(&entries);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- fixes `fund_batch` so a closing batch can keep accepting remaining entries after the funding target is crossed
- defers `FundingCloseSnapshot` creation until the full accepted closing batch has been processed, so `total_principal` matches the final batch-funded denominator
- expands `fund_batch` coverage for single-call equivalence, unique funder count, min contribution floor rejection, mid-batch close continuation, and post-funded batch rejection
- updates the lifecycle docs to clarify the closing-batch snapshot semantics

Fixes #402.

## Security notes
`fund()` and `fund_with_commitment()` still write the close snapshot immediately when they cross the target. The deferred snapshot mode is limited to `fund_batch`, and a fresh `fund_batch` call still rejects an escrow that was already funded before the call. This keeps post-close funding blocked while preserving the intended same-batch acceptance semantics.

## Testing
- `rustfmt --check --config skip_children=true escrow/src/lib.rs escrow/src/tests/funding.rs`
- `git diff --check`
- `cargo test -p liquifact_escrow fund_batch -- --nocapture` currently does not reach these tests because the current upstream test target fails to compile first on unrelated existing errors, including duplicate `EscrowError` discriminant `164`, missing `is_settleable` client methods referenced from `escrow/src/tests/coverage.rs`, missing `soroban_sdk::testutils::Events` imports in coverage tests, stale `init` arity calls in `escrow/src/tests/properties.rs`, and a missing lifetime in `escrow/src/tests/integration.rs`.
