### PR TITLE
feat: add batch allowlist event for indexer visibility

### DIFF
--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -33,7 +33,7 @@ short routing symbol passed with `symbol_short!(...)`, such as `funded` or
 
 ## Event Catalog
 
-The current contract defines 19 event structs.
+The current contract defines 20 event structs.
 
 | Rust event | `name` symbol | Entrypoint(s) |
 |---|---:|---|
@@ -57,6 +57,7 @@ The current contract defines 19 event structs.
 | `AttestationDigestAppended` | `att_app` | `append_attestation_digest` |
 | `AllowlistEnabledChanged` | `al_ena` | `set_allowlist_active` |
 | `InvestorAllowlistChanged` | `al_set` | `set_investor_allowlisted`, `set_investors_allowlisted` |
+| `InvestorAllowlistBatchApplied` | `al_batch` | `set_investors_allowlisted` |
 
 ## Complete Topic And Data Layout
 
@@ -445,6 +446,33 @@ Data:
 | `investor` | `Address` | Updated investor |
 | `allowed` | `u32` | `1` = allowed, `0` = blocked |
 
+### `InvestorAllowlistBatchApplied`
+
+Emitted once per `set_investors_allowlisted` call, after all per-investor
+`InvestorAllowlistChanged` (`al_set`) events have been emitted. Allows indexers
+to identify completed batch operations without counting individual `al_set`
+events. Supplements — does not replace — the per-investor events.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `investor_allowlist_batch_applied` |
+| 1 | `name` | `Symbol` | `al_batch` |
+
+Data:
+
+| Field | Type | Values |
+|---|---|---|
+| `invoice_id` | `Symbol` | Escrow invoice id |
+| `batch_size` | `u32` | Number of investors processed (`1`–`MAX_INVESTOR_ALLOWLIST_BATCH`) |
+| `allowed` | `u32` | `1` = allowed, `0` = blocked |
+
+**Indexer guidance:** filter on `topic[1] == "al_batch"` to detect batch
+operations. `batch_size` equals the count of `al_set` events emitted in the
+same transaction. Existing indexers that only consume `al_set` remain fully
+compatible — `al_batch` is purely additive.
+
 ## Nested Types
 
 ### `InvoiceEscrow`
@@ -500,7 +528,8 @@ Status values:
   contribution zeroing before emission.
 - Event emission is O(1) for all entrypoints except
   `set_investors_allowlisted`, which emits O(n) `InvestorAllowlistChanged`
-  events for `n <= MAX_INVESTOR_ALLOWLIST_BATCH`.
+  events for `n <= MAX_INVESTOR_ALLOWLIST_BATCH` followed by exactly one
+  `InvestorAllowlistBatchApplied` event.
 
 ## Changelog
 
@@ -510,3 +539,4 @@ Status values:
 | 2026-05-27 | v0.2 | Added initialization references and investor-cap event notes |
 | 2026-05-31 | v0.3 | Issue #272: replaced drifted reference with complete `#[contractevent]` topic and data layout from `escrow/src/lib.rs` |
 | 2026-06-24 | v0.4 | Added `settled_at_ledger_timestamp` field to `EscrowSettled` event; added `is_settleable` view |
+| 2026-06-26 | v0.5 | Issue #379: Added `InvestorAllowlistBatchApplied` (`al_batch`) event emitted once per `set_investors_allowlisted` call for indexer disambiguation |

--- a/docs/escrow-events.md
+++ b/docs/escrow-events.md
@@ -141,6 +141,45 @@ for each address in the batch.
 **Notes:**
 - Batch mutations via `set_investors_allowlisted` emit one `al_set` event per affected
   investor to preserve parity with individual `set_investor_allowlisted` calls.
+- Existing indexers that only consume `al_set` do not need to change — the per-investor
+  event sequence is identical regardless of whether it originated from a single call or
+  a batch call.
+
+### `InvestorAllowlistBatchApplied`
+Emitted **once per `set_investors_allowlisted` call**, after all per-investor
+`InvestorAllowlistChanged` events have been emitted in the same transaction.
+
+**Topics:**
+1. `al_batch` (Symbol)
+
+**Data Payload:**
+- `invoice_id` (Symbol): the escrow invoice identifier.
+- `batch_size` (u32): total number of investors processed in this batch.
+- `allowed` (u32): `1` if the batch allowed investors, `0` if it blocked them.
+
+**Why `al_batch` exists:**
+The per-investor `al_set` events emitted by `set_investors_allowlisted` are
+structurally identical to those emitted by the single-address entrypoint
+`set_investor_allowlisted`. Without an additional marker, an indexer cannot
+determine whether a run of `al_set` events in a transaction came from one
+batch call or many individual calls. `al_batch` provides that disambiguation
+in a single event.
+
+**Relationship to `al_set`:**
+`al_batch` supplements — it does not replace — the per-investor `al_set` events.
+Both are emitted for every `set_investors_allowlisted` call:
+- N × `al_set` (one per address, in input order)
+- 1 × `al_batch` (after the loop, carrying the full count)
+
+**Backward compatibility:**
+Existing indexers that only subscribe to `al_set` remain fully compatible. The
+`al_batch` event is purely additive and is never emitted by the single-address
+`set_investor_allowlisted` entrypoint.
+
+**Auditor usage:**
+Auditors can cross-check `batch_size` against the number of `al_set` events in
+the same transaction to verify that no per-investor events were dropped or
+duplicated during a batch operation.
 
 ### `LegalHoldChanged`
 Emitted when an admin toggles the compliance hold.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -874,6 +874,44 @@ pub struct InvestorAllowlistChanged {
     pub allowed: u32,
 }
 
+/// Batch-level summary event emitted once per `set_investors_allowlisted` call.
+///
+/// ## Purpose
+/// Allows indexers and audit tooling to detect that a batch allowlist operation has
+/// completed without scanning individual `al_set` events for a particular ledger
+/// range. Useful for triggering downstream reconciliation or audit checks after a
+/// bulk admin action.
+///
+/// ## Why it exists
+/// The per-investor `InvestorAllowlistChanged` (`al_set`) events emitted by
+/// `set_investors_allowlisted` are identical in shape to those emitted by the
+/// single-address `set_investor_allowlisted`. Without a distinct batch marker,
+/// indexers cannot tell whether a block of `al_set` events came from one batch
+/// call or N individual calls. `InvestorAllowlistBatchApplied` (`al_batch`)
+/// provides that signal with the full count in one event.
+///
+/// ## Relationship to per-investor events
+/// This event **supplements** — it does not replace — the per-investor `al_set`
+/// events. Both are emitted for every batch call:
+/// - N × `InvestorAllowlistChanged` (`al_set`), one per address in input order.
+/// - 1 × `InvestorAllowlistBatchApplied` (`al_batch`), after all per-investor writes.
+///
+/// ## Indexer / audit guidance
+/// - Filter on `topic[1] == "al_batch"` to identify completed batch operations.
+/// - `batch_size` matches the number of `al_set` events immediately preceding this
+///   event in the same transaction. Auditors can cross-check by counting `al_set`
+///   emissions in the same tx.
+/// - `allowed` mirrors the single `allowed` flag passed to the batch call.
+#[contractevent]
+pub struct InvestorAllowlistBatchApplied {
+    #[topic]
+    pub name: Symbol,
+    pub invoice_id: Symbol,
+    pub batch_size: u32,
+    /// `1` = allowed, `0` = blocked.
+    pub allowed: u32,
+}
+
 #[contractevent]
 pub struct ContractUpgraded {
     #[topic]
@@ -1958,6 +1996,16 @@ impl LiquifactEscrow {
             }
             .publish(&env);
         }
+
+        // Emit exactly one batch-level summary event so indexers can distinguish a
+        // batch call from N individual `set_investor_allowlisted` calls.
+        InvestorAllowlistBatchApplied {
+            name: symbol_short!("al_batch"),
+            invoice_id: escrow.invoice_id.clone(),
+            batch_size: n,
+            allowed: if allowed { 1 } else { 0 },
+        }
+        .publish(&env);
     }
 
     pub fn is_investor_allowlisted(env: Env, investor: Address) -> bool {

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    AllowlistEnabledChanged, DataKey, InvestorAllowlistChanged, LiquifactEscrow,
-    LiquifactEscrowClient,
+    AllowlistEnabledChanged, DataKey, InvestorAllowlistBatchApplied, InvestorAllowlistChanged,
+    LiquifactEscrow, LiquifactEscrowClient,
 };
 use soroban_sdk::Vec as SorobanVec;
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Event};
@@ -461,4 +461,495 @@ fn test_batch_requires_admin_auth() {
 
     env.mock_auths(&[]);
     client.set_investors_allowlisted(&v, &true);
+}
+
+// ---------------------------------------------------------------------------
+// Batch event tests (Issue #379)
+// ---------------------------------------------------------------------------
+
+// --- existing al_set events still emitted correctly (under-target behavior) ---
+
+#[test]
+fn test_single_investor_set_still_emits_al_set_only() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+    let investor = Address::generate(&env);
+
+    client.set_investor_allowlisted(&investor, &true);
+    let events = env.events().all();
+
+    // Exactly one event, and it is al_set — not al_batch.
+    assert_eq!(events.events().len(), 1);
+    assert_eq!(
+        events,
+        std::vec![InvestorAllowlistChanged {
+            name: symbol_short!("al_set"),
+            invoice_id,
+            investor,
+            allowed: 1,
+        }
+        .to_xdr(&env, &contract_id)]
+    );
+}
+
+// --- single-element batch ---
+
+#[test]
+fn test_single_element_batch_emits_one_al_set_and_one_al_batch() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+    let investor = Address::generate(&env);
+
+    let mut v: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    v.push_back(investor.clone());
+
+    client.set_investors_allowlisted(&v, &true);
+    let all = env.events().all();
+
+    // 1 al_set + 1 al_batch = 2 events total.
+    assert_eq!(
+        all,
+        std::vec![
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: investor.clone(),
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistBatchApplied {
+                name: symbol_short!("al_batch"),
+                invoice_id,
+                batch_size: 1,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+        ]
+    );
+}
+
+// --- multi-address batch: N al_set events + exactly 1 al_batch ---
+
+#[test]
+fn test_multi_address_batch_emits_n_al_set_and_one_al_batch() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let mut v: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    v.push_back(a.clone());
+    v.push_back(b.clone());
+    v.push_back(c.clone());
+
+    client.set_investors_allowlisted(&v, &true);
+    let all = env.events().all();
+
+    // 3 al_set events + 1 al_batch = 4 events total.
+    assert_eq!(
+        all,
+        std::vec![
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: a,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: b,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: c,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistBatchApplied {
+                name: symbol_short!("al_batch"),
+                invoice_id,
+                batch_size: 3,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+        ]
+    );
+}
+
+// --- batch metadata: invoice_id, batch_size, allowed ---
+
+#[test]
+fn test_batch_event_metadata_allow() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let mut v: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    v.push_back(Address::generate(&env));
+    v.push_back(Address::generate(&env));
+
+    client.set_investors_allowlisted(&v, &true);
+    let all = env.events().all();
+    // Last event is the batch event — compare the full sequence.
+    let a0 = v.get(0).unwrap();
+    let a1 = v.get(1).unwrap();
+    assert_eq!(
+        all,
+        std::vec![
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: a0,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: a1,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistBatchApplied {
+                name: symbol_short!("al_batch"),
+                invoice_id,
+                batch_size: 2,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+        ]
+    );
+}
+
+#[test]
+fn test_batch_event_metadata_disallow() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let mut v: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    v.push_back(Address::generate(&env));
+    v.push_back(Address::generate(&env));
+    v.push_back(Address::generate(&env));
+
+    client.set_investors_allowlisted(&v, &false);
+    let all = env.events().all();
+    let a0 = v.get(0).unwrap();
+    let a1 = v.get(1).unwrap();
+    let a2 = v.get(2).unwrap();
+    assert_eq!(
+        all,
+        std::vec![
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: a0,
+                allowed: 0,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: a1,
+                allowed: 0,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: a2,
+                allowed: 0,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistBatchApplied {
+                name: symbol_short!("al_batch"),
+                invoice_id,
+                batch_size: 3,
+                allowed: 0,
+            }
+            .to_xdr(&env, &contract_id),
+        ]
+    );
+}
+
+// --- allow path ---
+
+#[test]
+fn test_batch_allow_flag_true() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let investor = Address::generate(&env);
+    let mut v: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    v.push_back(investor.clone());
+
+    client.set_investors_allowlisted(&v, &true);
+    let all = env.events().all();
+
+    assert_eq!(
+        all,
+        std::vec![
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: investor.clone(),
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistBatchApplied {
+                name: symbol_short!("al_batch"),
+                invoice_id,
+                batch_size: 1,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+        ]
+    );
+    assert!(client.is_investor_allowlisted(&investor));
+}
+
+// --- disallow path ---
+
+#[test]
+fn test_batch_allow_flag_false() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let investor = Address::generate(&env);
+    let mut v: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    v.push_back(investor.clone());
+
+    // First allow, then disallow via batch.
+    client.set_investors_allowlisted(&v, &true);
+
+    client.set_investors_allowlisted(&v, &false);
+    let all = env.events().all();
+
+    assert_eq!(
+        all,
+        std::vec![
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: investor.clone(),
+                allowed: 0,
+            }
+            .to_xdr(&env, &contract_id),
+            InvestorAllowlistBatchApplied {
+                name: symbol_short!("al_batch"),
+                invoice_id,
+                batch_size: 1,
+                allowed: 0,
+            }
+            .to_xdr(&env, &contract_id),
+        ]
+    );
+    assert!(!client.is_investor_allowlisted(&investor));
+}
+
+// --- large batch ---
+
+#[test]
+fn test_large_batch_per_investor_events_and_one_batch_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let cap = super::MAX_INVESTOR_ALLOWLIST_BATCH as usize;
+    let mut v: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    for _ in 0..cap {
+        v.push_back(Address::generate(&env));
+    }
+
+    client.set_investors_allowlisted(&v, &true);
+    let all = env.events().all();
+
+    // cap al_set events + 1 al_batch event.
+    let expected_total = cap + 1;
+    assert_eq!(all.events().len(), expected_total);
+
+    // Build expected event list: cap al_set events followed by one al_batch.
+    let mut expected: std::vec::Vec<soroban_sdk::xdr::ContractEvent> =
+        std::vec::Vec::with_capacity(expected_total);
+    for i in 0..cap {
+        expected.push(
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: v.get(i as u32).unwrap(),
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id),
+        );
+    }
+    expected.push(
+        InvestorAllowlistBatchApplied {
+            name: symbol_short!("al_batch"),
+            invoice_id,
+            batch_size: cap as u32,
+            allowed: 1,
+        }
+        .to_xdr(&env, &contract_id),
+    );
+
+    assert_eq!(all, expected);
+}
+
+// --- invariant preservation ---
+
+#[test]
+fn test_batch_produces_same_per_investor_events_as_individual_calls() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    // --- single-call path ---
+    let client1 = deploy(&env);
+    init(&env, &client1);
+    let contract_id1 = client1.address.clone();
+    let invoice_id = client1.get_escrow().invoice_id;
+
+    client1.set_investor_allowlisted(&a, &true);
+    let single_a_events = env.events().all();
+
+    client1.set_investor_allowlisted(&b, &true);
+    let single_b_events = env.events().all();
+
+    // --- batch path (new contract, same invoice id) ---
+    let client2 = deploy(&env);
+    let admin2 = Address::generate(&env);
+    let sme2 = Address::generate(&env);
+    let token2 = Address::generate(&env);
+    let treasury2 = Address::generate(&env);
+    client2.init(
+        &admin2,
+        &soroban_sdk::String::from_str(&env, "ALINV001"),
+        &sme2,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &token2,
+        &None,
+        &treasury2,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let contract_id2 = client2.address.clone();
+
+    let mut v: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    v.push_back(a.clone());
+    v.push_back(b.clone());
+    client2.set_investors_allowlisted(&v, &true);
+    let batch_events = env.events().all();
+
+    // The per-investor events from the batch match the shape of single-call events.
+    // Single-call path emits exactly the al_set event.
+    assert_eq!(
+        single_a_events,
+        std::vec![InvestorAllowlistChanged {
+            name: symbol_short!("al_set"),
+            invoice_id: invoice_id.clone(),
+            investor: a.clone(),
+            allowed: 1,
+        }
+        .to_xdr(&env, &contract_id1)]
+    );
+    assert_eq!(
+        single_b_events,
+        std::vec![InvestorAllowlistChanged {
+            name: symbol_short!("al_set"),
+            invoice_id: invoice_id.clone(),
+            investor: b.clone(),
+            allowed: 1,
+        }
+        .to_xdr(&env, &contract_id1)]
+    );
+
+    // Batch path emits the same per-investor events (same structure, different contract id)
+    // followed by one al_batch summary.
+    assert_eq!(
+        batch_events,
+        std::vec![
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: a,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id2),
+            InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: b,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id2),
+            InvestorAllowlistBatchApplied {
+                name: symbol_short!("al_batch"),
+                invoice_id,
+                batch_size: 2,
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id2),
+        ]
+    );
 }


### PR DESCRIPTION
Closes #379

## Summary

Adds a distinct `InvestorAllowlistBatchApplied` (`al_batch`) contract event emitted once per `set_investors_allowlisted` call, enabling indexers to distinguish batch allowlist operations from individual `set_investor_allowlisted` calls.

## Changes

- `escrow/src/lib.rs`: New `InvestorAllowlistBatchApplied` `#[contractevent]` struct with `al_batch` topic; emitted after the per-investor loop in `set_investors_allowlisted`
- `escrow/src/test_allowlist_tests.rs`: 9 new tests covering under-target behavior, single-element batch, multi-address batch, metadata (allow/disallow), large batch, and invariant preservation
- `docs/EVENT_SCHEMA.md`: Added `al_batch` to catalog, full topic/data layout, updated emission note, v0.5 changelog entry
- `docs/escrow-events.md`: Added `InvestorAllowlistBatchApplied` section with indexer and auditor guidance

## Test Results

- `cargo fmt --all -- --check`: passes for all modified files (pre-existing fmt diffs in unrelated files unchanged)
- `cargo build`: pre-existing E0081 duplicate discriminant in `EscrowError` (unrelated, present on `main` before this PR)
- `cargo test`: zero new errors introduced; all errors are pre-existing in unrelated files

## Security Notes

- Existing per-address `al_set` invariant preserved
- Existing authorization unchanged
- Existing `al_set` events preserved — purely additive change
- Exactly one `al_batch` event emitted per batch call
- No state changes introduced by the new event    closes #379