### PR TITLE
test: cover unrevoke_attestation_digest reversal and guard conditions

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -313,6 +313,8 @@ pub enum EscrowError {
     AttestationIndexOutOfRange = 52,
     /// [`LiquifactEscrow::revoke_attestation_digest`] called on an already-revoked index.
     AttestationAlreadyRevoked = 53,
+    /// [`LiquifactEscrow::unrevoke_attestation_digest`] called on a non-revoked index.
+    AttestationNotRevoked = 54,
 
     /// [`LiquifactEscrow::record_sme_collateral_commitment`] received a non-positive amount.
     CollateralAmountNotPositive = 60,

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -8,10 +8,11 @@
 )]
 #[allow(unused_imports)]
 use super::{
-    AttestationDigestAppended, AttestationDigestRevoked, CollateralRecordedEvt, DataKey,
-    EscrowError, EscrowFunded, EscrowInitialized, FundingTargetUpdated, LiquifactEscrow,
-    LiquifactEscrowClient, MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, YieldTier,
-    MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH, SCHEMA_VERSION,
+    AttestationDigestAppended, AttestationDigestRevoked, AttestationDigestUnrevoked,
+    CollateralRecordedEvt, DataKey, EscrowError, EscrowFunded, EscrowInitialized,
+    FundingTargetUpdated, LiquifactEscrow, LiquifactEscrowClient, MaxUniqueInvestorsCapLowered,
+    PrimaryAttestationBound, YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT,
+    MAX_FUND_BATCH, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -10,7 +10,7 @@
 //! off-chain verifiers can confirm the on-chain anchor matches their document set.
 
 use super::*;
-use soroban_sdk::{BytesN, Error, InvokeError};
+use soroban_sdk::{symbol_short, testutils::Events, BytesN, Error, InvokeError};
 use std::fmt::Debug;
 
 fn assert_contract_error<T, E>(
@@ -418,4 +418,252 @@ fn test_revoke_non_admin_returns_error() {
     env.mock_auths(&[]);
     // Any error (not Ok) satisfies the auth-rejection requirement.
     assert!(client.try_revoke_attestation_digest(&0).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// unrevoke_attestation_digest — reversal of revocation
+// ---------------------------------------------------------------------------
+
+/// Happy path: revoke then unrevoke index 0; confirm `is_attestation_revoked`
+/// flips back to `false` and the digest remains readable.
+#[test]
+fn test_unrevoke_single_entry() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let d = digest(&env, 0xAA);
+    client.append_attestation_digest(&d);
+
+    client.revoke_attestation_digest(&0);
+    assert!(client.is_attestation_revoked(&0));
+
+    client.unrevoke_attestation_digest(&0);
+    assert!(!client.is_attestation_revoked(&0));
+
+    let log = client.get_attestation_append_log();
+    assert_eq!(log.len(), 1);
+    assert_eq!(log.get(0).unwrap(), d);
+}
+
+/// Unrevoke emits `att_unrev` with the correct index.
+#[test]
+fn test_unrevoke_emits_event() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let contract_id = client.address.clone();
+    let d = digest(&env, 0xBB);
+    client.append_attestation_digest(&d);
+    client.revoke_attestation_digest(&0);
+
+    let invoice_id = client.get_escrow().invoice_id;
+    client.unrevoke_attestation_digest(&0);
+
+    assert_eq!(
+        env.events().all().events().last().unwrap().clone(),
+        AttestationDigestUnrevoked {
+            name: symbol_short!("att_unrev"),
+            invoice_id,
+            index: 0,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+/// Unrevoking an index beyond the current log length returns
+/// `AttestationIndexOutOfRange`.
+#[test]
+fn test_unrevoke_out_of_range() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    // Empty log — index 0 is out of range.
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&0),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+}
+
+/// Unrevoking an index equal to log length returns `AttestationIndexOutOfRange`.
+#[test]
+fn test_unrevoke_at_log_len() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x10));
+    // log.len() == 1, index 1 is out of range.
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&1),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+}
+
+/// A large out-of-range index returns `AttestationIndexOutOfRange`.
+#[test]
+fn test_unrevoke_large_index_out_of_range() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&99),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+}
+
+/// Unrevoking an index that was never revoked returns `AttestationNotRevoked`.
+#[test]
+fn test_unrevoke_not_revoked() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x42));
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&0),
+        EscrowError::AttestationNotRevoked,
+    );
+}
+
+/// Unrevoking an index that was never revoked still returns
+/// `AttestationNotRevoked` even after an unrelated index was revoked.
+#[test]
+fn test_unrevoke_not_revoked_while_other_revoked() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    client.append_attestation_digest(&digest(&env, 0x02));
+    client.revoke_attestation_digest(&1);
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&0),
+        EscrowError::AttestationNotRevoked,
+    );
+}
+
+/// Digest is preserved through revoke → unrevoke cycles.
+#[test]
+fn test_unrevoke_preserves_digest() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let d = digest(&env, 0xCA);
+    client.append_attestation_digest(&d);
+
+    client.revoke_attestation_digest(&0);
+    client.unrevoke_attestation_digest(&0);
+
+    let log = client.get_attestation_append_log();
+    assert_eq!(log.len(), 1);
+    assert_eq!(log.get(0).unwrap(), d);
+}
+
+/// Multiple revoke → unrevoke cycles on the same index preserve the digest
+/// and toggle the revoked flag each time.
+#[test]
+fn test_revoke_unrevoke_cycle() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let d = digest(&env, 0xDD);
+    client.append_attestation_digest(&d);
+
+    for _ in 0..3 {
+        assert!(!client.is_attestation_revoked(&0));
+        client.revoke_attestation_digest(&0);
+        assert!(client.is_attestation_revoked(&0));
+        client.unrevoke_attestation_digest(&0);
+        assert!(!client.is_attestation_revoked(&0));
+    }
+    let log = client.get_attestation_append_log();
+    assert_eq!(log.get(0).unwrap(), d);
+}
+
+/// Revoke → unrevoke → revoke again succeeds (full round-trip).
+#[test]
+fn test_revoke_unrevoke_revoke_again() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0xEE));
+
+    client.revoke_attestation_digest(&0);
+    assert!(client.is_attestation_revoked(&0));
+
+    client.unrevoke_attestation_digest(&0);
+    assert!(!client.is_attestation_revoked(&0));
+
+    client.revoke_attestation_digest(&0);
+    assert!(client.is_attestation_revoked(&0));
+}
+
+/// Unrevoking one index does not affect the revocation state of others.
+#[test]
+fn test_unrevoke_does_not_affect_other_indices() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    client.append_attestation_digest(&digest(&env, 0x02));
+    client.append_attestation_digest(&digest(&env, 0x03));
+
+    client.revoke_attestation_digest(&0);
+    client.revoke_attestation_digest(&2);
+    assert!(client.is_attestation_revoked(&0));
+    assert!(!client.is_attestation_revoked(&1));
+    assert!(client.is_attestation_revoked(&2));
+
+    client.unrevoke_attestation_digest(&0);
+
+    assert!(!client.is_attestation_revoked(&0));
+    assert!(!client.is_attestation_revoked(&1));
+    assert!(client.is_attestation_revoked(&2));
+}
+
+/// Unrevoking all revoked entries sequentially clears every marker.
+#[test]
+fn test_unrevoke_all_entries() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..5 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    for i in 0u8..5 {
+        client.revoke_attestation_digest(&(i as u32));
+    }
+    for i in 0u8..5 {
+        assert!(client.is_attestation_revoked(&(i as u32)));
+        client.unrevoke_attestation_digest(&(i as u32));
+        assert!(!client.is_attestation_revoked(&(i as u32)));
+    }
+}
+
+/// Unrevoked index correctly reports `false` via `is_attestation_revoked`
+/// while other revoked indices remain `true`.
+#[test]
+fn test_unrevoke_mid_index() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..3 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    for i in 0u8..3 {
+        client.revoke_attestation_digest(&(i as u32));
+    }
+    // Unrevoke only the middle entry.
+    client.unrevoke_attestation_digest(&1);
+    assert!(client.is_attestation_revoked(&0));
+    assert!(!client.is_attestation_revoked(&1));
+    assert!(client.is_attestation_revoked(&2));
+}
+
+/// Non-admin caller must not be able to unrevoke.
+#[test]
+#[should_panic]
+fn test_unrevoke_non_admin_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0xFF));
+    client.revoke_attestation_digest(&0);
+    env.mock_auths(&[]);
+    client.unrevoke_attestation_digest(&0);
+}
+
+/// Non-admin `try_unrevoke_attestation_digest` returns an error.
+#[test]
+fn test_unrevoke_non_admin_returns_error() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0xFF));
+    client.revoke_attestation_digest(&0);
+    env.mock_auths(&[]);
+    assert!(client.try_unrevoke_attestation_digest(&0).is_err());
 }


### PR DESCRIPTION
Closes #476 

## 📝 PR Summary: Cover `unrevoke_attestation_digest` reversal and guard conditions

###  Production Bugfix
* **`escrow/src/lib.rs`**: Added the missing `AttestationNotRevoked = 54` variant to `EscrowError`. The `unrevoke_attestation_digest` function referenced this variant, but it was undefined in the enum, which would cause a compile error.

---

###  Tests
> Added **15 new tests** in `escrow/src/tests/attestations.rs`.

####  Happy Path & State
* `test_unrevoke_single_entry` – Revoke then unrevoke, confirm `is_attestation_revoked` flips to false.
* `test_unrevoke_emits_event` – Verify `att_unrev` event fires with correct `invoice_id` and index.
* `test_unrevoke_preserves_digest` – Digest remains unchanged after revoke $\rightarrow$ unrevoke sequence.
* `test_unrevoke_all_entries` – Sequential unrevoke of every entry in a 5-entry log.

####  Cycle & Round-trip
* `test_revoke_unrevoke_cycle` – 3 revoke $\rightarrow$ unrevoke cycles on the same index.
* `test_revoke_unrevoke_revoke_again` – Revoke $\rightarrow$ unrevoke $\rightarrow$ revoke again.

####  Scope Isolation
* `test_unrevoke_does_not_affect_other_indices` – Unrevoking index 0 leaves index 2 revoked.
* `test_unrevoke_mid_index` – Unrevoke middle entry while outer entries stay revoked.

####  Error Guards
* `test_unrevoke_out_of_range` – Empty log $\rightarrow$ `AttestationIndexOutOfRange`.
* `test_unrevoke_at_log_len` – Index == `log.len()` $\rightarrow$ `AttestationIndexOutOfRange`.
* `test_unrevoke_large_index_out_of_range` – Index = 99 with 1-entry log $\rightarrow$ `AttestationIndexOutOfRange`.
* `test_unrevoke_not_revoked` – Never-revoked index $\rightarrow$ `AttestationNotRevoked`.
* `test_unrevoke_not_revoked_while_other_revoked` – Not-revoked index 0 while index 1 is revoked $\rightarrow$ `AttestationNotRevoked`.

####  Authorization
* `test_unrevoke_non_admin_panics` – Non-admin call panics.
* `test_unrevoke_non_admin_returns_error` – Non-admin `try_` returns error.

####  Support Changes
* **`escrow/src/tests.rs`**: Added `AttestationDigestUnrevoked` to imports.
* **`escrow/src/tests/attestations.rs`**: Added `symbol_short` and `testutils::Events` imports.

---

###  Security Notes
* **Admin-gated:** All non-admin calls are rejected (both panic and typed-error paths verified).
* **Digest Integrity:** The append-log entry is never modified by revoke/unrevoke — only the revocation marker toggles.
* **No Silent No-op:** Calling unrevoke on a non-revoked index returns a clear `AttestationNotRevoked` error.
* **Bounds Enforced:** Out-of-range indices are rejected with `AttestationIndexOutOfRange` before any auth or storage mutation.
* **Guard Ordering (ADR-002):** Range check $\rightarrow$ revocation-state check $\rightarrow$ `require_auth` $\rightarrow$ storage mutation.