### PR TITLE
docs: document the investor allowlist model and persistent-storage semantics with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ cargo clippy --all-targets -- -D warnings
 | `sweep_terminal_dust` | Treasury sweeps rounding residue from a terminal escrow. |
 | `migrate` | Schema version gate — **typed errors on all paths** in the current release (codes 90–92). |
 | `set_legal_hold` | Admin activates/clears compliance hold. |
+| `set_allowlist_active` | Admin enables/disables the investor allowlist gate. |
+| `set_investor_allowlisted` | Admin sets per-address allowlist status. |
+| `set_investors_allowlisted` | Admin batch-sets allowlist status for multiple addresses. |
 | `bind_primary_attestation_hash` | Admin sets a single-write 32-byte digest. |
 | `append_attestation_digest` | Admin appends to bounded audit log. |
 | `record_sme_collateral_commitment` | SME records collateral pledge (metadata only). |
@@ -228,6 +231,16 @@ external token contracts.
 ## SME collateral metadata
 
 See [`docs/escrow-sme-collateral.md`](docs/escrow-sme-collateral.md) for the risk-team handling rules for `record_sme_collateral_commitment` and `CollateralRecordedEvt`. The record is SME-reported metadata only; it is not proof of custody, token movement, or an enforceable on-chain claim.
+
+## Investor allowlist
+
+The escrow supports an optional investor allowlist gate that controls which addresses may fund. See [`docs/escrow-allowlist.md`](docs/escrow-allowlist.md) for the complete allowlist model documentation, including:
+
+- Active/inactive toggle behavior and interaction with per-address entries
+- Persistent storage model and TTL/archival implications
+- Fund-gate enforcement rules and default-to-deny semantics
+- Batch operations and equivalence to single calls
+- Security considerations for TTL management and admin key security
 
 ## Security notes
 

--- a/docs/escrow-allowlist.md
+++ b/docs/escrow-allowlist.md
@@ -1,0 +1,246 @@
+# Investor Allowlist Model
+
+## Overview
+
+The LiquiFact escrow contract provides an optional investor allowlist gate that controls which addresses may fund an invoice escrow. The allowlist consists of two independent components:
+
+1. **Toggle state** (`DataKey::AllowlistActive`) — stored in instance storage, controls whether the gate is enforced
+2. **Per-address entries** (`DataKey::InvestorAllowlisted(Address)`) — stored in persistent storage, indicates whether a specific address is allowlisted
+
+This document describes the interaction between these components, the storage model, TTL behavior, and the fund-gate enforcement rules.
+
+## Storage Architecture
+
+### Instance Storage: Toggle State
+
+The allowlist toggle state is stored in **instance storage** under `DataKey::AllowlistActive`:
+
+- **Type:** `bool`
+- **Location:** Instance storage (shared TTL with the contract instance)
+- **Default:** `false` (disabled) when absent
+- **Mutability:** Admin-only via [`LiquifactEscrow::set_allowlist_active`]
+
+Instance storage is loaded in full on every contract invocation and has a shared TTL with the contract instance. The toggle state is small (1 byte) and does not significantly impact instance storage footprint.
+
+### Persistent Storage: Per-Address Entries
+
+Per-address allowlist entries are stored in **persistent storage** under `DataKey::InvestorAllowlisted(Address)`:
+
+- **Type:** `bool`
+- **Location:** Persistent storage (independent per-address TTL)
+- **Default:** `false` when absent (default-to-deny semantics)
+- **Mutability:** Admin-only via [`LiquifactEscrow::set_investor_allowlisted`] or [`LiquifactEscrow::set_investors_allowlisted`]
+
+Persistent storage entries have independent TTLs per address and are not loaded on every contract invocation. This design allows the allowlist to scale to many investors without growing the instance storage footprint.
+
+### TTL Extension
+
+When an allowlist entry is written or updated via `set_investor_allowlisted` or `set_investors_allowlisted`, the contract extends the persistent storage TTL by [`PERSISTENT_TTL_MIN_EXTENSION_LEDGERS`] (≈1 hour at 1 ledger/sec). This reduces the risk of silent allowlist disablement due to entry archival.
+
+**Important:** TTL extension is **not** automatic on read operations. Operators must periodically write to allowlist entries (e.g., via a no-op `set_investor_allowlisted(addr, true)` for existing allowlisted addresses) to keep entries alive over long time horizons.
+
+## Fund-Gate Enforcement
+
+### Gate Logic
+
+The fund-gate is enforced in `fund_impl` (the internal implementation shared by `fund` and `fund_with_commitment`) with the following logic:
+
+```rust
+if Self::is_allowlist_active(env.clone()) {
+    ensure(
+        &env,
+        Self::is_investor_allowlisted(env.clone(), investor.clone()),
+        EscrowError::InvestorNotAllowlisted,
+    );
+}
+```
+
+The gate is **only checked when the allowlist is active**. When inactive, any address may fund regardless of allowlist entries.
+
+### Gate Behavior Matrix
+
+| Allowlist Active | Entry Present | Entry Value | Funding Allowed |
+|------------------|---------------|-------------|-----------------|
+| `false` | Any | Any | ✅ Yes (gate bypassed) |
+| `true` | Yes | `true` | ✅ Yes |
+| `true` | Yes | `false` | ❌ No (rejected with `InvestorNotAllowlisted`) |
+| `true` | No | N/A | ❌ No (default-to-deny, rejected with `InvestorNotAllowlisted`) |
+
+### Default-to-Deny Semantics
+
+When the allowlist is active, **absent entries are treated as `false`**. This default-to-deny behavior ensures that:
+
+- Archived/evicted entries (due to TTL expiration) do not silently allow funding
+- Addresses never added to the allowlist are blocked by default
+- Explicit removal (`set_investor_allowlisted(addr, false)`) and absence are functionally equivalent
+
+This is implemented via the `unwrap_or(false)` pattern in `is_investor_allowlisted`:
+
+```rust
+pub fn is_investor_allowlisted(env: Env, investor: Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::InvestorAllowlisted(investor))
+        .unwrap_or(false)  // ← default-to-deny
+}
+```
+
+## Active/Inactive Toggle Interaction
+
+### Toggle Independence
+
+The toggle state and per-address entries are **independent**:
+
+- Disabling the toggle does **not** delete per-address entries
+- Enabling the toggle does **not** auto-populate entries
+- Entries persist across enable/disable cycles
+
+This design allows operators to:
+- Pre-populate the allowlist before enabling the gate
+- Temporarily disable the gate for emergency funding without losing the allowlist
+- Re-enable the gate with the same entries intact
+
+### Toggle During Funding
+
+The toggle can be changed at any time (including while the escrow is open for funding). This enables use cases such as:
+
+- **Phase-based funding:** Start with allowlist disabled for early adopters, then enable for KYC'd investors
+- **Emergency override:** Temporarily disable to allow urgent funding from non-allowlisted addresses
+- **Gradual rollout:** Add addresses to the allowlist while the gate is disabled, then enable when ready
+
+**Important:** Changing the toggle state affects **future** funding attempts only. It does not retroactively validate or invalidate existing contributions.
+
+## Batch Operations
+
+### Batch Bound
+
+The batch operation [`LiquifactEscrow::set_investors_allowlisted`] is bounded by [`MAX_INVESTOR_ALLOWLIST_BATCH`] (32 entries) to keep storage and CPU work per call bounded. This prevents:
+
+- Excessive storage writes in a single transaction
+- Event emission spam (one event per address)
+- CPU timeout risk on large batches
+
+### Equivalence to Single Calls
+
+The batch operation is **semantically equivalent” to calling [`LiquifactEscrow::set_investor_allowlisted`] individually for each address in the batch:
+
+- Each address receives its own persistent storage write
+- Each address receives its own TTL bump
+- Each address emits its own [`InvestorAllowlistChanged`] event
+- Admin authorization is required once for the entire batch
+
+**Invariant:** The end state and emitted events after a batch call are identical to the same operations performed via single calls.
+
+### Batch Use Cases
+
+Batch operations are useful for:
+
+- **Initial allowlist setup:** Adding KYC'd investors in bulk before funding opens
+- **Bulk removal:** Removing a group of investors after compliance review
+- **Periodic refresh:** Re-writing entries to extend TTLs for many addresses at once
+
+## API Reference
+
+### Admin Functions
+
+#### `set_allowlist_active(env: Env, active: bool)`
+
+Enable or disable the allowlist gate.
+
+- **Authorization:** Admin only
+- **Storage:** Writes to instance storage (`DataKey::AllowlistActive`)
+- **Events:** Emits [`AllowlistEnabledChanged`]
+
+#### `set_investor_allowlisted(env: Env, investor: Address, allowed: bool)`
+
+Set whether a specific address is allowlisted.
+
+- **Authorization:** Admin only
+- **Storage:** Writes to persistent storage (`DataKey::InvestorAllowlisted(investor)`)
+- **TTL:** Extends persistent TTL by [`PERSISTENT_TTL_MIN_EXTENSION_LEDGERS`]
+- **Events:** Emits [`InvestorAllowlistChanged`]
+
+#### `set_investors_allowlisted(env: Env, investors: Vec<Address>, allowed: bool)`
+
+Batch set allowlist status for multiple addresses.
+
+- **Authorization:** Admin only (once for the entire batch)
+- **Storage:** Writes to persistent storage for each address
+- **TTL:** Extends persistent TTL for each entry
+- **Events:** Emits one [`InvestorAllowlistChanged`] per address
+- **Bounds:** Rejects empty vectors or vectors > [`MAX_INVESTOR_ALLOWLIST_BATCH`] (32)
+- **Errors:**
+  - [`EscrowError::InvestorBatchEmpty`] (70) — empty vector
+  - [`EscrowError::InvestorBatchTooLarge`] (71) — exceeds batch bound
+
+### Read Functions
+
+#### `is_allowlist_active(env: Env) -> bool`
+
+Read whether the allowlist gate is active.
+
+- **Authorization:** None (read-only)
+- **Returns:** `true` if active, `false` if inactive
+- **Default:** `false` when key is absent
+
+#### `is_investor_allowlisted(env: Env, investor: Address) -> bool`
+
+Check whether a specific address is allowlisted.
+
+- **Authorization:** None (read-only)
+- **Returns:** `true` if entry is `true`, `false` if entry is `false` or absent
+- **Default:** `false` when key is absent (default-to-deny)
+
+## Security Considerations
+
+### TTL Management
+
+Persistent storage entries can be archived if their TTL expires. To prevent silent allowlist disablement:
+
+1. **Monitor TTL:** Track the age of allowlist entries off-chain
+2. **Periodic refresh:** Call `set_investor_allowlisted(addr, true)` for active entries to extend TTL
+3. **Gate validation:** When the gate is active, absent entries default to deny, so archival safely blocks funding
+
+### Admin Key Security
+
+The allowlist is controlled by the escrow admin. To prevent single-point-of-failure:
+
+- Use a multisig or DAO-controlled admin address
+- Implement governance processes for allowlist changes
+- Document allowlist policies and change procedures
+
+### Gate Bypass Risk
+
+The allowlist gate is **only enforced in the contract**. To prevent bypass:
+
+- Ensure all funding flows through the contract's `fund` or `fund_with_commitment` entrypoints
+- Do not provide alternative funding paths that skip the gate
+- Monitor for unexpected funding from non-allowlisted addresses when the gate is active
+
+## Testing
+
+Comprehensive tests for the allowlist model are located in `escrow/src/test_allowlist_tests.rs`. Key test coverage includes:
+
+- Default states (disabled toggle, absent entries default to false)
+- Enable/disable toggle behavior
+- Add/remove per-address entries
+- Fund gating when active vs inactive
+- Batch operations and equivalence to single calls
+- Batch bounds (empty, at bound, exceeds bound)
+- Archived entry behavior (simulated via storage removal)
+- Toggle during funding phase
+- Multiple toggle cycles
+- Entry persistence across enable/disable
+
+Run tests with:
+
+```bash
+cargo test -p liquifact_escrow test_allowlist
+```
+
+## Related Documentation
+
+- [Escrow Data Model](escrow-data-model.md) — Full storage schema and key reference
+- [Escrow Error Messages](escrow-error-messages.md) — Typed error codes including `InvestorNotAllowlisted` (104)
+- [ADR-007: Storage Key Evolution](adr/ADR-007-storage-key-evolution.md) — Persistent vs instance storage rationale
+- [Escrow Gas and Storage Notes](escrow-gas-storage-notes.md) — Storage TTL and archival behavior

--- a/docs/escrow-data-model.md
+++ b/docs/escrow-data-model.md
@@ -83,6 +83,10 @@ When `AllowlistActive` is enabled (instance storage flag), `fund_impl` gates `fu
 `fund_with_commitment` by asserting `InvestorAllowlisted(investor) == true`. Only the admin may
 mutate allowlist membership.
 
+See [`escrow-allowlist.md`](escrow-allowlist.md) for the complete allowlist model documentation,
+including the active/inactive toggle interaction, TTL/archival behavior, batch operations, and
+fund-gate enforcement rules.
+
 ---
 
 ## Stored struct reference

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -365,7 +365,7 @@ pub enum EscrowError {
     NoPendingAdmin = 163,
     /// The contract's funding-token balance is less than `funded_amount` at withdraw time.
     /// Funds must be custodied in this contract before the SME can pull them.
-    InsufficientContractBalance = 164,
+    InsufficientContractBalance = 165,
 }
 
 #[inline(always)]
@@ -1882,8 +1882,32 @@ impl LiquifactEscrow {
         .publish(&env);
     }
 
-    /// Enable or disable the investor allowlist. When enabled, only addresses with
-    /// [`DataKey::InvestorAllowlisted`] set to true may fund the escrow.
+    /// Enable or disable the investor allowlist gate.
+    ///
+    /// When enabled (active = true), only addresses with [`DataKey::InvestorAllowlisted`] set to
+    /// `true` may call [`LiquifactEscrow::fund`] or [`LiquifactEscrow::fund_with_commitment`].
+    /// When disabled (active = false), the gate is bypassed and any address may fund.
+    ///
+    /// The toggle state is stored in **instance** storage ([`DataKey::AllowlistActive`]) and
+    /// defaults to `false` (disabled) when absent. Per-address allowlist entries in
+    /// [`DataKey::InvestorAllowlisted`] live in **persistent** storage and persist independently
+    /// of the toggle state—disabling the gate does not delete entries.
+    ///
+    /// # Authorization
+    /// Requires admin authorization via [`Address::require_auth()`].
+    ///
+    /// # Events
+    /// Emits [`AllowlistEnabledChanged`] with the new state.
+    ///
+    /// # Storage
+    /// - Writes to instance storage: [`DataKey::AllowlistActive`]
+    /// - Bumps instance storage TTL via [`Env::storage().instance().extend_ttl()`]
+    ///
+    /// # See also
+    /// - [`LiquifactEscrow::is_allowlist_active`] — read the current toggle state
+    /// - [`LiquifactEscrow::set_investor_allowlisted`] — set per-address allowlist entry
+    /// - [`LiquifactEscrow::set_investors_allowlisted`] — batch set per-address entries
+    /// - [`docs/escrow-allowlist.md`](../docs/escrow-allowlist.md) — full allowlist model documentation
     pub fn set_allowlist_active(env: Env, active: bool) {
         let escrow = Self::load_escrow_require_admin(&env);
         env.storage()
@@ -1897,6 +1921,20 @@ impl LiquifactEscrow {
         .publish(&env);
     }
 
+    /// Read whether the investor allowlist gate is currently active.
+    ///
+    /// Returns `true` when [`DataKey::AllowlistActive`] is set to `true`, `false` otherwise.
+    /// The key lives in instance storage and defaults to `false` when absent.
+    ///
+    /// This is a read-only function and does not require authorization.
+    ///
+    /// # Returns
+    /// - `true` if the allowlist gate is active (only allowlisted addresses may fund)
+    /// - `false` if the allowlist gate is inactive (any address may fund)
+    ///
+    /// # See also
+    /// - [`LiquifactEscrow::set_allowlist_active`] — toggle the gate state
+    /// - [`LiquifactEscrow::is_investor_allowlisted`] — check if a specific address is allowlisted
     pub fn is_allowlist_active(env: Env) -> bool {
         env.storage()
             .instance()
@@ -1904,7 +1942,35 @@ impl LiquifactEscrow {
             .unwrap_or(false)
     }
 
-    /// Add or remove an investor from the allowlist.
+    /// Set whether a specific investor address is allowlisted.
+    ///
+    /// Writes a boolean entry to **persistent** storage under [`DataKey::InvestorAllowlisted`].
+    /// The entry has an independent TTL per address and persists even when the allowlist gate
+    /// is disabled via [`LiquifactEscrow::set_allowlist_active`].
+    ///
+    /// When the allowlist gate is active, [`LiquifactEscrow::fund`] and
+    /// [`LiquifactEscrow::fund_with_commitment`] check this entry and reject funding with
+    /// [`EscrowError::InvestorNotAllowlisted`] if the entry is absent or `false`.
+    ///
+    /// # Authorization
+    /// Requires admin authorization via [`Address::require_auth()`].
+    ///
+    /// # Events
+    /// Emits [`InvestorAllowlistChanged`] for the address.
+    ///
+    /// # Storage
+    /// - Writes to persistent storage: [`DataKey::InvestorAllowlisted(investor)`]
+    /// - Bumps persistent storage TTL via [`Env::storage().persistent().extend_ttl()`]
+    ///   with [`PERSISTENT_TTL_MIN_EXTENSION_LEDGERS`] (≈1 hour at 1 ledger/sec)
+    ///
+    /// # Arguments
+    /// - `investor` — The address to allowlist or remove
+    /// - `allowed` — `true` to allowlist, `false` to remove from allowlist
+    ///
+    /// # See also
+    /// - [`LiquifactEscrow::is_investor_allowlisted`] — check if an address is allowlisted
+    /// - [`LiquifactEscrow::set_investors_allowlisted`] — batch variant for multiple addresses
+    /// - [`docs/escrow-allowlist.md`](../docs/escrow-allowlist.md) — full allowlist model documentation
     pub fn set_investor_allowlisted(env: Env, investor: Address, allowed: bool) {
         let escrow = Self::load_escrow_require_admin(&env);
         env.storage()
@@ -1923,15 +1989,36 @@ impl LiquifactEscrow {
     /// Batch add or remove investors from the allowlist.
     ///
     /// Accepts a `Vec<Address>` and a single `allowed` flag. Requires admin authorization
-    /// once. The call is rejected for empty vectors or vectors longer than
-    /// `MAX_INVESTOR_ALLOWLIST_BATCH` to keep storage and CPU bounded.
+    /// once for the entire batch. The call is rejected for empty vectors or vectors longer than
+    /// [`MAX_INVESTOR_ALLOWLIST_BATCH`] (32) to keep storage and CPU bounded.
     ///
-    /// Invariant: the end state and emitted events are identical to calling
-    /// `set_investor_allowlisted` individually for each element in `investors`.
+    /// **Invariant:** the end state and emitted events are identical to calling
+    /// [`LiquifactEscrow::set_investor_allowlisted`] individually for each element in `investors`.
+    /// Each address receives its own persistent storage write, TTL bump, and event emission.
+    ///
+    /// # Authorization
+    /// Requires admin authorization via [`Address::require_auth()`] once for the entire batch.
+    ///
+    /// # Events
+    /// Emits one [`InvestorAllowlistChanged`] event per address in the batch.
+    ///
+    /// # Storage
+    /// - Writes to persistent storage: [`DataKey::InvestorAllowlisted(investor)`] for each address
+    /// - Bumps persistent storage TTL via [`Env::storage().persistent().extend_ttl()`]
+    ///   with [`PERSISTENT_TTL_MIN_EXTENSION_LEDGERS`] (≈1 hour at 1 ledger/sec) for each entry
+    ///
+    /// # Arguments
+    /// - `investors` — Vector of addresses to allowlist or remove (must be non-empty and ≤32 entries)
+    /// - `allowed` — `true` to allowlist all addresses, `false` to remove all from allowlist
     ///
     /// # Errors
-    /// Emits typed [`EscrowError`] codes when the escrow is uninitialized, the batch is empty, or
-    /// the batch exceeds [`MAX_INVESTOR_ALLOWLIST_BATCH`].
+    /// - [`EscrowError::InvestorBatchEmpty`] (70) — when `investors` is empty
+    /// - [`EscrowError::InvestorBatchTooLarge`] (71) — when `investors.len() > MAX_INVESTOR_ALLOWLIST_BATCH`
+    ///
+    /// # See also
+    /// - [`LiquifactEscrow::set_investor_allowlisted`] — single-address variant
+    /// - [`LiquifactEscrow::is_investor_allowlisted`] — check if an address is allowlisted
+    /// - [`docs/escrow-allowlist.md`](../docs/escrow-allowlist.md) — full allowlist model documentation
     pub fn set_investors_allowlisted(env: Env, investors: Vec<Address>, allowed: bool) {
         let escrow = Self::load_escrow_require_admin(&env);
 
@@ -1960,6 +2047,25 @@ impl LiquifactEscrow {
         }
     }
 
+    /// Check whether a specific investor address is allowlisted.
+    ///
+    /// Reads from **persistent** storage under [`DataKey::InvestorAllowlisted`]. Returns `false`
+    /// when the entry is absent or explicitly set to `false`. This default-to-deny behavior
+    /// ensures that archived/evicted entries or addresses never added to the allowlist are
+    /// treated as not allowlisted when the gate is active.
+    ///
+    /// This is a read-only function and does not require authorization.
+    ///
+    /// # Arguments
+    /// - `investor` — The address to check
+    ///
+    /// # Returns
+    /// - `true` if the address has an allowlist entry set to `true`
+    /// - `false` if the entry is absent, `false`, or has been archived
+    ///
+    /// # See also
+    /// - [`LiquifactEscrow::set_investor_allowlisted`] — set per-address allowlist entry
+    /// - [`LiquifactEscrow::set_allowlist_active`] — toggle the gate state
     pub fn is_investor_allowlisted(env: Env, investor: Address) -> bool {
         env.storage()
             .persistent()
@@ -2201,11 +2307,7 @@ impl LiquifactEscrow {
         let n = entries.len();
 
         ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
-        ensure(
-            &env,
-            n <= MAX_FUND_BATCH,
-            EscrowError::FundingBatchTooLarge,
-        );
+        ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
 
         let mut escrow = Self::get_escrow(env.clone());
 

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -462,3 +462,304 @@ fn test_batch_requires_admin_auth() {
     env.mock_auths(&[]);
     client.set_investors_allowlisted(&v, &true);
 }
+
+// --- batch equivalence to single calls ---
+
+#[test]
+fn test_batch_equivalence_to_single_calls_add() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    // Batch add
+    let mut batch_vec: SorobanVec<Address> = SorobanVec::new(&env);
+    batch_vec.push_back(a.clone());
+    batch_vec.push_back(b.clone());
+    batch_vec.push_back(c.clone());
+    client.set_investors_allowlisted(&batch_vec, &true);
+
+    let batch_events = env.events().all();
+
+    // Clear events and do single calls
+    env.events().all();
+    let d = Address::generate(&env);
+    let e = Address::generate(&env);
+    let f = Address::generate(&env);
+    client.set_investor_allowlisted(&d, &true);
+    client.set_investor_allowlisted(&e, &true);
+    client.set_investor_allowlisted(&f, &true);
+
+    let single_events = env.events().all();
+
+    // Both should emit 3 events with same structure
+    assert_eq!(batch_events.len(), 3);
+    assert_eq!(single_events.len(), 3);
+
+    // Verify storage state is identical
+    env.as_contract(&contract_id, || {
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(a.clone()))
+                == Some(true)
+        );
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(b.clone()))
+                == Some(true)
+        );
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(c.clone()))
+                == Some(true)
+        );
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(d.clone()))
+                == Some(true)
+        );
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(e.clone()))
+                == Some(true)
+        );
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(f.clone()))
+                == Some(true)
+        );
+    });
+}
+
+#[test]
+fn test_batch_equivalence_to_single_calls_remove() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    // First add them
+    client.set_investor_allowlisted(&a, &true);
+    client.set_investor_allowlisted(&b, &true);
+    client.set_investor_allowlisted(&c, &true);
+
+    // Batch remove
+    let mut batch_vec: SorobanVec<Address> = SorobanVec::new(&env);
+    batch_vec.push_back(a.clone());
+    batch_vec.push_back(b.clone());
+    batch_vec.push_back(c.clone());
+    client.set_investors_allowlisted(&batch_vec, &false);
+
+    // Verify storage state is identical to single remove
+    env.as_contract(&contract_id, || {
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(a.clone()))
+                == Some(false)
+        );
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(b.clone()))
+                == Some(false)
+        );
+        assert!(
+            env.storage()
+                .persistent()
+                .get::<DataKey, bool>(&DataKey::InvestorAllowlisted(c.clone()))
+                == Some(false)
+        );
+    });
+}
+
+#[test]
+fn test_batch_at_max_bound() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let cap = super::MAX_INVESTOR_ALLOWLIST_BATCH;
+    let mut v: SorobanVec<Address> = SorobanVec::new(&env);
+    for _ in 0..cap {
+        v.push_back(Address::generate(&env));
+    }
+
+    // Should succeed at exactly the bound
+    client.set_investors_allowlisted(&v, &true);
+    assert_eq!(v.len(), cap);
+}
+
+// --- archived entry default behavior ---
+
+#[test]
+fn test_absent_entry_defaults_to_false() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let stranger = Address::generate(&env);
+    // Never added to allowlist - should return false
+    assert!(!client.is_investor_allowlisted(&stranger));
+}
+
+#[test]
+fn test_fund_gate_with_archived_entry_simulated() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+    let investor = Address::generate(&env);
+
+    // Enable allowlist and add investor
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+
+    // Simulate archival by manually removing the persistent entry
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::InvestorAllowlisted(investor.clone()));
+    });
+
+    // Now the entry is absent (simulating archival)
+    assert!(!client.is_investor_allowlisted(&investor));
+
+    // Funding should be blocked (absent entry defaults to false)
+    let blocked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund(&investor, &1_000i128);
+    }));
+    assert!(blocked.is_err());
+}
+
+#[test]
+fn test_fund_gate_with_explicitly_false_entry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let investor = Address::generate(&env);
+
+    // Enable allowlist and explicitly set to false
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &false);
+
+    // Funding should be blocked
+    let blocked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund(&investor, &1_000i128);
+    }));
+    assert!(blocked.is_err());
+}
+
+// --- edge cases with toggle ---
+
+#[test]
+fn test_toggle_during_funding_phase() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let investor_a = Address::generate(&env);
+    let investor_b = Address::generate(&env);
+
+    // Start with allowlist disabled
+    assert!(!client.is_allowlist_active());
+
+    // Investor A funds while disabled
+    client.fund(&investor_a, &3_000i128);
+
+    // Enable allowlist and add investor B
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor_b, &true);
+
+    // Investor B can now fund
+    client.fund(&investor_b, &2_000i128);
+
+    // Investor A (not on allowlist) cannot fund anymore
+    let blocked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund(&investor_a, &1_000i128);
+    }));
+    assert!(blocked.is_err());
+
+    // Disable allowlist - both can fund again
+    client.set_allowlist_active(&false);
+    client.fund(&investor_a, &1_000i128);
+    client.fund(&investor_b, &1_000i128);
+}
+
+#[test]
+fn test_allowlist_state_persists_after_funding_complete() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let investor = Address::generate(&env);
+
+    // Enable allowlist and add investor
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+
+    // Fund to completion
+    client.fund(&investor, &10_000i128);
+
+    // Allowlist state should still be readable
+    assert!(client.is_allowlist_active());
+    assert!(client.is_investor_allowlisted(&investor));
+
+    // Toggle should still work after funding
+    client.set_allowlist_active(&false);
+    assert!(!client.is_allowlist_active());
+}
+
+#[test]
+fn test_multiple_toggle_cycles() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let investor = Address::generate(&env);
+
+    // Cycle: off -> on -> off -> on -> off
+    assert!(!client.is_allowlist_active());
+
+    client.set_allowlist_active(&true);
+    assert!(client.is_allowlist_active());
+
+    client.set_allowlist_active(&false);
+    assert!(!client.is_allowlist_active());
+
+    client.set_allowlist_active(&true);
+    assert!(client.is_allowlist_active());
+
+    client.set_allowlist_active(&false);
+    assert!(!client.is_allowlist_active());
+
+    // Entry persists through all cycles
+    client.set_investor_allowlisted(&investor, &true);
+    assert!(client.is_investor_allowlisted(&investor));
+
+    // Re-enable and verify funding works
+    client.set_allowlist_active(&true);
+    client.fund(&investor, &5_000i128);
+}

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -777,8 +777,7 @@ fn test_update_funding_target_fails_when_settled() {
 fn test_update_funding_target_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "WD001");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "WD001");
     client.withdraw(); // status → 3 (withdrawn)
     client.update_funding_target(&6_000i128);
 }
@@ -984,8 +983,7 @@ fn test_update_maturity_fails_when_settled() {
 fn test_update_maturity_fails_when_withdrawn() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _escrow_id, _sme) =
-        init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, 5_000i128, "MAT004");
     client.withdraw(); // status → 3
     client.update_maturity(&2000u64);
 }

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -581,10 +581,7 @@ fn test_get_funding_token_before_init_fails_with_typed_error() {
 fn test_get_treasury_before_init_fails_with_typed_error() {
     let env = Env::default();
     let client = deploy(&env);
-    assert_contract_error(
-        client.try_get_treasury(),
-        EscrowError::TreasuryNotSet,
-    );
+    assert_contract_error(client.try_get_treasury(), EscrowError::TreasuryNotSet);
 }
 
 #[test]

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -890,12 +890,14 @@ fn withdraw_transfers_funded_amount_to_sme() {
     env.mock_all_auths();
 
     let target = 50_000_000i128;
-    let (client, escrow_id, token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_BAL001");
+    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
 
     let sme_before = token.balance(&sme);
     let contract_before = token.balance(&escrow_id);
-    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
+    assert_eq!(
+        contract_before, target,
+        "escrow must hold exactly funded_amount before withdraw"
+    );
 
     client.withdraw();
 
@@ -911,7 +913,11 @@ fn withdraw_transfers_funded_amount_to_sme() {
         contract_after, 0,
         "escrow contract balance must be zero after disbursement"
     );
-    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
+    assert_eq!(
+        client.get_escrow().status,
+        3u32,
+        "status must be 3 after withdraw"
+    );
 }
 
 /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
@@ -921,8 +927,7 @@ fn withdraw_updates_distributed_principal() {
     env.mock_all_auths();
 
     let target = 20_000_000i128;
-    let (client, _escrow_id, _token, _sme) =
-        setup_withdraw_with_token(&env, target, "WD_DP001");
+    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
 
     client.withdraw();
 
@@ -1058,8 +1063,7 @@ fn withdraw_event_includes_recipient() {
     env.mock_all_auths();
 
     let target = 5_000_000i128;
-    let (client, escrow_id, _token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_EV001");
+    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
 
     client.withdraw();
 
@@ -1074,9 +1078,9 @@ fn withdraw_event_includes_recipient() {
     .to_xdr(&env, &escrow_id);
 
     let all_events = env.events().all().filter_by_contract(&escrow_id);
-    let found = all_events
-        .events()
-        .iter()
-        .any(|e| *e == expected_xdr);
-    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
+    let found = all_events.events().iter().any(|e| *e == expected_xdr);
+    assert!(
+        found,
+        "SmeWithdrew event with correct recipient and amount must be emitted"
+    );
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -45,7 +45,11 @@ fn fund_to_target(client: &super::LiquifactEscrowClient<'_>, env: &Env) -> Addre
 /// actually transfer them.  Returns `(client, sme, sac_admin_client)`.
 fn setup_funded_with_token<'a>(
     env: &'a Env,
-) -> (super::LiquifactEscrowClient<'a>, Address, StellarAssetClient<'a>) {
+) -> (
+    super::LiquifactEscrowClient<'a>,
+    Address,
+    StellarAssetClient<'a>,
+) {
     let sac = env.register_stellar_asset_contract_v2(Address::generate(env));
     let token_id = sac.address();
     let sac_admin = StellarAssetClient::new(env, &token_id);


### PR DESCRIPTION
closes #415

This PR adds comprehensive documentation for the investor allowlist functionality, including:

NatSpec-style rustdoc comments for all allowlist functions
Dedicated documentation file covering storage architecture, TTL behavior, and fund-gate enforcement
Expanded test suite covering batch equivalence, archival behavior, and toggle edge cases
Cross-references from README and data model documentation
Bug fix: duplicate error code in EscrowError enum