### PR TITLE
refactor: extract unique-funder-count into shared helper and add update_legal_hold_clear_delay

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -440,6 +440,9 @@ pub enum EscrowError {
     /// The contract's funding-token balance is less than `funded_amount` at withdraw time.
     /// Funds must be custodied in this contract before the SME can pull them.
     InsufficientContractBalance = 165,
+    /// [`LiquifactEscrow::update_legal_hold_clear_delay`] was called while a clear request
+    /// was pending ([`DataKey::LegalHoldClearableAt`] is set).
+    LegalHoldClearPendingUpdateRejected = 166,
 }
 
 #[inline(always)]
@@ -908,6 +911,16 @@ pub struct LegalHoldClearRequested {
     pub invoice_id: Symbol,
     /// Inclusive ledger timestamp when clearing may occur.
     pub clearable_at: u64,
+}
+
+#[contractevent]
+pub struct LegalHoldClearDelayUpdated {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub old_delay: u64,
+    pub new_delay: u64,
 }
 
 /// SME collateral commitment metadata recorded.
@@ -2473,6 +2486,43 @@ impl LiquifactEscrow {
         .publish(&env);
     }
 
+    /// Update the legal-hold clear delay after init. Rejects the update while a clear
+    /// request is pending ([`DataKey::LegalHoldClearableAt`] set) so an admin cannot
+    /// shorten the timelock to bypass an active waiting period.
+    ///
+    /// # Authorization
+    /// [`InvoiceEscrow::admin`].
+    ///
+    /// # Errors
+    ///
+    /// | Condition | Typed error |
+    /// |-----------|-------------|
+    /// | `LegalHoldClearableAt` is set (clear request pending) | [`EscrowError::LegalHoldClearPendingUpdateRejected`] |
+    pub fn update_legal_hold_clear_delay(env: Env, new_delay: u64) {
+        let escrow = Self::load_escrow_require_admin(&env);
+
+        ensure(
+            &env,
+            !env.storage()
+                .instance()
+                .has(&DataKey::LegalHoldClearableAt),
+            EscrowError::LegalHoldClearPendingUpdateRejected,
+        );
+
+        let old_delay = Self::get_legal_hold_clear_delay(env.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::LegalHoldClearDelay, &new_delay);
+
+        LegalHoldClearDelayUpdated {
+            name: symbol_short!("lh_del"),
+            invoice_id: escrow.invoice_id.clone(),
+            old_delay,
+            new_delay,
+        }
+        .publish(&env);
+    }
+
     /// Enable or disable the investor allowlist gate.
     ///
     /// When enabled (active = true), only addresses with [`DataKey::InvestorAllowlisted`] set to
@@ -2993,6 +3043,30 @@ impl LiquifactEscrow {
         escrow
     }
 
+    fn increment_unique_funder(env: &Env, prev: i128) -> u32 {
+        if prev == 0 {
+            let cur: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::UniqueFunderCount)
+                .unwrap_or(0);
+            if let Some(cap) = env
+                .storage()
+                .instance()
+                .get::<DataKey, u32>(&DataKey::MaxUniqueInvestorsCap)
+            {
+                ensure(env, cur < cap, EscrowError::UniqueInvestorCapReached);
+            }
+            let new_count = cur + 1;
+            env.storage()
+                .instance()
+                .set(&DataKey::UniqueFunderCount, &new_count);
+            new_count
+        } else {
+            0
+        }
+    }
+
     fn fund_impl(
         env: Env,
         investor: Address,
@@ -3056,28 +3130,7 @@ impl LiquifactEscrow {
             );
         }
 
-        let cur_funder_count: u32 = if prev == 0 {
-            env.storage()
-                .instance()
-                .get(&DataKey::UniqueFunderCount)
-                .unwrap_or(0)
-        } else {
-            0
-        };
-
-        if prev == 0 {
-            if let Some(cap) = env
-                .storage()
-                .instance()
-                .get::<DataKey, u32>(&DataKey::MaxUniqueInvestorsCap)
-            {
-                ensure(
-                    &env,
-                    cur_funder_count < cap,
-                    EscrowError::UniqueInvestorCapReached,
-                );
-            }
-        }
+        let _cur_funder_count = Self::increment_unique_funder(&env, prev);
 
         let investor_effective_yield_bps: i64;
         let tier_lock_secs: u64;
@@ -3163,11 +3216,6 @@ impl LiquifactEscrow {
             env.storage()
                 .instance()
                 .set(&DataKey::InvestorIndex, &index);
-
-            // Use the hoisted cur_funder_count; no second storage read needed.
-            env.storage()
-                .instance()
-                .set(&DataKey::UniqueFunderCount, &(cur_funder_count + 1));
         }
 
         escrow.status = next_status;

--- a/escrow/src/tests/legal_hold.rs
+++ b/escrow/src/tests/legal_hold.rs
@@ -940,3 +940,66 @@ fn recovery_new_admin_clears_hold_and_operations_resume() {
     client.claim_investor_payout(&investor);
     assert!(client.is_investor_claimed(&investor));
 }
+
+// ── update_legal_hold_clear_delay ─────────────────────────────────────────────
+
+#[test]
+fn update_legal_hold_clear_delay_by_admin_succeeds() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "LHUPD001");
+    assert_eq!(client.get_legal_hold_clear_delay(), 0u64);
+    client.update_legal_hold_clear_delay(&86_400u64);
+    assert_eq!(client.get_legal_hold_clear_delay(), 86_400u64);
+}
+
+#[test]
+#[should_panic]
+fn update_legal_hold_clear_delay_by_non_admin_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "LHUPD002");
+    env.mock_auths(&[]);
+    client.update_legal_hold_clear_delay(&86_400u64);
+}
+
+#[test]
+fn update_legal_hold_clear_delay_rejects_during_pending_clear() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open_with_clear_delay(
+        &client,
+        &env,
+        &admin,
+        &sme,
+        "LHUPD003",
+        Some(86_400u64),
+    );
+    client.set_legal_hold(&true);
+    client.request_clear_legal_hold();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.update_legal_hold_clear_delay(&3_600u64);
+    }));
+    assert!(
+        result.is_err(),
+        "update must be rejected while clear is pending"
+    );
+}
+
+#[test]
+fn update_legal_hold_clear_delay_before_request_allows_new_delay_to_take_effect() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "LHUPD004");
+    client.update_legal_hold_clear_delay(&100u64);
+    assert_eq!(client.get_legal_hold_clear_delay(), 100u64);
+    client.set_legal_hold(&true);
+    client.request_clear_legal_hold();
+    let clearable_at = client.get_legal_hold_clearable_at().unwrap();
+    let now = env.ledger().timestamp();
+    assert!(
+        clearable_at >= now + 100,
+        "clearable_at must reflect the updated delay"
+    );
+}
+


### PR DESCRIPTION
## Summary

This PR implements two improvements:

### 1. Shared unique-funder-count helper (Closes #487)
Extracts the repeated new-investor detection, `MaxUniqueInvestorsCap` enforcement, and `UniqueFunderCount` increment into a single `increment_unique_funder` helper. All deposit paths (`fund`, `fund_with_commitment`, `fund_batch`) transitively use the same logic through `fund_impl`, eliminating the risk of divergent accounting.

### 2. Admin entrypoint for legal-hold clear delay (Closes #469)
Adds `update_legal_hold_clear_delay(env, new_delay)` gated by admin auth:
- Rejects the update while a clear request is pending (`LegalHoldClearableAt` set) via new error `LegalHoldClearPendingUpdateRejected = 166`
- Emits `LegalHoldClearDelayUpdated` event with old and new delay
- Updates the stored `LegalHoldClearDelay` which is read by `request_clear_legal_hold`

### Security notes
- The cap cannot be bypassed via any deposit path since all paths route through `fund_impl` which calls the shared helper
- An in-flight clear cannot be accelerated by changing the delay: `update_legal_hold_clear_delay` rejects while `LegalHoldClearableAt` is set
- The existing two-phase clear semantics (`request_clear_legal_hold` -> wait -> `set_legal_hold(false)`) are preserved

### Testing
- Added 4 new tests in `tests/legal_hold.rs` covering admin success, non-admin rejection, pending-clear rejection, and delay-takes-effect ordering
- Existing unique-funder-count tests in `tests/cap_validation.rs` continue to pass unchanged

Closes #487
Closes #469