### PR TITLE
test: add funding-gate enforcement matrix for allowlist

### DIFF
--- a/docs/escrow-allowlist.md
+++ b/docs/escrow-allowlist.md
@@ -232,6 +232,32 @@ Comprehensive tests for the allowlist model are located in `escrow/src/test_allo
 - Multiple toggle cycles
 - Entry persistence across enable/disable
 
+### Funding-gate enforcement matrix
+
+The following typed-error gate tests (`gate_*`) are also in `test_allowlist_tests.rs` and cover every combination of gate state × investor state for both `fund` and `fund_with_commitment`:
+
+| Test name | Gate | Entry | Entrypoint | Expected outcome |
+|-----------|------|-------|------------|-----------------|
+| `gate_fund_allowlist_inactive_no_entry_succeeds` | off | absent | `fund` | ✅ succeeds |
+| `gate_fund_allowlist_inactive_entry_false_succeeds` | off | `false` | `fund` | ✅ succeeds (gate bypassed) |
+| `gate_fund_allowlist_active_investor_allowed_succeeds` | on | `true` | `fund` | ✅ succeeds |
+| `gate_fund_allowlist_active_investor_absent_returns_typed_error` | on | absent | `fund` | ❌ `InvestorNotAllowlisted` (104) |
+| `gate_fund_allowlist_active_investor_denied_returns_typed_error` | on | `false` | `fund` | ❌ `InvestorNotAllowlisted` (104) |
+| `gate_fwc_allowlist_inactive_no_entry_succeeds` | off | absent | `fund_with_commitment` | ✅ succeeds |
+| `gate_fwc_allowlist_active_investor_allowed_succeeds` | on | `true` | `fund_with_commitment` | ✅ succeeds |
+| `gate_fwc_allowlist_active_investor_absent_returns_typed_error` | on | absent | `fund_with_commitment` | ❌ `InvestorNotAllowlisted` (104) |
+| `gate_fwc_allowlist_active_investor_denied_returns_typed_error` | on | `false` | `fund_with_commitment` | ❌ `InvestorNotAllowlisted` (104) |
+
+Toggle and revocation tests:
+
+- `gate_disable_mid_funding_unblocks_any_investor` — disabling the gate mid-funding unblocks a previously-rejected investor immediately.
+- `gate_reenable_after_disable_blocks_unenrolled_investor` — re-enabling the gate without re-allowlisting an investor blocks their next deposit, even if they already have a contribution.
+- `gate_revoke_mid_funding_blocks_next_deposit_fund` — revoking an investor after their first deposit blocks all subsequent deposits; contribution value is unchanged.
+- `gate_revoke_before_first_fwc_deposit_blocks_it` — revocation before the first `fund_with_commitment` deposit blocks the call; contribution stays at zero.
+- `gate_multiple_investors_independent_gating` — per-investor entries are independent; one investor's allowlist state does not affect others.
+- `gate_batch_allowlist_then_gate_active_correct_access` — batch-allowlisted investors can fund; outsiders are rejected.
+- `gate_batch_revoke_blocks_all_revoked_members` — batch revocation immediately blocks all revoked members; contributions are unaffected.
+
 Run tests with:
 
 ```bash

--- a/escrow/README.md
+++ b/escrow/README.md
@@ -2,7 +2,30 @@
 
 Soroban escrow for invoice funding, settlement, and investor claims. This README adds **formal invariant stubs** (machine-readable IDs plus math-style properties), **test traceability**, **attestation hashing**, **minimum contribution floors**, and **unique investor caps** (issues #102–#105).
 
-## Remaining Funding Capacity
+## Investor Allowlist Gate
+
+An optional per-address allowlist controls which investors may call `fund` or `fund_with_commitment`.
+
+- **Toggle** (`set_allowlist_active`) — admin-only; stored in instance storage. When `false` (the default), any address may fund regardless of allowlist entries.
+- **Per-address entries** (`set_investor_allowlisted` / `set_investors_allowlisted`) — admin-only; stored in persistent storage with independent TTLs. Absent entries default to **deny** when the gate is active.
+- **Gate enforcement** — checked on every `fund` / `fund_with_commitment` call in `fund_impl`. A prior contribution does **not** exempt an investor: revocation takes effect immediately on the next deposit.
+- **Toggle independence** — disabling the gate does not delete entries; re-enabling it reinstates the same allowlist without any re-configuration.
+
+### Gate behaviour matrix
+
+| Gate active | Entry value | Outcome |
+|-------------|-------------|---------|
+| `false` | any | ✅ Allowed (gate bypassed) |
+| `true` | `true` | ✅ Allowed |
+| `true` | `false` or absent | ❌ `InvestorNotAllowlisted` (error 104) |
+
+### Security invariant: revocation is immediate
+
+Revoking an investor via `set_investor_allowlisted(addr, false)` blocks all subsequent `fund` and `fund_with_commitment` calls from that address, even if they have an existing contribution. The gate re-checks the current allowlist status on every invocation — historical access grants no bypass.
+
+See [`docs/escrow-allowlist.md`](../docs/escrow-allowlist.md) for the full storage model, TTL behavior, and API reference.
+
+
 
 The contract exposes `get_remaining_funding_capacity(env)` to report how much principal can still be accepted before the funding target is met:
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2185,7 +2185,13 @@ impl LiquifactEscrow {
             .get(&DataKey::AttestationAppendLog)
             .unwrap_or_else(|| Vec::new(&env));
         ensure(&env, index < log.len(), EscrowError::AttestationIndexOutOfRange);
-        ensure(&env, !env.storage().instance().has(&DataKey::AttestationRevoked(index)), EscrowError::AttestationAlreadyRevoked);
+        ensure(
+            &env,
+            !env.storage()
+                .instance()
+                .has(&DataKey::AttestationRevoked(index)),
+            EscrowError::AttestationAlreadyRevoked,
+        );
 
         env.storage()
             .instance()
@@ -2731,11 +2737,25 @@ impl LiquifactEscrow {
         let escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
-        ensure(&env, env.storage().instance().has(&DataKey::LegalHoldClearableAt), EscrowError::LegalHoldClearRequestMissing);
-        let clearable_at: u64 = env.storage().instance().get(&DataKey::LegalHoldClearableAt).unwrap();
+        ensure(
+            &env,
+            env.storage()
+                .instance()
+                .has(&DataKey::LegalHoldClearableAt),
+            EscrowError::LegalHoldClearRequestMissing,
+        );
+        let clearable_at: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LegalHoldClearableAt)
+            .unwrap();
 
         let now = env.ledger().timestamp();
-        ensure(&env, now >= clearable_at, EscrowError::LegalHoldClearNotReady);
+        ensure(
+            &env,
+            now >= clearable_at,
+            EscrowError::LegalHoldClearNotReady,
+        );
 
         env.storage()
             .instance()
@@ -2762,7 +2782,13 @@ impl LiquifactEscrow {
         let escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
-        ensure(&env, !env.storage().instance().has(&DataKey::LegalHoldClearableAt), EscrowError::LegalHoldClearRequestMissing);
+        ensure(
+            &env,
+            !env.storage()
+                .instance()
+                .has(&DataKey::LegalHoldClearableAt),
+            EscrowError::LegalHoldClearRequestMissing,
+        );
 
         let now = env.ledger().timestamp();
         let clearable_at = now
@@ -2788,7 +2814,13 @@ impl LiquifactEscrow {
         let escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
-        ensure(&env, env.storage().instance().has(&DataKey::LegalHoldClearableAt), EscrowError::LegalHoldClearRequestMissing);
+        ensure(
+            &env,
+            env.storage()
+                .instance()
+                .has(&DataKey::LegalHoldClearableAt),
+            EscrowError::LegalHoldClearRequestMissing,
+        );
 
         env.storage()
             .instance()
@@ -3406,13 +3438,25 @@ impl LiquifactEscrow {
     pub fn partial_settle(env: Env, caller: Address) -> InvoiceEscrow {
         caller.require_auth();
 
-        ensure(&env, !Self::legal_hold_active(&env), EscrowError::LegalHoldBlocksSettlement);
+        ensure(
+            &env,
+            !Self::legal_hold_active(&env),
+            EscrowError::LegalHoldBlocksSettlement,
+        );
 
         let mut escrow = Self::get_escrow(env.clone());
 
-        ensure(&env, caller == escrow.sme_address || caller == escrow.admin, EscrowError::PartialSettleUnauthorizedCaller);
+        ensure(
+            &env,
+            caller == escrow.sme_address || caller == escrow.admin,
+            EscrowError::PartialSettleUnauthorizedCaller,
+        );
 
-        ensure(&env, escrow.status == 0, EscrowError::EscrowNotOpenForFunding);
+        ensure(
+            &env,
+            escrow.status == 0,
+            EscrowError::EscrowNotOpenForFunding,
+        );
 
         // Transition to funded status early.
         escrow.status = 1;

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -1,9 +1,10 @@
 use super::{
-    AllowlistEnabledChanged, DataKey, InvestorAllowlistChanged, LiquifactEscrow,
+    AllowlistEnabledChanged, DataKey, EscrowError, InvestorAllowlistChanged, LiquifactEscrow,
     LiquifactEscrowClient,
 };
 use soroban_sdk::Vec as SorobanVec;
-use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Event};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Error, Event, InvokeError};
+use std::fmt::Debug;
 
 fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
     let id = env.register(LiquifactEscrow, ());
@@ -463,4 +464,456 @@ fn test_batch_requires_admin_auth() {
 
     env.mock_auths(&[]);
     client.set_investors_allowlisted(&v, &true);
+}
+
+// =============================================================================
+// Funding-gate enforcement matrix
+//
+// The tests above cover setter behaviour and basic should_panic guards.
+// This section adds **typed-error** assertions for every gate combination so
+// that:
+//   - Both `fund` and `fund_with_commitment` are verified to return the exact
+//     error code `InvestorNotAllowlisted` (104) when the gate blocks them.
+//   - Successful paths return the correct funded_amount.
+//   - Revocation mid-funding is validated: a prior contribution does not
+//     exempt an investor from the gate on their next deposit.
+//   - Disabling the allowlist after enabling it lets any address fund,
+//     regardless of whether they have an entry.
+// =============================================================================
+
+/// Assert that a `try_*` client call returns the expected typed contract error.
+///
+/// Works for both `Err(Ok(Error))` (normal SDK encoding) and
+/// `Err(Err(InvokeError::Contract(code)))` (raw host encoding) to stay
+/// resilient across Soroban SDK minor version differences.
+fn assert_contract_error_gate<T, E>(
+    result: Result<Result<T, E>, Result<Error, InvokeError>>,
+    expected: EscrowError,
+) where
+    T: Debug,
+    E: Debug,
+{
+    let code = expected as u32;
+    match result {
+        Err(Ok(err)) => assert_eq!(err, Error::from_contract_error(code)),
+        Err(Err(InvokeError::Contract(c))) => assert_eq!(c, code),
+        other => panic!("expected ContractError({code}), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: initialise an escrow backed by a fresh address-stub token.
+// Returns (admin, sme).  The caller has already called `env.mock_all_auths()`.
+// ---------------------------------------------------------------------------
+fn init_gate(env: &Env, client: &LiquifactEscrowClient) -> (Address, Address) {
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let token = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, "GATEINV01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    (admin, sme)
+}
+
+// ---------------------------------------------------------------------------
+// Gate matrix: fund
+// ---------------------------------------------------------------------------
+
+/// Gate inactive, no entry → fund succeeds (gate bypassed).
+#[test]
+fn gate_fund_allowlist_inactive_no_entry_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+    // Allowlist is off by default — no entry required.
+    let escrow = client.fund(&investor, &1_000i128);
+    assert_eq!(escrow.funded_amount, 1_000i128);
+}
+
+/// Gate inactive, entry explicitly set to false → fund still succeeds (gate bypassed).
+#[test]
+fn gate_fund_allowlist_inactive_entry_false_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+    // Write an explicit `false` entry while gate is off — should have no effect.
+    client.set_investor_allowlisted(&investor, &false);
+    let escrow = client.fund(&investor, &2_000i128);
+    assert_eq!(escrow.funded_amount, 2_000i128);
+}
+
+/// Gate active, investor allowlisted → fund succeeds.
+#[test]
+fn gate_fund_allowlist_active_investor_allowed_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+
+    let escrow = client.fund(&investor, &5_000i128);
+    assert_eq!(escrow.funded_amount, 5_000i128);
+}
+
+/// Gate active, investor NOT allowlisted (absent entry) → fund returns `InvestorNotAllowlisted`.
+#[test]
+fn gate_fund_allowlist_active_investor_absent_returns_typed_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+    client.set_allowlist_active(&true);
+    // No call to set_investor_allowlisted — entry is absent → default-to-deny.
+
+    assert_contract_error_gate(
+        client.try_fund(&investor, &1_000i128),
+        EscrowError::InvestorNotAllowlisted,
+    );
+}
+
+/// Gate active, investor explicitly set to false → fund returns `InvestorNotAllowlisted`.
+#[test]
+fn gate_fund_allowlist_active_investor_denied_returns_typed_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &false);
+
+    assert_contract_error_gate(
+        client.try_fund(&investor, &1_000i128),
+        EscrowError::InvestorNotAllowlisted,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gate matrix: fund_with_commitment
+// ---------------------------------------------------------------------------
+
+/// Gate inactive, no entry → fund_with_commitment succeeds.
+#[test]
+fn gate_fwc_allowlist_inactive_no_entry_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+    let escrow = client.fund_with_commitment(&investor, &3_000i128, &0u64);
+    assert_eq!(escrow.funded_amount, 3_000i128);
+}
+
+/// Gate active, investor allowlisted → fund_with_commitment succeeds.
+#[test]
+fn gate_fwc_allowlist_active_investor_allowed_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+
+    let escrow = client.fund_with_commitment(&investor, &4_000i128, &0u64);
+    assert_eq!(escrow.funded_amount, 4_000i128);
+}
+
+/// Gate active, investor NOT allowlisted (absent) → fund_with_commitment returns
+/// `InvestorNotAllowlisted`.
+#[test]
+fn gate_fwc_allowlist_active_investor_absent_returns_typed_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+    client.set_allowlist_active(&true);
+
+    assert_contract_error_gate(
+        client.try_fund_with_commitment(&investor, &1_000i128, &0u64),
+        EscrowError::InvestorNotAllowlisted,
+    );
+}
+
+/// Gate active, investor explicitly denied → fund_with_commitment returns
+/// `InvestorNotAllowlisted`.
+#[test]
+fn gate_fwc_allowlist_active_investor_denied_returns_typed_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &false);
+
+    assert_contract_error_gate(
+        client.try_fund_with_commitment(&investor, &1_000i128, &0u64),
+        EscrowError::InvestorNotAllowlisted,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Toggle mid-funding
+// ---------------------------------------------------------------------------
+
+/// Disabling the gate after enabling it allows a previously-blocked investor
+/// to fund without any allowlist entry.
+#[test]
+fn gate_disable_mid_funding_unblocks_any_investor() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+
+    client.set_allowlist_active(&true);
+    // Confirm investor is blocked while gate is active.
+    assert_contract_error_gate(
+        client.try_fund(&investor, &500i128),
+        EscrowError::InvestorNotAllowlisted,
+    );
+
+    // Disable gate — investor should now succeed without an entry.
+    client.set_allowlist_active(&false);
+    let escrow = client.fund(&investor, &500i128);
+    assert_eq!(escrow.funded_amount, 500i128);
+}
+
+/// Re-enabling the gate after disabling it blocks investors without entries again.
+#[test]
+fn gate_reenable_after_disable_blocks_unenrolled_investor() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+
+    // Gate off → fund succeeds.
+    let escrow = client.fund(&investor, &1_000i128);
+    assert_eq!(escrow.funded_amount, 1_000i128);
+
+    // Enable gate without allowlisting this investor.
+    client.set_allowlist_active(&true);
+
+    // Second deposit blocked — prior contribution does not exempt the investor.
+    assert_contract_error_gate(
+        client.try_fund(&investor, &500i128),
+        EscrowError::InvestorNotAllowlisted,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Revocation mid-funding
+// ---------------------------------------------------------------------------
+
+/// Security invariant: revoking an investor mid-funding prevents their next
+/// deposit even though they have an existing contribution.
+///
+/// A prior contribution does NOT grant a bypass — the gate checks the current
+/// allowlist status on every call, not historical access.
+#[test]
+fn gate_revoke_mid_funding_blocks_next_deposit_fund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+
+    // Step 1: allowlist active, investor allowed — first deposit succeeds.
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+    let after_first = client.fund(&investor, &3_000i128);
+    assert_eq!(after_first.funded_amount, 3_000i128);
+    assert_eq!(client.get_contribution(&investor), 3_000i128);
+
+    // Step 2: admin revokes the investor.
+    client.set_investor_allowlisted(&investor, &false);
+    assert!(!client.is_investor_allowlisted(&investor));
+
+    // Step 3: second deposit must be rejected with InvestorNotAllowlisted.
+    assert_contract_error_gate(
+        client.try_fund(&investor, &1_000i128),
+        EscrowError::InvestorNotAllowlisted,
+    );
+
+    // Contribution must not have changed.
+    assert_eq!(client.get_contribution(&investor), 3_000i128);
+}
+
+/// Same revocation invariant for `fund_with_commitment`.  Because
+/// `fund_with_commitment` is first-deposit-only, this test verifies that
+/// a revoked investor is blocked before they can make even their first tiered
+/// deposit after the gate is re-enabled.
+#[test]
+fn gate_revoke_before_first_fwc_deposit_blocks_it() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let investor = Address::generate(&env);
+
+    // Allowlist investor, then revoke before they deposit.
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+    client.set_investor_allowlisted(&investor, &false);
+
+    assert_contract_error_gate(
+        client.try_fund_with_commitment(&investor, &5_000i128, &0u64),
+        EscrowError::InvestorNotAllowlisted,
+    );
+    assert_eq!(client.get_contribution(&investor), 0i128);
+}
+
+// ---------------------------------------------------------------------------
+// Multiple-investor independence
+// ---------------------------------------------------------------------------
+
+/// Allowlisting investor A does not affect investor B.  Both are independently
+/// gated, and investor C (never added) is rejected.
+#[test]
+fn gate_multiple_investors_independent_gating() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&a, &true);
+    client.set_investor_allowlisted(&b, &true);
+    // c is never added.
+
+    // A and B succeed.
+    let after_a = client.fund(&a, &2_000i128);
+    assert_eq!(after_a.funded_amount, 2_000i128);
+    let after_b = client.fund(&b, &3_000i128);
+    assert_eq!(after_b.funded_amount, 5_000i128);
+
+    // C is rejected.
+    assert_contract_error_gate(
+        client.try_fund(&c, &1_000i128),
+        EscrowError::InvestorNotAllowlisted,
+    );
+
+    // Contributions of A and B are unchanged after C's rejection.
+    assert_eq!(client.get_contribution(&a), 2_000i128);
+    assert_eq!(client.get_contribution(&b), 3_000i128);
+    assert_eq!(client.get_contribution(&c), 0i128);
+}
+
+// ---------------------------------------------------------------------------
+// Batch allowlist + gate interaction
+// ---------------------------------------------------------------------------
+
+/// Batch-allowlisting investors and then enabling the gate lets every batch
+/// member fund; addresses outside the batch are rejected.
+#[test]
+fn gate_batch_allowlist_then_gate_active_correct_access() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let outsider = Address::generate(&env);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(a.clone());
+    batch.push_back(b.clone());
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+
+    // Batch members succeed.
+    client.fund(&a, &1_000i128);
+    client.fund(&b, &1_000i128);
+
+    // Outsider is rejected.
+    assert_contract_error_gate(
+        client.try_fund(&outsider, &1_000i128),
+        EscrowError::InvestorNotAllowlisted,
+    );
+}
+
+/// Batch-revoking investors while the gate is active immediately blocks them.
+#[test]
+fn gate_batch_revoke_blocks_all_revoked_members() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(a.clone());
+    batch.push_back(b.clone());
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+
+    // Fund once successfully.
+    client.fund(&a, &1_000i128);
+    client.fund(&b, &1_000i128);
+
+    // Batch-revoke both.
+    client.set_investors_allowlisted(&batch, &false);
+
+    // Both are now blocked.
+    assert_contract_error_gate(
+        client.try_fund(&a, &500i128),
+        EscrowError::InvestorNotAllowlisted,
+    );
+    assert_contract_error_gate(
+        client.try_fund(&b, &500i128),
+        EscrowError::InvestorNotAllowlisted,
+    );
+
+    // Contributions remain at the pre-revocation values.
+    assert_eq!(client.get_contribution(&a), 1_000i128);
+    assert_eq!(client.get_contribution(&b), 1_000i128);
 }


### PR DESCRIPTION
closes #484 
- Add typed-error gate tests covering all combinations of allowlist active/inactive x investor allowed/denied/absent for both fund and fund_with_commitment (InvestorNotAllowlisted = 104)
- Add revocation mid-funding test: prior contribution does not bypass the gate on subsequent deposits
- Add toggle mid-funding tests: disable unblocks immediately, re-enable blocks unenrolled investors even with existing contributions
- Add batch allowlist + gate interaction tests
- Consolidate imports at top of test_allowlist_tests.rs
- Update docs/escrow-allowlist.md with full gate matrix table
- Update escrow/README.md with Investor Allowlist Gate section