### PR TITLE
feat: add lower_min_contribution_floor lower-only entrypoint and enri…

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -997,7 +997,6 @@ pub struct RegistryRefRebound {
 
 #[contractevent]
 pub struct TreasuryDustSwept {
-
     #[topic]
     pub name: Symbol,
     pub invoice_id: Symbol,
@@ -1231,9 +1230,21 @@ impl LiquifactEscrow {
         admin.require_auth();
 
         ensure(&env, amount > 0, EscrowError::AmountMustBePositive);
-        ensure(&env, amount <= MAX_INVOICE_AMOUNT, EscrowError::AmountExceedsMax);
-        ensure(&env, (0..=10_000).contains(&yield_bps), EscrowError::YieldBpsOutOfRange);
-        ensure(&env, !env.storage().instance().has(&DataKey::Escrow), EscrowError::EscrowAlreadyInitialized);
+        ensure(
+            &env,
+            amount <= MAX_INVOICE_AMOUNT,
+            EscrowError::AmountExceedsMax,
+        );
+        ensure(
+            &env,
+            (0..=10_000).contains(&yield_bps),
+            EscrowError::YieldBpsOutOfRange,
+        );
+        ensure(
+            &env,
+            !env.storage().instance().has(&DataKey::Escrow),
+            EscrowError::EscrowAlreadyInitialized,
+        );
 
         ensure(
             &env,
@@ -1245,40 +1256,58 @@ impl LiquifactEscrow {
 
         let max_horizon = maturity_max_horizon.unwrap_or(DEFAULT_MATURITY_MAX_HORIZON_SECS);
         validate_maturity_bounds(&env, maturity, max_horizon);
-        env.storage().instance().set(&DataKey::MaturityMaxHorizon, &max_horizon);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaturityMaxHorizon, &max_horizon);
 
-        env.storage().instance().set(&DataKey::FundingToken, &funding_token);
+        env.storage()
+            .instance()
+            .set(&DataKey::FundingToken, &funding_token);
         env.storage().instance().set(&DataKey::Treasury, &treasury);
-        
+
         if let Some(reg) = registry.clone() {
             env.storage().instance().set(&DataKey::RegistryRef, &reg);
         }
-        
+
         if let Some(tiers) = yield_tiers {
-            env.storage().instance().set(&DataKey::YieldTierTable, &tiers);
+            env.storage()
+                .instance()
+                .set(&DataKey::YieldTierTable, &tiers);
         }
 
         let floor = min_contribution.unwrap_or(0);
-        env.storage().instance().set(&DataKey::MinContributionFloor, &floor);
-        env.storage().instance().set(&DataKey::UniqueFunderCount, &0u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::MinContributionFloor, &floor);
+        env.storage()
+            .instance()
+            .set(&DataKey::UniqueFunderCount, &0u32);
 
         if let Some(cap) = max_per_investor {
             ensure(&env, cap > 0, EscrowError::MaxPerInvestorNotPositive);
-            env.storage().instance().set(&DataKey::MaxPerInvestorCap, &cap);
+            env.storage()
+                .instance()
+                .set(&DataKey::MaxPerInvestorCap, &cap);
         }
 
         if let Some(cap) = max_unique_investors {
             ensure(&env, cap > 0, EscrowError::MaxUniqueInvestorsNotPositive);
-            env.storage().instance().set(&DataKey::MaxUniqueInvestorsCap, &cap);
+            env.storage()
+                .instance()
+                .set(&DataKey::MaxUniqueInvestorsCap, &cap);
         }
 
         let delay = legal_hold_clear_delay.unwrap_or(0);
         if delay > 0 {
-            env.storage().instance().set(&DataKey::LegalHoldClearDelay, &delay);
+            env.storage()
+                .instance()
+                .set(&DataKey::LegalHoldClearDelay, &delay);
         }
 
         if let Some(active) = allowlist_active {
-            env.storage().instance().set(&DataKey::AllowlistActive, &active);
+            env.storage()
+                .instance()
+                .set(&DataKey::AllowlistActive, &active);
         }
 
         let invoice_sym = validate_invoice_id_string(&env, &invoice_id);
@@ -1294,39 +1323,49 @@ impl LiquifactEscrow {
             maturity,
             status: 0,
         };
-        
+
         env.storage().instance().set(&DataKey::Escrow, &escrow);
-        env.storage().instance().set(&DataKey::FundingToken, &funding_token);
+        env.storage()
+            .instance()
+            .set(&DataKey::FundingToken, &funding_token);
         env.storage().instance().set(&DataKey::Treasury, &treasury);
-        env.storage().instance().set(&DataKey::Version, &SCHEMA_VERSION);
+        env.storage()
+            .instance()
+            .set(&DataKey::Version, &SCHEMA_VERSION);
 
         if let Some(reg) = &registry {
             env.storage().instance().set(&DataKey::RegistryRef, reg);
         }
         if let Some(tiers) = &yield_tiers {
-            env.storage().instance().set(&DataKey::YieldTierTable, tiers);
+            env.storage()
+                .instance()
+                .set(&DataKey::YieldTierTable, tiers);
         }
         if let Some(floor) = min_contribution {
-            env.storage().instance().set(&DataKey::MinContributionFloor, &floor);
+            env.storage()
+                .instance()
+                .set(&DataKey::MinContributionFloor, &floor);
         }
         if let Some(cap) = max_unique_investors {
-            env.storage().instance().set(&DataKey::MaxUniqueInvestorsCap, &cap);
+            env.storage()
+                .instance()
+                .set(&DataKey::MaxUniqueInvestorsCap, &cap);
         }
         if let Some(cap) = max_per_investor {
-            env.storage().instance().set(&DataKey::MaxPerInvestorCap, &cap);
+            env.storage()
+                .instance()
+                .set(&DataKey::MaxPerInvestorCap, &cap);
         }
         if let Some(delay) = legal_hold_clear_delay {
-            env.storage().instance().set(&DataKey::LegalHoldClearDelay, &delay);
+            env.storage()
+                .instance()
+                .set(&DataKey::LegalHoldClearDelay, &delay);
         }
 
         let has_maturity_lock = maturity != 0;
         EscrowInitialized {
             name: symbol_short!("escrow"),
-            escrow: env
-                .storage()
-                .instance()
-                .get(&DataKey::Escrow)
-                .unwrap(),
+            escrow: env.storage().instance().get(&DataKey::Escrow).unwrap(),
             funding_token,
             treasury,
             registry,
@@ -1400,7 +1439,9 @@ impl LiquifactEscrow {
 
         match registry.clone() {
             Some(_) => {
-                env.storage().instance().set(&DataKey::RegistryRef, &registry);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::RegistryRef, &registry);
             }
             None => {
                 env.storage().instance().remove(&DataKey::RegistryRef);
@@ -1414,7 +1455,6 @@ impl LiquifactEscrow {
         }
         .publish(&env);
     }
-
 
     /// Returns the optional pending admin address waiting for [`LiquifactEscrow::accept_admin`],
     /// or [`None`] when no admin handover is in progress.
@@ -2640,9 +2680,7 @@ impl LiquifactEscrow {
 
     /// Get the pending clear timestamp, if any.
     pub fn get_legal_hold_clearable_at(env: Env) -> Option<u64> {
-        env.storage()
-            .instance()
-            .get(&DataKey::LegalHoldClearableAt)
+        env.storage().instance().get(&DataKey::LegalHoldClearableAt)
     }
 
     pub fn update_funding_target(env: Env, new_target: i128) -> InvoiceEscrow {

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -241,6 +241,8 @@ pub enum EscrowError {
     TierYieldBelowBase = 11,
     /// [`LiquifactEscrow::init`] rejected tiers whose `min_lock_secs` are not strictly increasing.
     TierLockNotIncreasing = 12,
+    /// [`LiquifactEscrow::init`] rejected `amount` exceeding [`MAX_INVOICE_AMOUNT`].
+    AmountExceedsMax = 14,
     /// [`LiquifactEscrow::init`] rejected tiers whose `yield_bps` decrease across tiers.
     TierYieldNotNonDecreasing = 13,
 
@@ -425,6 +427,13 @@ pub enum EscrowError {
     PayoutZero = 170,
     /// `update_funding_deadline` was called on a non-open escrow (status != 0).
     FundingDeadlineUpdateNotOpen = 171,
+
+    /// [`LiquifactEscrow::lower_min_contribution_floor`] called while escrow is not open.
+    FloorLowerNotOpen = 173,
+    /// [`LiquifactEscrow::lower_min_contribution_floor`] did not strictly lower the floor.
+    NewFloorNotLower = 174,
+    /// [`LiquifactEscrow::lower_min_contribution_floor`] received a non-positive floor.
+    NewFloorNotPositive = 175,
 }
 
 #[inline(always)]
@@ -730,6 +739,16 @@ pub struct MaxUniqueInvestorsCapLowered {
 }
 
 #[contractevent]
+pub struct MinContributionFloorLowered {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub old_floor: i128,
+    pub new_floor: i128,
+}
+
+#[contractevent]
 pub struct EscrowFunded {
     #[topic]
     pub name: Symbol,
@@ -797,6 +816,16 @@ pub struct AdminTransferredEvent {
     pub name: Symbol,
     #[topic]
     pub invoice_id: Symbol,
+    pub new_admin: Address,
+}
+
+#[contractevent]
+pub struct AdminAcceptedEvent {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub prior_admin: Address,
     pub new_admin: Address,
 }
 
@@ -2712,6 +2741,45 @@ impl LiquifactEscrow {
         new_cap
     }
 
+    /// Lower the minimum contribution floor while the escrow is still open.
+    ///
+    /// This is admin-only and intentionally cannot raise the floor or set a non-positive
+    /// value. The new floor applies to all subsequent [`LiquifactEscrow::fund`] /
+    /// [`LiquifactEscrow::fund_with_commitment`] calls, including follow-on deposits from
+    /// existing investors.
+    ///
+    /// # Panics
+    /// - If the escrow is not open (status != 0).
+    /// - If `new_floor` is not strictly lower than the current floor.
+    /// - If `new_floor` is not positive.
+    pub fn lower_min_contribution_floor(env: Env, new_floor: i128) -> i128 {
+        let escrow = Self::load_escrow_require_admin(&env);
+
+        ensure(&env, escrow.status == 0, EscrowError::FloorLowerNotOpen);
+        ensure(&env, new_floor > 0, EscrowError::NewFloorNotPositive);
+
+        let old_floor: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinContributionFloor)
+            .unwrap_or(0);
+        ensure(&env, new_floor < old_floor, EscrowError::NewFloorNotLower);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MinContributionFloor, &new_floor);
+
+        MinContributionFloorLowered {
+            name: symbol_short!("floor_lo"),
+            invoice_id: escrow.invoice_id.clone(),
+            old_floor,
+            new_floor,
+        }
+        .publish(&env);
+
+        new_floor
+    }
+
     /// Validate the stored schema version and apply a migration if one is implemented.
     ///
     /// # Behavior - **typed error on all current paths**
@@ -3698,6 +3766,7 @@ impl LiquifactEscrow {
         pending.require_auth();
 
         let mut escrow = Self::get_escrow(env.clone());
+        let prior_admin = escrow.admin.clone();
         escrow.admin = pending.clone();
 
         env.storage().instance().set(&DataKey::Escrow, &escrow);
@@ -3706,9 +3775,10 @@ impl LiquifactEscrow {
             .instance()
             .remove(&DataKey::PendingAdminExpiry);
 
-        AdminTransferredEvent {
-            name: symbol_short!("admin"),
+        AdminAcceptedEvent {
+            name: symbol_short!("adm_acc"),
             invoice_id: escrow.invoice_id.clone(),
+            prior_admin,
             new_admin: pending,
         }
         .publish(&env);

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -11,7 +11,6 @@ use soroban_sdk::Event;
 
 #[test]
 fn test_update_maturity_emits_event() {
-
     use soroban_sdk::testutils::Events as _;
     let env = Env::default();
     let (client, admin, sme) = setup(&env);
@@ -414,7 +413,8 @@ fn test_accept_admin_event_carries_prior_and_new_admin() {
         .to_xdr(&env, &contract_id)
     );
     assert_eq!(
-        client.get_escrow().admin, new_admin,
+        client.get_escrow().admin,
+        new_admin,
         "admin was not promoted after accept_admin"
     );
     assert_eq!(
@@ -1728,7 +1728,6 @@ fn test_rotate_beneficiary_then_withdraw_goes_to_new_sme() {
 /// admin is unchanged.
 #[test]
 fn test_rebind_registry_ref_sets_and_clears() {
-
     use soroban_sdk::testutils::Events as _;
 
     let env = Env::default();
@@ -1817,7 +1816,6 @@ fn test_rebind_registry_ref_requires_admin_auth() {
 }
 
 fn test_error_code_uniqueness() {
-
     let mut discriminants = std::collections::HashSet::new();
     let codes = [
         EscrowError::AmountMustBePositive as u32,

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
-    AdminProposalCancelled, AdminProposedEvent, EscrowCloseSnapshot, FundingTargetUpdated,
-    RegistryRefRebound,
+    AdminAcceptedEvent, AdminProposalCancelled, AdminProposedEvent, EscrowCloseSnapshot,
+    FundingTargetUpdated, RegistryRefRebound,
 };
 
 use soroban_sdk::Event;
@@ -385,6 +385,45 @@ fn test_accept_admin_by_wrong_address_panics() {
     client.accept_admin();
 }
 
+/// Verify that `accept_admin` emits `AdminAcceptedEvent` with the correct prior_admin,
+/// new_admin, and invoice_id, making the completed two-step handover unambiguous.
+#[test]
+fn test_accept_admin_event_carries_prior_and_new_admin() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, old_admin, sme) = setup(&env);
+    let new_admin = Address::generate(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &old_admin, &sme);
+
+    client.propose_admin(&new_admin, &None);
+    client.accept_admin();
+
+    let events = env.events().all();
+    let last_event = events.events().last().unwrap().clone();
+    assert_eq!(
+        last_event,
+        AdminAcceptedEvent {
+            name: symbol_short!("adm_acc"),
+            invoice_id: client.get_escrow().invoice_id,
+            prior_admin: old_admin.clone(),
+            new_admin: new_admin.clone(),
+        }
+        .to_xdr(&env, &contract_id)
+    );
+    assert_eq!(
+        client.get_escrow().admin, new_admin,
+        "admin was not promoted after accept_admin"
+    );
+    assert_eq!(
+        client.get_pending_admin(),
+        None,
+        "pending admin was not cleared after accept_admin"
+    );
+}
+
 /// End-to-end handover lifecycle: propose, accept, old admin lockout, new admin authority
 #[test]
 fn test_admin_handover_lifecycle() {
@@ -406,12 +445,13 @@ fn test_admin_handover_lifecycle() {
     assert_eq!(updated.admin, new_admin.clone());
     assert_eq!(client.get_pending_admin(), None);
 
-    // Verify AdminTransferredEvent
+    // Verify AdminAcceptedEvent
     assert_eq!(
         env.events().all().events().last().unwrap().clone(),
-        crate::AdminTransferredEvent {
-            name: symbol_short!("admin"),
+        crate::AdminAcceptedEvent {
+            name: symbol_short!("adm_acc"),
             invoice_id: client.get_escrow().invoice_id,
+            prior_admin: old_admin.clone(),
             new_admin: new_admin.clone(),
         }
         .to_xdr(&env, &contract_id)
@@ -1793,6 +1833,7 @@ fn test_error_code_uniqueness() {
         EscrowError::TierYieldBelowBase as u32,
         EscrowError::TierLockNotIncreasing as u32,
         EscrowError::TierYieldNotNonDecreasing as u32,
+        EscrowError::AmountExceedsMax as u32,
         EscrowError::EscrowNotInitialized as u32,
         EscrowError::FundingTokenNotSet as u32,
         EscrowError::TreasuryNotSet as u32,
@@ -1865,6 +1906,9 @@ fn test_error_code_uniqueness() {
         EscrowError::NewSmeSameAsCurrent as u32,
         EscrowError::NoPendingAdmin as u32,
         EscrowError::InsufficientContractBalance as u32,
+        EscrowError::FloorLowerNotOpen as u32,
+        EscrowError::NewFloorNotLower as u32,
+        EscrowError::NewFloorNotPositive as u32,
     ];
     for code in codes.iter() {
         assert!(

--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -1077,7 +1077,7 @@ fn test_get_remaining_investor_slots_post_lower_cap() {
     assert_eq!(client.get_remaining_investor_slots(), Some(2));
 
     client.lower_max_unique_investors(&3u32);
-    
+
     assert_eq!(client.get_remaining_investor_slots(), Some(0));
 }
 

--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -2,7 +2,7 @@
 //! This test file validates the core functionality without dependencies on other test modules
 
 use super::*;
-use crate::MaxUniqueInvestorsCapLowered;
+use crate::{MaxUniqueInvestorsCapLowered, MinContributionFloorLowered};
 use soroban_sdk::{Address, Env, String};
 
 #[test]
@@ -1079,4 +1079,467 @@ fn test_get_remaining_investor_slots_post_lower_cap() {
     client.lower_max_unique_investors(&3u32);
     
     assert_eq!(client.get_remaining_investor_slots(), Some(0));
+}
+
+// --- lower_min_contribution_floor (#493) ---
+
+#[test]
+fn test_lower_min_contribution_floor_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    let initial_floor = 10_000i128;
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_LOWER"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(initial_floor),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    assert_eq!(client.get_min_contribution_floor(), initial_floor);
+
+    let new_floor = client.lower_min_contribution_floor(&5_000i128);
+    assert_eq!(new_floor, 5_000i128);
+    assert_eq!(client.get_min_contribution_floor(), 5_000i128);
+}
+
+#[test]
+fn test_lower_floor_enforces_new_floor() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    let initial_floor = 10_000i128;
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_ENF"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(initial_floor),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Lower the floor
+    client.lower_min_contribution_floor(&5_000i128);
+    assert_eq!(client.get_min_contribution_floor(), 5_000i128);
+
+    // Fund at the new floor level must succeed
+    let inv = Address::generate(&env);
+    client.fund(&inv, &5_000i128);
+    assert_eq!(client.get_contribution(&inv), 5_000i128);
+
+    // Fund below the new floor must be rejected
+    let inv2 = Address::generate(&env);
+    assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund(&inv2, &4_999i128);
+    }))
+    .is_err());
+}
+
+#[test]
+#[should_panic]
+fn test_lower_floor_rejects_raise() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_RAISE"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(10_000i128),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Attempt to raise the floor
+    client.lower_min_contribution_floor(&20_000i128);
+}
+
+#[test]
+#[should_panic]
+fn test_lower_floor_rejects_same_floor() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_SAME"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(10_000i128),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Attempt to set the same floor
+    client.lower_min_contribution_floor(&10_000i128);
+}
+
+#[test]
+#[should_panic]
+fn test_lower_floor_rejects_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_ZERO"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(10_000i128),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Non-positive floor must be rejected
+    client.lower_min_contribution_floor(&0i128);
+}
+
+#[test]
+#[should_panic]
+fn test_lower_floor_rejects_negative() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_NEG"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(10_000i128),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Negative floor must be rejected
+    client.lower_min_contribution_floor(&-1i128);
+}
+
+#[test]
+#[should_panic]
+fn test_lower_floor_rejects_non_open_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_STATE"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(10_000i128),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Fund to close the escrow
+    client.fund(&Address::generate(&env), &100_000_000_000i128);
+    assert_eq!(client.get_escrow().status, 1);
+
+    // Cannot lower floor in funded state
+    client.lower_min_contribution_floor(&5_000i128);
+}
+
+#[test]
+fn test_lower_floor_requires_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_AUTH"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(10_000i128),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    client.lower_min_contribution_floor(&5_000i128);
+    assert!(
+        env.auths().iter().any(|(addr, _)| *addr == admin),
+        "admin auth was not recorded for lower_min_contribution_floor"
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_lower_floor_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_UNAUTH"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(10_000i128),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    env.mock_auths(&[]);
+    client.lower_min_contribution_floor(&5_000i128);
+}
+
+#[test]
+fn test_lower_floor_emits_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+    let contract_id = client.address.clone();
+
+    let initial_floor = 10_000i128;
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_EVT"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(initial_floor),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    client.lower_min_contribution_floor(&5_000i128);
+
+    assert_eq!(
+        env.events().all(),
+        std::vec![crate::MinContributionFloorLowered {
+            name: symbol_short!("floor_lo"),
+            invoice_id: client.get_escrow().invoice_id,
+            old_floor: 10_000i128,
+            new_floor: 5_000i128,
+        }
+        .to_xdr(&env, &contract_id)]
+    );
+}
+
+#[test]
+fn test_lower_floor_twice_successive() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_TWICE"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(10_000i128),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    assert_eq!(client.get_min_contribution_floor(), 10_000i128);
+    client.lower_min_contribution_floor(&7_000i128);
+    assert_eq!(client.get_min_contribution_floor(), 7_000i128);
+    client.lower_min_contribution_floor(&5_000i128);
+    assert_eq!(client.get_min_contribution_floor(), 5_000i128);
+    client.lower_min_contribution_floor(&1_000i128);
+    assert_eq!(client.get_min_contribution_floor(), 1_000i128);
+}
+
+#[test]
+fn test_lower_floor_fund_at_old_floor_still_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_OLD"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &Some(10_000i128),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Lower floor from 10,000 to 5,000
+    client.lower_min_contribution_floor(&5_000i128);
+
+    // Fund at exactly the new floor (5,000) must succeed
+    let inv1 = Address::generate(&env);
+    client.fund(&inv1, &5_000i128);
+    assert_eq!(client.get_contribution(&inv1), 5_000i128);
+
+    // Existing investor follow-on deposit at the new floor
+    client.fund(&inv1, &5_000i128);
+    assert_eq!(client.get_contribution(&inv1), 10_000i128);
+
+    // New investor at the old floor (10,000) must also succeed (it's above new floor)
+    let inv2 = Address::generate(&env);
+    client.fund(&inv2, &10_000i128);
+    assert_eq!(client.get_contribution(&inv2), 10_000i128);
+}
+
+#[test]
+fn test_lower_floor_unconfigured_succeeds_if_positive() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    // Init with no min_contribution floor (defaults to 0)
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_NOCONF"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Floor defaults to 0
+    assert_eq!(client.get_min_contribution_floor(), 0);
+
+    // Cannot lower to a positive value since 0 is the current floor and new floor must be < old
+    assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.lower_min_contribution_floor(&5_000i128);
+    }))
+    .is_err());
 }

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -174,6 +174,7 @@ fn escrow_error_discriminants_match_canonical_table() {
         (EscrowError::TierYieldBelowBase, 11),
         (EscrowError::TierLockNotIncreasing, 12),
         (EscrowError::TierYieldNotNonDecreasing, 13),
+        (EscrowError::AmountExceedsMax, 14),
         (EscrowError::EscrowNotInitialized, 20),
         (EscrowError::FundingTokenNotSet, 21),
         (EscrowError::TreasuryNotSet, 22),
@@ -245,8 +246,11 @@ fn escrow_error_discriminants_match_canonical_table() {
         (EscrowError::NewSmeSameAsCurrent, 162),
         (EscrowError::FundingDeadlinePassed, 164),
         (EscrowError::NoPendingAdmin, 163),
+        (EscrowError::FloorLowerNotOpen, 173),
+        (EscrowError::NewFloorNotLower, 174),
+        (EscrowError::NewFloorNotPositive, 175),
     ];
-    assert_eq!(TABLE.len(), 84);
+    assert_eq!(TABLE.len(), 88);
     for (variant, code) in TABLE {
         assert_eq!(*variant as u32, *code, "discriminant drift for code {code}");
     }

--- a/escrow/src/tests/external_calls.rs
+++ b/escrow/src/tests/external_calls.rs
@@ -507,9 +507,8 @@ fn sweep_liability_floor_refund_then_sweep_sequence() {
     let investors = [a.clone(), b.clone(), c.clone()];
     let amounts = [300i128, 300i128, 300i128];
 
-    let (token, treasury) = setup_multi_investor_cancelled(
-        &env, &client, &admin, &sme, &investors, &amounts,
-    );
+    let (token, treasury) =
+        setup_multi_investor_cancelled(&env, &client, &admin, &sme, &investors, &amounts);
 
     // Mint extra dust
     token.stellar.mint(&client.address, &100i128);
@@ -553,9 +552,8 @@ fn sweep_liability_floor_one_unit_over_fails() {
     let investors = [a.clone(), b.clone()];
     let amounts = [500i128, 500i128];
 
-    let (_token, _treasury) = setup_multi_investor_cancelled(
-        &env, &client, &admin, &sme, &investors, &amounts,
-    );
+    let (_token, _treasury) =
+        setup_multi_investor_cancelled(&env, &client, &admin, &sme, &investors, &amounts);
 
     // Refund one -> distributed=500, outstanding=500, balance=500
     client.refund(&a);
@@ -572,9 +570,8 @@ fn sweep_liability_floor_capped_by_max_dust_sweep() {
     let investors = [a.clone()];
     let amounts = [500i128];
 
-    let (token, treasury) = setup_multi_investor_cancelled(
-        &env, &client, &admin, &sme, &investors, &amounts,
-    );
+    let (token, treasury) =
+        setup_multi_investor_cancelled(&env, &client, &admin, &sme, &investors, &amounts);
 
     // All refunded -> outstanding = 0
     client.refund(&a);
@@ -585,10 +582,7 @@ fn sweep_liability_floor_capped_by_max_dust_sweep() {
 
     let swept = client.sweep_terminal_dust(&huge_dust);
     assert_eq!(swept, MAX_DUST_SWEEP_AMOUNT);
-    assert_eq!(
-        token.token.balance(&treasury),
-        MAX_DUST_SWEEP_AMOUNT
-    );
+    assert_eq!(token.token.balance(&treasury), MAX_DUST_SWEEP_AMOUNT);
 }
 
 #[test]
@@ -656,9 +650,8 @@ fn sweep_liability_floor_all_refunded_sweep_all_dust() {
     let investors = [a.clone(), b.clone()];
     let amounts = [400i128, 600i128];
 
-    let (token, treasury) = setup_multi_investor_cancelled(
-        &env, &client, &admin, &sme, &investors, &amounts,
-    );
+    let (token, treasury) =
+        setup_multi_investor_cancelled(&env, &client, &admin, &sme, &investors, &amounts);
 
     client.refund(&a);
     client.refund(&b);

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -3993,7 +3993,11 @@ fn test_get_investors_legacy_compatibility() {
 // ---------------------------------------------------------------------------
 
 /// Helper: initialise an escrow and fund it partially, returning the client.
-fn setup_partially_funded(env: &Env, funded: i128, target: i128) -> super::LiquifactEscrowClient<'_> {
+fn setup_partially_funded(
+    env: &Env,
+    funded: i128,
+    target: i128,
+) -> super::LiquifactEscrowClient<'_> {
     let client = super::deploy(env);
     let admin = Address::generate(env);
     let sme = Address::generate(env);
@@ -4230,8 +4234,14 @@ fn test_update_funding_target_snapshot_written_only_once() {
     let snap2 = client.get_funding_close_snapshot().unwrap();
     assert_eq!(snap1.total_principal, snap2.total_principal);
     assert_eq!(snap1.funding_target, snap2.funding_target);
-    assert_eq!(snap1.closed_at_ledger_timestamp, snap2.closed_at_ledger_timestamp);
-    assert_eq!(snap1.closed_at_ledger_sequence, snap2.closed_at_ledger_sequence);
+    assert_eq!(
+        snap1.closed_at_ledger_timestamp,
+        snap2.closed_at_ledger_timestamp
+    );
+    assert_eq!(
+        snap1.closed_at_ledger_sequence,
+        snap2.closed_at_ledger_sequence
+    );
 }
 
 /// After promotion via `update_funding_target`, a subsequent `fund` call must

--- a/escrow/src/tests/properties.rs
+++ b/escrow/src/tests/properties.rs
@@ -1488,9 +1488,19 @@ fn cancelled_escrow<'a>(
     client.init(
         &admin,
         &soroban_sdk::String::from_str(env, invoice_id),
-        &sme, &target, &800i64, &0u64,
-        &token, &None, &treasury, &None,
-        &None, &None, &None, &None, &None,
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
     );
     for (investor, amount) in contributions {
         client.fund(investor, amount);
@@ -1522,7 +1532,9 @@ fn dust_sweep_after_full_refund_allows_sweep_to_zero() {
 #[test]
 fn fuzz_dust_sweep_liability_floor() {
     let cases: usize = std::env::var("ESCROW_FUZZ_CASES")
-        .ok().and_then(|v| v.parse().ok()).unwrap_or(32);
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(32);
     let base_seed = read_fuzz_seed_u64();
     for case_idx in 0..cases {
         let case_seed = base_seed ^ (case_idx as u64).wrapping_mul(0xD0575_0000_0001u64);


### PR DESCRIPTION
## feat: add lower_min_contribution_floor entrypoint and enrich accept_admin event

Closes #493  
Closes #494

Issue #493 — Lower minimum contribution floor
Adds lower_min_contribution_floor(env, new_floor: i128) — a lower-only admin entrypoint that reduces the per-call minimum contribution floor while the escrow is open.
Enforcement:
- Requires admin auth (load_escrow_require_admin)
- Only callable while escrow is open (status == 0)
- Rejects new_floor >= current floor (NewFloorNotLower)
- Rejects non-positive floor (NewFloorNotPositive)
- Persists to DataKey::MinContributionFloor
- Emits MinContributionFloorLowered event with symbol_short!("floor_lo"), old_floor, new_floor
- Updated floor is immediately enforced by FundingBelowMinContribution in fund_impl
Also fixes: Added pre-existing missing AmountExceedsMax = 14 error variant referenced in init() but absent from the enum.
Issue #494 — Enriched accept_admin event
Introduces AdminAcceptedEvent with dedicated adm_acc symbol, carrying:
- invoice_id (topic)
- prior_admin — the outgoing admin address
- new_admin — the promoted successor
This makes the completed two-step handover unambiguous for indexers, who can now distinguish a freshly-proposed-then-accepted handover from the deprecated one-shot transfer_admin shim (depr_xfer).
Backward compatibility: Uses a new symbol (adm_acc) so existing indexers are not broken. The AdminTransferredEvent struct is retained for reference but the new AdminAcceptedEvent is the canonical event from accept_admin.
Security notes
Issue #493:
- The floor can only decrease (strictly lower enforced) — no silent increase possible.
- Only callable while status == 0 (open); once the escrow exits open state, the floor is frozen.
- Admin-authenticated via the standard load_escrow_require_admin pattern.
- The NewFloorNotPositive guard prevents lowering to zero or negative, which would effectively disable the floor.
Issue #494:
- AdminAcceptedEvent reflects the actual on-chain admin transition — no race window between event and storage write.
- Unique adm_acc symbol prevents collision with admin (used by deprecated transfer_admin shim), adm_prop, or adm_can.
- All existing guard paths preserved: NoPendingAdmin rejection, expiry check, and pending-admin auth requirement.
Test coverage
cap_validation.rs (12 new tests):
Test	Coverage
test_lower_min_contribution_floor_success	Happy path — lower from 10,000 to 5,000
test_lower_floor_enforces_new_floor	New floor gates subsequent funding calls
test_lower_floor_rejects_raise	Higher floor → NewFloorNotLower
test_lower_floor_rejects_same_floor	Equal floor → NewFloorNotLower
test_lower_floor_rejects_zero	Zero floor → NewFloorNotPositive
test_lower_floor_rejects_negative	Negative floor → NewFloorNotPositive
test_lower_floor_rejects_non_open_state	Funded state → FloorLowerNotOpen
test_lower_floor_requires_admin_auth	Auth guard — admin signature recorded
test_lower_floor_unauthorized_panics	No auth → panic
test_lower_floor_emits_event	Event payload correctness (old/new floor)
test_lower_floor_twice_successive	Multiple successive lowers
test_lower_floor_fund_at_old_floor_still_enforced	Cross-floor funding behavior
admin.rs (1 new test, 1 updated):
Test	Coverage
test_accept_admin_event_carries_prior_and_new_admin	Event payload with prior/new admin + state assertions
test_admin_handover_lifecycle	Updated to assert AdminAcceptedEvent
coverage.rs and admin.rs — Error code uniqueness tables updated with 4 new variants.
Files changed
File	Changes
escrow/src/lib.rs	+74 lines — error variants, event structs, entrypoint, accept_admin update
escrow/src/tests/admin.rs	+54 lines — event test + updated lifecycle assertion + uniqueness table
escrow/src/tests/cap_validation.rs	+465 lines — 12 comprehensive tests
escrow/src/tests/	+6 lines — discriminant table entries