### PR TITLE
feat: add paginated allowlist enumeration and sweep liability-floor tests

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -208,6 +208,9 @@ pub const MAX_FUND_BATCH: u32 = 50;
 /// Caps blast radius if instrumentation mis-estimates “dust”; tune per asset decimals off-chain.
 pub const MAX_DUST_SWEEP_AMOUNT: i128 = 100_000_000;
 
+/// Upper bound on [`LiquifactEscrow::set_investors_allowlisted`] entries to keep storage bounded.
+pub const MAX_INVESTOR_ALLOWLIST_BATCH: u32 = 32;
+
 /// Maximum UTF-8 byte length for the invoice `String` at init (matches Soroban [`Symbol`] max).
 pub const MAX_INVOICE_ID_STRING_LEN: u32 = 32;
 
@@ -582,6 +585,10 @@ pub enum DataKey {
     AllowlistActive,
     /// Whether a specific address is permitted to fund when [`DataKey::AllowlistActive`] is true.
     InvestorAllowlisted(Address),
+    /// Index of allowlisted addresses for paginated enumeration.
+    /// Updated atomically with each `set_investor_allowlisted` / `set_investors_allowlisted` call.
+    /// Revoked addresses are removed so enumeration always reflects live state.
+    AllowlistIndex,
     /// Set to `true` once an investor's principal has been refunded in a cancelled escrow.
     /// Absent ⇒ `false`. Written once; prevents double-refund.
     InvestorRefunded(Address),
@@ -2564,9 +2571,39 @@ impl LiquifactEscrow {
     /// - [`docs/escrow-allowlist.md`](../docs/escrow-allowlist.md) — full allowlist model documentation
     pub fn set_investor_allowlisted(env: Env, investor: Address, allowed: bool) {
         let escrow = Self::load_escrow_require_admin(&env);
+
+        let was_allowlisted: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::InvestorAllowlisted(investor.clone()))
+            .unwrap_or(false);
+
         env.storage()
             .persistent()
             .set(&DataKey::InvestorAllowlisted(investor.clone()), &allowed);
+
+        // Maintain the allowlist index
+        let mut index: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllowlistIndex)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        if allowed && !was_allowlisted {
+            index.push_back(investor.clone());
+        } else if !allowed && was_allowlisted {
+            // Remove from index by position
+            for i in 0..index.len() {
+                if index.get(i).unwrap() == investor {
+                    index.remove(i);
+                    break;
+                }
+            }
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::AllowlistIndex, &index);
 
         InvestorAllowlistChanged {
             name: symbol_short!("al_set"),
@@ -2621,12 +2658,36 @@ impl LiquifactEscrow {
             EscrowError::InvestorBatchTooLarge,
         );
 
-        // Iterate and perform per-address persistent storage write and event emission.
+        // Load index once for the entire batch
+        let mut index: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllowlistIndex)
+            .unwrap_or_else(|| Vec::new(&env));
+
         for i in 0..n {
             let inv = investors.get(i).unwrap();
+
+            let was_allowlisted: bool = env
+                .storage()
+                .persistent()
+                .get(&DataKey::InvestorAllowlisted(inv.clone()))
+                .unwrap_or(false);
+
             env.storage()
                 .persistent()
                 .set(&DataKey::InvestorAllowlisted(inv.clone()), &allowed);
+
+            if allowed && !was_allowlisted {
+                index.push_back(inv.clone());
+            } else if !allowed && was_allowlisted {
+                for j in 0..index.len() {
+                    if index.get(j).unwrap() == inv {
+                        index.remove(j);
+                        break;
+                    }
+                }
+            }
 
             InvestorAllowlistChanged {
                 name: symbol_short!("al_set"),
@@ -2636,6 +2697,10 @@ impl LiquifactEscrow {
             }
             .publish(&env);
         }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::AllowlistIndex, &index);
 
         // Emit exactly one batch-level summary event so indexers can distinguish a
         // batch call from N individual `set_investor_allowlisted` calls.
@@ -2672,6 +2737,74 @@ impl LiquifactEscrow {
             .persistent()
             .get(&DataKey::InvestorAllowlisted(investor))
             .unwrap_or(false)
+    }
+
+    /// Returns a paginated list of allowlisted investor addresses.
+    ///
+    /// Reads the allowlist index and filters by live `InvestorAllowlisted` status
+    /// so revoked addresses never appear in the result.
+    ///
+    /// # Arguments
+    /// * `start` - The starting index (0-based) of the pagination.
+    /// * `limit` - The maximum number of addresses to return (capped at a hard limit of 50).
+    ///
+    /// # Returns
+    /// A `Vec<Address>` containing the allowlisted addresses within the requested page.
+    pub fn get_allowlisted_investors(env: Env, start: u32, limit: u32) -> Vec<Address> {
+        let index: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllowlistIndex)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let len = index.len();
+        if start >= len || limit == 0 {
+            return Vec::new(&env);
+        }
+
+        let actual_limit = limit.min(50);
+        let end = (start + actual_limit).min(len);
+
+        let mut result = Vec::new(&env);
+        for i in start..end {
+            let addr = index.get(i).unwrap();
+            // Only include addresses that are still allowlisted
+            let is_al: bool = env
+                .storage()
+                .persistent()
+                .get(&DataKey::InvestorAllowlisted(addr.clone()))
+                .unwrap_or(false);
+            if is_al {
+                result.push_back(addr);
+            }
+        }
+        result
+    }
+
+    /// Returns the total number of currently-allowlisted addresses.
+    ///
+    /// Reads the allowlist index and counts entries where the live
+    /// `InvestorAllowlisted` flag is still `true`.
+    pub fn get_allowlisted_investors_count(env: Env) -> u32 {
+        let index: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllowlistIndex)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut count: u32 = 0;
+        for i in 0..index.len() {
+            let addr = index.get(i).unwrap();
+            let is_al: bool = env
+                .storage()
+                .persistent()
+                .get(&DataKey::InvestorAllowlisted(addr.clone()))
+                .unwrap_or(false);
+            if is_al {
+                count += 1;
+            }
+        }
+        count
     }
 
     /// Convenience alias for [`LiquifactEscrow::set_legal_hold`] with `active = false`.

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -954,3 +954,223 @@ fn test_batch_produces_same_per_investor_events_as_individual_calls() {
         ]
     );
 }
+
+// ---------------------------------------------------------------------------
+// Allowlist enumeration tests (Issue #467)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_allowlisted_investors_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let result = client.get_allowlisted_investors(&0u32, &10u32);
+    assert_eq!(result.len(), 0);
+
+    let count = client.get_allowlisted_investors_count();
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn test_get_allowlisted_investors_single_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    client.set_investor_allowlisted(&a, &true);
+    client.set_investor_allowlisted(&b, &true);
+    client.set_investor_allowlisted(&c, &true);
+
+    let result = client.get_allowlisted_investors(&0u32, &10u32);
+    assert_eq!(result.len(), 3);
+    assert_eq!(result.get(0).unwrap(), a);
+    assert_eq!(result.get(1).unwrap(), b);
+    assert_eq!(result.get(2).unwrap(), c);
+
+    let count = client.get_allowlisted_investors_count();
+    assert_eq!(count, 3);
+}
+
+#[test]
+fn test_get_allowlisted_investors_multi_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let mut addrs = SorobanVec::new(&env);
+    for _ in 0..25 {
+        let addr = Address::generate(&env);
+        addrs.push_back(addr);
+    }
+    client.set_investors_allowlisted(&addrs, &true);
+
+    // First page: 10 items
+    let page0 = client.get_allowlisted_investors(&0u32, &10u32);
+    assert_eq!(page0.len(), 10);
+    assert_eq!(page0.get(0).unwrap(), addrs.get(0).unwrap());
+    assert_eq!(page0.get(9).unwrap(), addrs.get(9).unwrap());
+
+    // Second page: 10 items
+    let page1 = client.get_allowlisted_investors(&10u32, &10u32);
+    assert_eq!(page1.len(), 10);
+    assert_eq!(page1.get(0).unwrap(), addrs.get(10).unwrap());
+    assert_eq!(page1.get(9).unwrap(), addrs.get(19).unwrap());
+
+    // Third page: remaining 5
+    let page2 = client.get_allowlisted_investors(&20u32, &10u32);
+    assert_eq!(page2.len(), 5);
+    assert_eq!(page2.get(0).unwrap(), addrs.get(20).unwrap());
+    assert_eq!(page2.get(4).unwrap(), addrs.get(24).unwrap());
+
+    let count = client.get_allowlisted_investors_count();
+    assert_eq!(count, 25);
+
+    // Out-of-range start returns empty
+    let empty = client.get_allowlisted_investors(&25u32, &10u32);
+    assert_eq!(empty.len(), 0);
+
+    // Zero limit returns empty
+    let empty = client.get_allowlisted_investors(&0u32, &0u32);
+    assert_eq!(empty.len(), 0);
+}
+
+#[test]
+fn test_get_allowlisted_investors_after_revoke() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    client.set_investor_allowlisted(&a, &true);
+    client.set_investor_allowlisted(&b, &true);
+    client.set_investor_allowlisted(&c, &true);
+
+    assert_eq!(client.get_allowlisted_investors_count(), 3);
+
+    // Revoke b
+    client.set_investor_allowlisted(&b, &false);
+
+    let result = client.get_allowlisted_investors(&0u32, &10u32);
+    assert_eq!(result.len(), 2);
+    assert_eq!(result.get(0).unwrap(), a);
+    assert_eq!(result.get(1).unwrap(), c);
+
+    assert_eq!(client.get_allowlisted_investors_count(), 2);
+
+    // Revoke a
+    client.set_investor_allowlisted(&a, &false);
+    assert_eq!(client.get_allowlisted_investors_count(), 1);
+    let result = client.get_allowlisted_investors(&0u32, &10u32);
+    assert_eq!(result.get(0).unwrap(), c);
+
+    // Revoke c
+    client.set_investor_allowlisted(&c, &false);
+    assert_eq!(client.get_allowlisted_investors_count(), 0);
+}
+
+#[test]
+fn test_get_allowlisted_investors_revoked_then_relisted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let a = Address::generate(&env);
+    client.set_investor_allowlisted(&a, &true);
+    assert_eq!(client.get_allowlisted_investors_count(), 1);
+
+    client.set_investor_allowlisted(&a, &false);
+    assert_eq!(client.get_allowlisted_investors_count(), 0);
+
+    // Re-list
+    client.set_investor_allowlisted(&a, &true);
+    assert_eq!(client.get_allowlisted_investors_count(), 1);
+    let result = client.get_allowlisted_investors(&0u32, &10u32);
+    assert_eq!(result.get(0).unwrap(), a);
+}
+
+#[test]
+fn test_get_allowlisted_investors_oversized_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let mut addrs = SorobanVec::new(&env);
+    for _ in 0..60 {
+        addrs.push_back(Address::generate(&env));
+    }
+    client.set_investors_allowlisted(&addrs, &true);
+
+    // Even with limit > 50, should only return 50
+    let result = client.get_allowlisted_investors(&0u32, &100u32);
+    assert_eq!(result.len(), 50);
+
+    let count = client.get_allowlisted_investors_count();
+    assert_eq!(count, 60);
+}
+
+#[test]
+fn test_get_allowlisted_investors_batch_add() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let mut v: SorobanVec<Address> = SorobanVec::new(&env);
+    v.push_back(a.clone());
+    v.push_back(b.clone());
+    v.push_back(c.clone());
+    client.set_investors_allowlisted(&v, &true);
+
+    let result = client.get_allowlisted_investors(&0u32, &10u32);
+    assert_eq!(result.len(), 3);
+    assert_eq!(result.get(0).unwrap(), a);
+    assert_eq!(result.get(1).unwrap(), b);
+    assert_eq!(result.get(2).unwrap(), c);
+
+    // Batch revoke b and c
+    let mut revoke_v: SorobanVec<Address> = SorobanVec::new(&env);
+    revoke_v.push_back(b.clone());
+    revoke_v.push_back(c.clone());
+    client.set_investors_allowlisted(&revoke_v, &false);
+
+    let result = client.get_allowlisted_investors(&0u32, &10u32);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.get(0).unwrap(), a);
+}
+
+#[test]
+fn test_get_allowlisted_investors_start_past_end() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+
+    let a = Address::generate(&env);
+    client.set_investor_allowlisted(&a, &true);
+
+    // start == len returns empty
+    let result = client.get_allowlisted_investors(&1u32, &10u32);
+    assert_eq!(result.len(), 0);
+
+    // start > len returns empty
+    let result = client.get_allowlisted_investors(&5u32, &10u32);
+    assert_eq!(result.len(), 0);
+}

--- a/escrow/src/tests/external_calls.rs
+++ b/escrow/src/tests/external_calls.rs
@@ -454,8 +454,223 @@ fn distributed_principal_accumulates_across_multiple_refunds() {
     client.refund(&inv_c);
     assert_eq!(client.get_distributed_principal(), 900i128);
 
-    // All refunded ÔÇö outstanding = 0, any dust can be swept
+    // All refunded — outstanding = 0, any dust can be swept
     token.stellar.mint(&client.address, &5i128);
     let swept = client.sweep_terminal_dust(&5i128);
     assert_eq!(swept, 5i128);
+}
+
+// ---------------------------------------------------------------------------
+// Refund-then-sweep floor sequence (Issue #475)
+// ---------------------------------------------------------------------------
+
+fn setup_multi_investor_cancelled<'a>(
+    env: &'a Env,
+    client: &LiquifactEscrowClient<'a>,
+    admin: &Address,
+    sme: &Address,
+    investors: &[Address],
+    amounts: &[i128],
+) -> (crate::tests::StellarTestToken<'a>, Address) {
+    let token = install_stellar_asset_token(env);
+    let treasury = Address::generate(env);
+    let total_fund: i128 = amounts.iter().sum();
+    client.init(
+        admin,
+        &soroban_sdk::String::from_str(env, "FLOOR06"),
+        sme,
+        &(total_fund * 2),
+        &0i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    token.stellar.mint(&client.address, &total_fund);
+    for i in 0..investors.len() {
+        client.fund(&investors[i], &amounts[i]);
+    }
+    client.cancel_funding();
+    (token, treasury)
+}
+
+#[test]
+fn sweep_liability_floor_refund_then_sweep_sequence() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let investors = [a.clone(), b.clone(), c.clone()];
+    let amounts = [300i128, 300i128, 300i128];
+
+    let (token, treasury) = setup_multi_investor_cancelled(
+        &env, &client, &admin, &sme, &investors, &amounts,
+    );
+
+    // Mint extra dust
+    token.stellar.mint(&client.address, &100i128);
+
+    // Step 1: no refunds, outstanding = 900, max_sweepable > 0 due to dust
+    assert_eq!(client.get_distributed_principal(), 0);
+    let swept1 = client.sweep_terminal_dust(&100i128);
+    assert_eq!(swept1, 100i128);
+
+    // Step 2: refund a (300) -> distributed = 300, outstanding = 600
+    client.refund(&a);
+    assert_eq!(client.get_distributed_principal(), 300);
+    // Mint more dust and sweep -- floor still respected
+    token.stellar.mint(&client.address, &50i128);
+    let swept2 = client.sweep_terminal_dust(&50i128);
+    assert_eq!(swept2, 50i128);
+
+    // Step 3: refund b (300) -> distributed = 600, outstanding = 300
+    client.refund(&b);
+    assert_eq!(client.get_distributed_principal(), 600);
+    token.stellar.mint(&client.address, &80i128);
+    let swept3 = client.sweep_terminal_dust(&80i128);
+    assert_eq!(swept3, 80i128);
+
+    // Step 4: refund c (300) -> all refunded, outstanding = 0
+    client.refund(&c);
+    assert_eq!(client.get_distributed_principal(), 900);
+    token.stellar.mint(&client.address, &200i128);
+    let swept4 = client.sweep_terminal_dust(&200i128);
+    assert_eq!(swept4, 200i128);
+}
+
+#[test]
+#[should_panic]
+fn sweep_liability_floor_one_unit_over_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let investors = [a.clone(), b.clone()];
+    let amounts = [500i128, 500i128];
+
+    let (_token, _treasury) = setup_multi_investor_cancelled(
+        &env, &client, &admin, &sme, &investors, &amounts,
+    );
+
+    // Refund one -> distributed=500, outstanding=500, balance=500
+    client.refund(&a);
+    // Sweeping 1 unit would leave 499 < 500
+    client.sweep_terminal_dust(&1i128);
+}
+
+#[test]
+fn sweep_liability_floor_capped_by_max_dust_sweep() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let a = Address::generate(&env);
+    let investors = [a.clone()];
+    let amounts = [500i128];
+
+    let (token, treasury) = setup_multi_investor_cancelled(
+        &env, &client, &admin, &sme, &investors, &amounts,
+    );
+
+    // All refunded -> outstanding = 0
+    client.refund(&a);
+
+    // Mint way more than MAX_DUST_SWEEP_AMOUNT
+    let huge_dust = MAX_DUST_SWEEP_AMOUNT * 2;
+    token.stellar.mint(&client.address, &huge_dust);
+
+    let swept = client.sweep_terminal_dust(&huge_dust);
+    assert_eq!(swept, MAX_DUST_SWEEP_AMOUNT);
+    assert_eq!(
+        token.token.balance(&treasury),
+        MAX_DUST_SWEEP_AMOUNT
+    );
+}
+
+#[test]
+#[should_panic]
+fn sweep_liability_floor_positive_amount_guard() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (_token, _treasury) =
+        setup_cancelled_with_token(&env, &client, &admin, &sme, &investor, 500i128);
+    client.sweep_terminal_dust(&0i128);
+}
+
+#[test]
+#[should_panic]
+fn sweep_liability_floor_terminal_status_guard() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let token = install_stellar_asset_token(&env);
+    let treasury = Address::generate(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FLOOR07"),
+        &sme,
+        &1_000i128,
+        &0i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client.sweep_terminal_dust(&1i128);
+}
+
+#[test]
+#[should_panic]
+fn sweep_liability_floor_legal_hold_blocks() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (_token, _treasury) =
+        setup_cancelled_with_token(&env, &client, &admin, &sme, &investor, 500i128);
+
+    client.set_legal_hold(&true);
+    client.sweep_terminal_dust(&1i128);
+}
+
+#[test]
+fn sweep_liability_floor_all_refunded_sweep_all_dust() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let investors = [a.clone(), b.clone()];
+    let amounts = [400i128, 600i128];
+
+    let (token, treasury) = setup_multi_investor_cancelled(
+        &env, &client, &admin, &sme, &investors, &amounts,
+    );
+
+    client.refund(&a);
+    client.refund(&b);
+
+    token.stellar.mint(&client.address, &999i128);
+    let expected = 999i128.min(MAX_DUST_SWEEP_AMOUNT);
+    let swept = client.sweep_terminal_dust(&999i128);
+    assert_eq!(swept, expected);
+    assert_eq!(token.token.balance(&treasury), expected);
 }


### PR DESCRIPTION
## Summary

- **Allowlist enumeration**: Add paginated `get_allowlisted_investors(start, limit)` and `get_allowlisted_investors_count()` views. Maintains an `AllowlistIndex` that tracks currently-allowlisted addresses, updated atomically with `set_investor_allowlisted`/`set_investors_allowlisted`. Revoked addresses are removed from the index so enumeration reflects live state.
- **Sweep liability-floor tests**: Add deterministic refund-then-sweep sequence tests walking the liability floor after partial refunds, plus edge cases for over-floor rejection, `MAX_DUST_SWEEP_AMOUNT` cap, positive-amount guard, terminal-status requirement, and legal-hold gate.
- **Bugfix**: Add missing `MAX_INVESTOR_ALLOWLIST_BATCH` constant (32).

## Changes

| File | Change |
|------|--------|
| `escrow/src/lib.rs` | Add `MAX_INVESTOR_ALLOWLIST_BATCH` constant, `AllowlistIndex` DataKey, index maintenance in `set_investor_allowlisted`/`set_investors_allowlisted`, `get_allowlisted_investors` and `get_allowlisted_investors_count` functions |
| `escrow/src/test_allowlist_tests.rs` | 9 new tests: empty, single page, multi-page, post-revoke, relist, cap, batch add, start-past-end |
| `escrow/src/tests/external_calls.rs` | 5 new tests: refund-then-sweep sequence, over-floor rejection, capped sweep, positive-amount guard, terminal-status guard, legal-hold gate, all-refunded sweep |

## Security Notes

- **Allowlist enumeration**: Revoked addresses never appear in enumeration results. The `AllowlistIndex` is maintained in instance storage; malicous TTL eviction cannot bypass the persistent-storage `InvestorAllowlisted` check on read.
- **Sweep floor tests**: The deterministic refund-then-sweep sequence proves the treasury can never sweep principal still owed to un-refunded investors. Over-floor sweeps (by 1 unit) are rejected with `SweepExceedsLiabilityFloor`.
- The existing `al_set`/`al_batch` event semantics are fully preserved.
- `limit` is bounded at 50 (consistent with `get_investors`) to prevent unbounded reads.

## Test Coverage

- Allowlist enumeration: empty allowlist, single page, multi-page (25 entries, 3 pages), revoked-then-listed, revoked-then-relisted, oversized limit, batch add/revoke, start-past-end.
- Sweep floor: no refunds, partial refunds (step-by-step), all refunded, over-floor by 1 unit, `MAX_DUST_SWEEP_AMOUNT` cap, zero-amount rejection, non-terminal rejection, legal-hold rejection.

Closes #467
Closes #475