### PR TITLE
feat: add claim_payouts_batch and MAX_CLAIM_BATCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ cargo clippy --all-targets -- -D warnings
 | `settle` | Mark a funded escrow as settled (SME auth required; maturity enforced). |
 | `withdraw` | SME pulls funded liquidity (accounting record). |
 | `claim_investor_payout` | Investor records a payout claim after settlement. |
+| `claim_payouts_batch` | Batch-record payout claims for up to `MAX_CLAIM_BATCH` investors in one transaction. |
 | `sweep_terminal_dust` | Treasury sweeps rounding residue from a terminal escrow. |
 | `migrate` | Schema version gate — **typed errors on all paths** in the current release (codes 90–92). |
 | `set_legal_hold` | Admin activates/clears compliance hold. |

--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -131,7 +131,10 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 161 | `RotationNotOpen` | `rotate_beneficiary` | status not `0` (open) or `1` (funded) | Rotation only before settlement | typed |
 | 162 | `NewSmeSameAsCurrent` | `rotate_beneficiary` | `new_sme == current sme_address` | Pass a different beneficiary | typed |
 | 163 | `NoPendingAdmin` | `accept_admin` | no pending admin nomination stored | Call `propose_admin` first | typed |
-| 164 | `FundingDeadlinePassed` | `init`, `fund`, `fund_with_commitment`, `fund_batch` | `funding_deadline` configured and `ledger.timestamp()` past deadline | Funding window closed; do not retry deposits | typed |
+| 164 | `InsufficientContractBalance` | `withdraw` | contract balance < `funded_amount` at withdraw time | Fund the contract before withdraw | typed |
+| 165 | `ClaimBatchEmpty` | `claim_payouts_batch` | `investors` vec is empty | Pass at least one investor | typed |
+| 166 | `ClaimBatchTooLarge` | `claim_payouts_batch` | `investors` vec exceeds `MAX_CLAIM_BATCH` (32) | Split into smaller batches | typed |
+| 167 | `FundingDeadlinePassed` | `init`, `fund`, `fund_with_commitment`, `fund_batch` | `funding_deadline` configured and `ledger.timestamp()` past deadline | Funding window closed; do not retry deposits | typed |
 
 ### Legacy panic strings (migration aid)
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -145,6 +145,10 @@ pub const MAX_ATTESTATION_APPEND_ENTRIES: u32 = 32;
 /// Mirrors the spirit of `MAX_ATTESTATION_APPEND_ENTRIES` to limit per-call work.
 pub const MAX_INVESTOR_ALLOWLIST_BATCH: u32 = 32;
 
+/// Upper bound on [`LiquifactEscrow::claim_payouts_batch`] entries to keep CPU/storage bounded.
+/// Mirrors [`MAX_INVESTOR_ALLOWLIST_BATCH`] to limit per-call work.
+pub const MAX_CLAIM_BATCH: u32 = 32;
+
 /// Upper bound on [`LiquifactEscrow::fund_batch`] entries to keep storage/CPU bounded.
 /// Mirrors the spirit of `MAX_ATTESTATION_APPEND_ENTRIES` to limit per-call work.
 pub const MAX_FUND_BATCH: u32 = 50;
@@ -351,7 +355,7 @@ pub enum EscrowError {
     /// Computing the legal-hold clear ready-at timestamp would overflow.
     LegalHoldClearDelayOverflow = 152,
     /// Funding deadline has passed, new deposits are rejected.
-    FundingDeadlinePassed = 164,
+    FundingDeadlinePassed = 167,
 
     /// A legal hold blocks rotating the beneficiary (SME) address.
     LegalHoldBlocksBeneficiaryRotation = 160,
@@ -366,6 +370,11 @@ pub enum EscrowError {
     /// The contract's funding-token balance is less than `funded_amount` at withdraw time.
     /// Funds must be custodied in this contract before the SME can pull them.
     InsufficientContractBalance = 164,
+
+    /// [`LiquifactEscrow::claim_payouts_batch`] received an empty batch.
+    ClaimBatchEmpty = 165,
+    /// [`LiquifactEscrow::claim_payouts_batch`] exceeded [`MAX_CLAIM_BATCH`].
+    ClaimBatchTooLarge = 166,
 }
 
 #[inline(always)]
@@ -1731,6 +1740,24 @@ impl LiquifactEscrow {
         Self::get_persistent_investor_claimed(&env, investor)
     }
 
+    /// Returns `true` when [`LiquifactEscrow::settle`] would succeed for the current ledger state.
+    ///
+    /// Specifically: escrow status must be `1` (funded), no legal hold must be active,
+    /// and the configured maturity (if non-zero) must have been reached.
+    pub fn is_settleable(env: Env) -> bool {
+        if Self::legal_hold_active(&env) {
+            return false;
+        }
+        let escrow = Self::get_escrow(env.clone());
+        if escrow.status != 1 {
+            return false;
+        }
+        if escrow.maturity > 0 && env.ledger().timestamp() < escrow.maturity {
+            return false;
+        }
+        true
+    }
+
     /// Record or replace the optional SME collateral commitment metadata.
     ///
     /// **Metadata-only:** this writes [`DataKey::SmeCollateralPledge`] and emits
@@ -2201,11 +2228,7 @@ impl LiquifactEscrow {
         let n = entries.len();
 
         ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
-        ensure(
-            &env,
-            n <= MAX_FUND_BATCH,
-            EscrowError::FundingBatchTooLarge,
-        );
+        ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
 
         let mut escrow = Self::get_escrow(env.clone());
 
@@ -2663,6 +2686,78 @@ impl LiquifactEscrow {
             invoice_id: escrow.invoice_id.clone(),
         }
         .publish(&env);
+    }
+
+    /// Batch record payout claims for up to [`MAX_CLAIM_BATCH`] investors in a single transaction.
+    ///
+    /// Applies **identical** per-investor gates as [`LiquifactEscrow::claim_investor_payout`]:
+    /// legal-hold check (once, up front), settled-status gate, `not_before` lock, and idempotency.
+    /// Each investor must individually authorize their own claim via `require_auth()`.
+    ///
+    /// Already-claimed entries are **silently skipped** — they do not abort the batch.
+    /// One `InvestorPayoutClaimed` event is emitted per newly-claimed investor.
+    ///
+    /// # Errors
+    /// - [`EscrowError::LegalHoldBlocksInvestorClaims`] — hold active at call time.
+    /// - [`EscrowError::ClaimBatchEmpty`] — `investors` is empty.
+    /// - [`EscrowError::ClaimBatchTooLarge`] — `investors` exceeds [`MAX_CLAIM_BATCH`].
+    /// - [`EscrowError::InvestorClaimNotSettled`] — escrow not yet settled.
+    /// - Per-investor: [`EscrowError::NoContributionToClaim`], [`EscrowError::InvestorCommitmentLockNotExpired`].
+    pub fn claim_payouts_batch(env: Env, investors: Vec<Address>) {
+        // Legal-hold gate: checked once for the entire batch.
+        ensure(
+            &env,
+            !Self::legal_hold_active(&env),
+            EscrowError::LegalHoldBlocksInvestorClaims,
+        );
+
+        let n = investors.len();
+        ensure(&env, n > 0, EscrowError::ClaimBatchEmpty);
+        ensure(&env, n <= MAX_CLAIM_BATCH, EscrowError::ClaimBatchTooLarge);
+
+        // Settled-status gate: checked once; all investors share the same escrow state.
+        // env.clone(): env is reused for per-investor storage reads and event emission.
+        let escrow = Self::get_escrow(env.clone());
+        ensure(
+            &env,
+            escrow.status == 2,
+            EscrowError::InvestorClaimNotSettled,
+        );
+
+        let now = env.ledger().timestamp();
+
+        for i in 0..n {
+            let investor = investors.get(i).unwrap();
+
+            investor.require_auth();
+
+            let contribution: i128 =
+                Self::get_persistent_investor_contribution(&env, investor.clone());
+            ensure(&env, contribution > 0, EscrowError::NoContributionToClaim);
+
+            let not_before: u64 =
+                Self::get_persistent_investor_claim_not_before(&env, investor.clone());
+            ensure(
+                &env,
+                now >= not_before,
+                EscrowError::InvestorCommitmentLockNotExpired,
+            );
+
+            // Skip already-claimed entries — no error, no re-emit.
+            if Self::get_persistent_investor_claimed(&env, investor.clone()) {
+                continue;
+            }
+
+            // Mark before emit — prevents re-emission on any re-entrant path.
+            Self::set_persistent_investor_claimed(&env, investor.clone(), true);
+
+            InvestorPayoutClaimed {
+                name: symbol_short!("inv_claim"),
+                investor,
+                invoice_id: escrow.invoice_id.clone(),
+            }
+            .publish(&env);
+        }
     }
 
     /// On-chain read-only pro-rata gross payout for `investor`.

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -1,10 +1,10 @@
 use super::{
     free_addresses, install_stellar_asset_token, setup, MAX_ATTESTATION_APPEND_ENTRIES,
-    SCHEMA_VERSION,
+    MAX_CLAIM_BATCH, SCHEMA_VERSION,
 };
 use crate::{CollateralCommitmentSnapshot, DataKey, EscrowCloseSnapshot, EscrowError, YieldTier};
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
+    testutils::{Address as _, Events, Ledger},
     Address, BytesN, Env, Error, InvokeError, Vec as SorobanVec,
 };
 
@@ -201,10 +201,12 @@ fn escrow_error_discriminants_match_canonical_table() {
         (EscrowError::LegalHoldBlocksBeneficiaryRotation, 160),
         (EscrowError::RotationNotOpen, 161),
         (EscrowError::NewSmeSameAsCurrent, 162),
-        (EscrowError::FundingDeadlinePassed, 164),
+        (EscrowError::FundingDeadlinePassed, 167),
         (EscrowError::NoPendingAdmin, 163),
+        (EscrowError::ClaimBatchEmpty, 165),
+        (EscrowError::ClaimBatchTooLarge, 166),
     ];
-    assert_eq!(TABLE.len(), 84);
+    assert_eq!(TABLE.len(), 86);
     for (variant, code) in TABLE {
         assert_eq!(*variant as u32, *code, "discriminant drift for code {code}");
     }
@@ -2707,5 +2709,224 @@ fn test_is_settleable_after_partial_settle_with_maturity() {
     assert!(
         !client.is_settleable(),
         "settled escrow must not be settleable"
+    );
+}
+
+// ── claim_payouts_batch tests ────────────────────────────────────────────────
+
+/// Helper: init an escrow with a real token, fund N investors, settle, and
+/// return the client + investors vec.
+fn setup_settled_batch(
+    env: &Env,
+    n: usize,
+) -> (crate::LiquifactEscrowClient<'_>, SorobanVec<Address>) {
+    env.mock_all_auths();
+    let token = install_stellar_asset_token(env);
+    let sac = soroban_sdk::token::StellarAssetClient::new(env, &token.id);
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let treasury = Address::generate(env);
+
+    let client = super::deploy(env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, "BATCH"),
+        &sme,
+        &(n as i128 * 100),
+        &0i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let mut investors = SorobanVec::new(env);
+    for _ in 0..n {
+        let inv = Address::generate(env);
+        sac.mint(&client.address, &100);
+        client.fund(&inv, &100);
+        investors.push_back(inv);
+    }
+
+    env.ledger().with_mut(|li| li.timestamp = 200);
+    client.settle();
+    (client, investors)
+}
+
+#[test]
+fn claim_payouts_batch_equals_n_single_claims() {
+    let env = Env::default();
+    let (client, investors) = setup_settled_batch(&env, 3);
+
+    client.claim_payouts_batch(&investors);
+
+    // Every investor should now be marked claimed.
+    for i in 0..investors.len() {
+        let inv = investors.get(i).unwrap();
+        assert!(client.is_investor_claimed(&inv));
+    }
+}
+
+#[test]
+fn claim_payouts_batch_skips_already_claimed() {
+    let env = Env::default();
+    let (client, investors) = setup_settled_batch(&env, 2);
+
+    // Claim the first investor individually.
+    let first = investors.get(0).unwrap();
+    client.claim_investor_payout(&first);
+
+    // Batch claim both — second claim for first must be a silent no-op.
+    client.claim_payouts_batch(&investors);
+
+    assert!(client.is_investor_claimed(&investors.get(0).unwrap()));
+    assert!(client.is_investor_claimed(&investors.get(1).unwrap()));
+}
+
+#[test]
+fn claim_payouts_batch_rejects_empty() {
+    let env = Env::default();
+    let (client, _) = setup_settled_batch(&env, 1);
+
+    let empty: SorobanVec<Address> = SorobanVec::new(&env);
+    assert_contract_error(
+        client.try_claim_payouts_batch(&empty),
+        EscrowError::ClaimBatchEmpty,
+    );
+}
+
+#[test]
+fn claim_payouts_batch_rejects_oversized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (funding_token, treasury) = free_addresses(&env);
+    let (client, admin, sme) = setup(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "OVR"),
+        &sme,
+        &((MAX_CLAIM_BATCH as i128 + 1) * 10),
+        &0i64,
+        &0u64,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let mut oversized: SorobanVec<Address> = SorobanVec::new(&env);
+    for _ in 0..=(MAX_CLAIM_BATCH) {
+        oversized.push_back(Address::generate(&env));
+    }
+
+    assert_contract_error(
+        client.try_claim_payouts_batch(&oversized),
+        EscrowError::ClaimBatchTooLarge,
+    );
+}
+
+#[test]
+fn claim_payouts_batch_rejects_legal_hold() {
+    let env = Env::default();
+    let (client, investors) = setup_settled_batch(&env, 1);
+    client.set_legal_hold(&true);
+
+    assert_contract_error(
+        client.try_claim_payouts_batch(&investors),
+        EscrowError::LegalHoldBlocksInvestorClaims,
+    );
+}
+
+#[test]
+fn claim_payouts_batch_rejects_not_settled() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (funding_token, treasury) = free_addresses(&env);
+    let (client, admin, sme) = setup(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "NS"),
+        &sme,
+        &100,
+        &0i64,
+        &0u64,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let investor = Address::generate(&env);
+    client.fund(&investor, &10);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(investor);
+
+    assert_contract_error(
+        client.try_claim_payouts_batch(&batch),
+        EscrowError::InvestorClaimNotSettled,
+    );
+}
+
+#[test]
+fn claim_payouts_batch_rejects_locked_investor() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let token = install_stellar_asset_token(&env);
+    let sac = soroban_sdk::token::StellarAssetClient::new(&env, &token.id);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    let client = super::deploy(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "LOCK"),
+        &sme,
+        &100,
+        &0i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let investor = Address::generate(&env);
+    sac.mint(&client.address, &100);
+    // Fund with a long lock — 3600s from timestamp=12345.
+    client.fund_with_commitment(&investor, &100, &3600);
+
+    // Settle at t=200 (before lock expires).
+    env.ledger().with_mut(|li| li.timestamp = 200);
+    client.settle();
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(investor);
+
+    assert_contract_error(
+        client.try_claim_payouts_batch(&batch),
+        EscrowError::InvestorCommitmentLockNotExpired,
     );
 }

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -831,14 +831,14 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
 /// Helper: deploy, init with a real SAC token, fund to `target`, and mint
 /// `target` tokens into the escrow contract.  Returns
 /// `(client, escrow_id, token_client, sme)`.
-fn setup_withdraw_with_token(
-    env: &Env,
+fn setup_withdraw_with_token<'a>(
+    env: &'a Env,
     target: i128,
-    invoice_id: &str,
+    invoice_id: &'a str,
 ) -> (
-    LiquifactEscrowClient<'_>,
+    LiquifactEscrowClient<'a>,
     soroban_sdk::Address,
-    soroban_sdk::token::TokenClient<'_>,
+    soroban_sdk::token::TokenClient<'a>,
     soroban_sdk::Address,
 ) {
     use crate::LiquifactEscrow;
@@ -890,12 +890,14 @@ fn withdraw_transfers_funded_amount_to_sme() {
     env.mock_all_auths();
 
     let target = 50_000_000i128;
-    let (client, escrow_id, token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_BAL001");
+    let (client, escrow_id, token, sme) = setup_withdraw_with_token(&env, target, "WD_BAL001");
 
     let sme_before = token.balance(&sme);
     let contract_before = token.balance(&escrow_id);
-    assert_eq!(contract_before, target, "escrow must hold exactly funded_amount before withdraw");
+    assert_eq!(
+        contract_before, target,
+        "escrow must hold exactly funded_amount before withdraw"
+    );
 
     client.withdraw();
 
@@ -911,7 +913,11 @@ fn withdraw_transfers_funded_amount_to_sme() {
         contract_after, 0,
         "escrow contract balance must be zero after disbursement"
     );
-    assert_eq!(client.get_escrow().status, 3u32, "status must be 3 after withdraw");
+    assert_eq!(
+        client.get_escrow().status,
+        3u32,
+        "status must be 3 after withdraw"
+    );
 }
 
 /// `withdraw` increments `DistributedPrincipal` by `funded_amount`.
@@ -921,8 +927,7 @@ fn withdraw_updates_distributed_principal() {
     env.mock_all_auths();
 
     let target = 20_000_000i128;
-    let (client, _escrow_id, _token, _sme) =
-        setup_withdraw_with_token(&env, target, "WD_DP001");
+    let (client, _escrow_id, _token, _sme) = setup_withdraw_with_token(&env, target, "WD_DP001");
 
     client.withdraw();
 
@@ -1058,8 +1063,7 @@ fn withdraw_event_includes_recipient() {
     env.mock_all_auths();
 
     let target = 5_000_000i128;
-    let (client, escrow_id, _token, sme) =
-        setup_withdraw_with_token(&env, target, "WD_EV001");
+    let (client, escrow_id, _token, sme) = setup_withdraw_with_token(&env, target, "WD_EV001");
 
     client.withdraw();
 
@@ -1074,9 +1078,9 @@ fn withdraw_event_includes_recipient() {
     .to_xdr(&env, &escrow_id);
 
     let all_events = env.events().all().filter_by_contract(&escrow_id);
-    let found = all_events
-        .events()
-        .iter()
-        .any(|e| *e == expected_xdr);
-    assert!(found, "SmeWithdrew event with correct recipient and amount must be emitted");
+    let found = all_events.events().iter().any(|e| *e == expected_xdr);
+    assert!(
+        found,
+        "SmeWithdrew event with correct recipient and amount must be emitted"
+    );
 }

--- a/escrow/src/tests/properties.rs
+++ b/escrow/src/tests/properties.rs
@@ -33,7 +33,6 @@ proptest! {
             &None,
             &None,
             &None,
-            &None,
         );
 
         let before = client.get_escrow().funded_amount;
@@ -70,7 +69,6 @@ proptest! {
             &Address::generate(&env),
             &None,
             &Address::generate(&env),
-            &None,
             &None,
             &None,
             &None,


### PR DESCRIPTION
closes #317 
closes #334
  
   - Add MAX_CLAIM_BATCH = 32 constant
- Add ClaimBatchEmpty (165) and ClaimBatchTooLarge (166) error variants
- Implement claim_payouts_batch: legal-hold gate once, settled-status gate, per-investor auth + contribution + not_before + idempotency (skip claimed)
- Add is_settleable view function
- Fix duplicate discriminant: FundingDeadlinePassed reassigned to 167
- Add comprehensive tests: batch==N singles, skip-claimed, empty, oversized, legal-hold, not-settled, locked investor
- Update README entrypoint table and error-messages docs
- Fix pre-existing compile errors (lifetime, 16-arg init, missing Events import)

Closes #11