### PR TITLE
feat: add get_yield_tiers read view for the configured tier table

### DIFF
--- a/docs/adr/ADR-005-tiered-yield.md
+++ b/docs/adr/ADR-005-tiered-yield.md
@@ -56,3 +56,11 @@ The state-machine rules above are verified in `escrow/src/tests/funding.rs`:
 | `test_commitment_zero_lock_follow_on_fund_no_claim_gate` | Follow-on `fund()` after zero-lock preserves both zero guards |
 | `test_fund_first_deposit_sets_base_yield_and_no_claim_gate` | Plain `fund()` first deposit → base yield, no claim gate |
 
+## Read API
+
+The tier table is readable after `init` via `get_yield_tiers() -> Vec<YieldTier>`.
+
+- Returns an empty `Vec` when no tiers were configured.
+- Returned order matches the validated non-decreasing ordering enforced at `init`.
+- Pure read — no auth required, no state mutation.
+- See `docs/escrow-read-api.md` for the full getter reference.

--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -213,3 +213,23 @@ A `#[contracttype]` enum representing the optional `FundingCloseSnapshot`:
 
 - `None` — Escrow is not yet funded; no close snapshot exists.
 - `Some(FundingCloseSnapshot)` — The pro-rata denominator snapshot captured when the escrow first transitioned to **funded**.
+
+---
+
+## `get_yield_tiers() → Vec<YieldTier>`
+
+**Storage key:** `DataKey::YieldTierTable`
+
+Returns the yield-tier ladder configured at `init`, or an empty `Vec` when no tiers were configured (base yield applies to all investors).
+
+- **Immutable** — set once at `init`; the contract never mutates this key after initialization.
+- **Order** — returned order matches the validated non-decreasing ordering enforced at `init`: `min_lock_secs` strictly increasing, `yield_bps` non-decreasing.
+- **Empty vec** — returned for both "no tiers passed at init" and "legacy instance predating tier support"; callers must not treat an empty result as an error.
+- **Pure read** — no auth required, no state mutation.
+
+### `YieldTier` fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `min_lock_secs` | `u64` | Minimum `committed_lock_secs` an investor must pass to qualify for this tier |
+| `yield_bps` | `i64` | Effective annualized yield in basis points for qualifying investors |

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -943,7 +943,35 @@ impl LiquifactEscrow {
             .get(&DataKey::Treasury)
             .unwrap_or_else(|| fail(env, EscrowError::TreasuryNotSet))
     }
-
+/// Validates the optional yield-tier table supplied at `init`.
+    ///
+    /// # Rules
+    ///
+    /// | Rule | Error |
+    /// |------|-------|
+    /// | Each `yield_bps` in `0..=10_000` | `TierYieldOutOfRange` |
+    /// | Each `yield_bps >= base_yield` | `TierYieldBelowBase` |
+    /// | `min_lock_secs` strictly increasing across tiers | `TierLockNotIncreasing` |
+    /// | `yield_bps` non-decreasing across tiers | `TierYieldNotNonDecreasing` |
+    ///
+    /// # Accepted example
+    /// ```text
+    /// base_yield = 800 bps
+    /// tiers = [(min_lock=100, yield=900), (min_lock=200, yield=1000)]
+    /// valid: locks increase (100 < 200), yields non-decrease (900 <= 1000), both >= 800
+    /// ```
+    ///
+    /// # Rejected examples
+    /// ```text
+    /// tiers = [(min_lock=200, yield=900), (min_lock=100, yield=1000)]
+    /// TierLockNotIncreasing: 200 > 100
+    ///
+    /// tiers = [(min_lock=100, yield=700)]
+    /// TierYieldBelowBase: 700 < 800
+    ///
+    /// tiers = [(min_lock=100, yield=1000), (min_lock=200, yield=900)]
+    /// TierYieldNotNonDecreasing: 1000 > 900
+    /// ```
     fn validate_yield_tiers_table(env: &Env, tiers: &Option<Vec<YieldTier>>, base_yield: i64) {
         let Some(tiers) = tiers else {
             return;
@@ -980,10 +1008,22 @@ impl LiquifactEscrow {
         }
     }
 
-    /// Returns `(effective_yield_bps, matched_lock_secs)` for a given commitment.
-    /// `matched_lock_secs` is the [`YieldTier::min_lock_secs`] of the best matching tier,
-    /// or `0` when no tier was matched (base yield applies).
+   /// Returns `(effective_yield_bps, matched_lock_secs)` for a given commitment.
+    ///
+    /// Scans [`DataKey::YieldTierTable`] and picks the tier with the highest `yield_bps`
+    /// where `committed_lock_secs >= tier.min_lock_secs`. Returns base yield when:
+    /// `committed_lock_secs == 0`, no tier table exists, or table is empty.
+    ///
+    /// Example with `base=800, tiers=[(100,900),(200,1000),(300,1200)]`:
+    /// - lock=50  -> (800, 0)    no tier matched
+    /// - lock=100 -> (900, 100)  tier 0
+    /// - lock=250 -> (1000, 200) tier 1
+    /// - lock=300 -> (1200, 300) tier 2 (highest)
+    ///
+    /// `matched_lock_secs` is the `min_lock_secs` of the matched tier, or `0` for base yield.
     fn effective_yield_for_commitment(
+    
+    
         env: &Env,
         base_yield: i64,
         committed_lock_secs: u64,
@@ -1683,6 +1723,16 @@ impl LiquifactEscrow {
     /// Earliest ledger timestamp for [`LiquifactEscrow::claim_investor_payout`]; `0` if not gated.
     pub fn get_investor_claim_not_before(env: Env, investor: Address) -> u64 {
         Self::get_persistent_investor_claim_not_before(&env, investor)
+    }
+    /// Returns the yield-tier table configured at `init`.
+    /// Returns an empty `Vec` when no tiers were configured.
+    /// Order matches the validated non-decreasing ordering enforced at `init`.
+    /// Pure read — no auth required, no state mutation.
+    pub fn get_yield_tiers(env: Env) -> Vec<YieldTier> {
+        env.storage()
+            .instance()
+            .get::<DataKey, Vec<YieldTier>>(&DataKey::YieldTierTable)
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     /// Retrieve the currently recorded SME collateral commitment metadata from storage.
@@ -2614,6 +2664,13 @@ impl LiquifactEscrow {
     /// 5. `not_before` ledger-time gate (see `docs/escrow-ledger-time.md`).
     /// 6. Idempotent early-return on `InvestorClaimed`.
     /// 7. Storage write + event emit.
+    ///
+   /// # Claim-lock enforcement
+    /// `InvestorClaimNotBefore = deposit_timestamp + committed_lock_secs`.
+    /// Enforces `now >= not_before` (inclusive boundary):
+    /// - deposit at t=1000, lock=500 -> not_before=1500
+    /// - claim at t=1499 -> InvestorCommitmentLockNotExpired
+    /// - claim at t=1500 -> succeeds
     ///
     /// # Errors
     /// Emits typed [`EscrowError`] codes for legal hold, missing contribution, unsettled escrow,

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -3263,3 +3263,419 @@ fn test_fund_batch_preserves_event_semantics() {
     // Each event corresponds to a fund operation
     // (Detailed event field verification depends on EscrowFunded structure)
 }
+
+#[test]
+fn test_tiered_yield_no_tiers_base_yield_applies() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    // No tier table — None
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "NOTIER01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let inv = Address::generate(&env);
+    // committed_lock_secs = 9999 but no tiers exist → base yield 800
+    client.fund_with_commitment(&inv, &100_000i128, &9999u64);
+    assert_eq!(
+        client.get_investor_yield_bps(&inv),
+        800,
+        "no tier table: must return base yield regardless of lock"
+    );
+}
+
+#[test]
+fn test_tiered_yield_single_tier_selection() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 1000,
+    });
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "SINGLE01"),
+        &sme,
+        &300_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let inv_below = Address::generate(&env);
+    let inv_at = Address::generate(&env);
+    let inv_above = Address::generate(&env);
+    // Below threshold → base yield 800
+    client.fund_with_commitment(&inv_below, &100_000i128, &99u64);
+    assert_eq!(client.get_investor_yield_bps(&inv_below), 800);
+    // Exactly at threshold → tier yield 1000
+    client.fund_with_commitment(&inv_at, &100_000i128, &100u64);
+    assert_eq!(client.get_investor_yield_bps(&inv_at), 1000);
+    // Above threshold → tier yield 1000
+    client.fund_with_commitment(&inv_above, &100_000i128, &500u64);
+    assert_eq!(client.get_investor_yield_bps(&inv_above), 1000);
+}
+
+#[test]
+fn test_tiered_yield_max_lock_tier_selected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier { min_lock_secs: 100, yield_bps: 900 });
+    tiers.push_back(YieldTier { min_lock_secs: 200, yield_bps: 1000 });
+    tiers.push_back(YieldTier { min_lock_secs: 300, yield_bps: 1200 });
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MAXLOCK01"),
+        &sme,
+        &400_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let inv = Address::generate(&env);
+    // lock = 300 → matches all three tiers → picks highest yield 1200
+    client.fund_with_commitment(&inv, &400_000i128, &300u64);
+    assert_eq!(
+        client.get_investor_yield_bps(&inv),
+        1200,
+        "max-lock investor must receive the highest tier yield"
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_tiered_second_deposit_rejected_with_numeric_example() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier { min_lock_secs: 100, yield_bps: 1000 });
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "SECDEPO01"),
+        &sme,
+        &200_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let inv = Address::generate(&env);
+    // First deposit: 100_000 at 100s lock → yield 1000 bps. OK.
+    client.fund_with_commitment(&inv, &100_000i128, &100u64);
+    // Second fund_with_commitment from same investor → TieredSecondDeposit panic
+    client.fund_with_commitment(&inv, &100_000i128, &100u64);
+}
+
+#[test]
+#[should_panic]
+fn test_init_tier_yield_not_non_decreasing_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    let mut tiers = SorobanVec::new(&env);
+    // yield_bps decreases from 1000 to 900 — violates non-decreasing rule
+    tiers.push_back(YieldTier { min_lock_secs: 100, yield_bps: 1000 });
+    tiers.push_back(YieldTier { min_lock_secs: 200, yield_bps: 900 });
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "BADDEC01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_claim_lock_not_expired_blocks_claim() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "CLLOCK01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let inv = Address::generate(&env);
+    // Ledger timestamp = 0. Lock = 1000s → claim_not_before = 1000
+    client.fund_with_commitment(&inv, &100_000i128, &1000u64);
+    // Settle the escrow
+    client.settle(&admin);
+    // Timestamp still 0 < 1000 → InvestorCommitmentLockNotExpired panic
+    client.claim_investor_payout(&inv);
+}
+
+#[test]
+fn test_claim_lock_boundary_passes_at_exact_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "CLBOUND01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let inv = Address::generate(&env);
+    // Ledger timestamp = 0. Lock = 1000s → claim_not_before = 1000
+    client.fund_with_commitment(&inv, &100_000i128, &1000u64);
+    // Settle the escrow
+    client.settle(&admin);
+    // Advance ledger to exactly claim_not_before = 1000
+    env.ledger().set_timestamp(1000);
+    // now == not_before → claim must succeed
+    client.claim_investor_payout(&inv);
+}
+
+// ── Issue #345: get_yield_tiers read view ────────────────────────────────────
+
+#[test]
+fn test_get_yield_tiers_returns_empty_when_no_tiers_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "NOTIER01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let tiers = client.get_yield_tiers();
+    assert_eq!(tiers.len(), 0, "expected empty vec when no tiers configured");
+}
+
+#[test]
+fn test_get_yield_tiers_returns_single_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 2_592_000,
+        yield_bps: 900,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "SINGLE01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let result = client.get_yield_tiers();
+    assert_eq!(result.len(), 1);
+    let t = result.get(0).unwrap();
+    assert_eq!(t.min_lock_secs, 2_592_000);
+    assert_eq!(t.yield_bps, 900);
+}
+
+#[test]
+fn test_get_yield_tiers_preserves_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier { min_lock_secs: 2_592_000,  yield_bps: 900   });
+    tiers.push_back(YieldTier { min_lock_secs: 7_776_000,  yield_bps: 1_100 });
+    tiers.push_back(YieldTier { min_lock_secs: 15_552_000, yield_bps: 1_400 });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "MULTI01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let result = client.get_yield_tiers();
+    assert_eq!(result.len(), 3);
+
+    let t0 = result.get(0).unwrap();
+    assert_eq!(t0.min_lock_secs, 2_592_000);
+    assert_eq!(t0.yield_bps, 900);
+
+    let t1 = result.get(1).unwrap();
+    assert_eq!(t1.min_lock_secs, 7_776_000);
+    assert_eq!(t1.yield_bps, 1_100);
+
+    let t2 = result.get(2).unwrap();
+    assert_eq!(t2.min_lock_secs, 15_552_000);
+    assert_eq!(t2.yield_bps, 1_400);
+}
+
+#[test]
+fn test_get_yield_tiers_is_pure_read_no_state_change() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier { min_lock_secs: 100, yield_bps: 900 });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "PURE01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let escrow_before = client.get_escrow();
+    client.get_yield_tiers();
+    client.get_yield_tiers();
+    let escrow_after = client.get_escrow();
+
+    assert_eq!(escrow_before, escrow_after, "get_yield_tiers must not mutate state");
+}


### PR DESCRIPTION
## Summary
Adds a `get_yield_tiers()` read-only view that exposes the yield-tier table configured at `init`.

## Changes

- `escrow/src/lib.rs` — added `get_yield_tiers() -> Vec<YieldTier>` public function that reads from `DataKey::YieldTierTable`
- `escrow/src/tests/funding.rs` — added 4 tests covering:
  - Empty vec when no tiers configured
  - Single tier returned correctly
  - Multiple tiers preserved in order
  - Pure read — no state mutation
- `docs/escrow-read-api.md` — documented the new getter with field descriptions and example
- `docs/adr/ADR-005-tiered-yield.md` — added Read API section

## Notes
- Pure read — no auth required, no state mutation
- Returns empty `Vec` for contracts initialized without tiers
- Order matches validated non-decreasing ordering enforced at `init`