### PR TITLE
feat Database health check connection pool saturation

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1,0 +1,769 @@
+'use strict';
+
+/**
+ * @fileoverview Prometheus metrics registry and /metrics route handler.
+ *
+ * ## Auth strategy (in priority order)
+ *
+ * 1. If `METRICS_BEARER_TOKEN` is set, require `Authorization: Bearer <token>`.
+ *    The token comparison uses a **constant-time** algorithm to prevent timing
+ *    side-channel attacks.
+ *
+ * 2. If `METRICS_BEARER_TOKEN` is **unset**, allow requests from loopback
+ *    addresses only (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`). This is suitable
+ *    for private-network Prometheus scraping.
+ *
+ * 3. All other requests receive a uniform `401` with no detail about _why_
+ *    (no distinction between "wrong token" and "missing token").
+ *
+ * ## Security: trusted-proxy & X-Forwarded-For
+ *
+ * Loopback detection **always** reads the direct TCP connection address from
+ * `req.socket.remoteAddress`. The `X-Forwarded-For` header is **never**
+ * consulted, so a remote attacker cannot spoof a loopback origin by setting
+ * `X-Forwarded-For: 127.0.0.1`.
+ *
+ * There is no `app.set('trust proxy', ...)` call anywhere in this application.
+ * If one is added in the future, `req.ip` could resolve to a `X-Forwarded-For`
+ * value, but this middleware **already** ignores `req.ip` for loopback checks
+ * and reads the socket directly, making it resilient to such config changes.
+ *
+ * @module metrics
+ */
+
+let client;
+try {
+  client = require('prom-client');
+} catch (_e) {
+  console.error('Failed to load prom-client:', _e);
+  // Fallback shim for environments without prom-client (tests).
+  //
+  // The shims maintain the same observable surface as real prom-client so
+  // tests can inspect `counter.hashMap` / `counter.get()` directly without
+  // changing the assertion code.
+
+  /**
+   * Minimal prom-client Registry shim for test environments.
+   * @implements {import('prom-client').Registry}
+   */
+  class RegistryShim {
+    /** @param {void} */
+    constructor() {
+      this.contentType = 'text/plain';
+      this._items = [];
+    }
+    /** @returns {string} */
+    metrics() {
+      return '';
+    }
+  }
+
+  /**
+   * Counter shim for test environments.
+   * @implements {import('prom-client').Counter}
+   */
+  class CounterShim {
+    /** @param {void} */
+    constructor() {}
+    /** @returns {void} */
+    inc() {}
+  }
+
+  /**
+   * Gauge shim for test environments.
+   * @implements {import('prom-client').Gauge}
+   */
+  class GaugeShim {
+    /** @param {void} */
+    constructor() {}
+    /** @returns {void} */
+    set() {}
+    /** @returns {void} */
+    setToCurrentTime() {}
+  }
+
+  client = {
+    Registry: RegistryShim,
+    /**
+     * No-op default metrics collector stub.
+     * @returns {void}
+     */
+    collectDefaultMetrics: () => { },
+    Counter: CounterShim,
+    Gauge: GaugeShim,
+  };
+}
+
+/** Shared registry — exported so tests can reset it between runs. */
+const registry = new client.Registry();
+
+if (typeof client.collectDefaultMetrics === 'function') {
+  client.collectDefaultMetrics({ register: registry });
+}
+
+const METRIC_REFRESH_INTERVAL_MS = 5000;
+const registeredJobQueues = new Set();
+const registeredWorkers = new Set();
+let refreshTimer = null;
+
+/**
+ * Registers a job queue for background metric scraping.
+ * @param {Object} queue - Queue to register.
+ * @returns {void}
+ */
+function registerJobQueue(queue) {
+  registeredJobQueues.add(queue);
+}
+
+/**
+ * Registers a background worker for metric scraping.
+ * @param {Object} worker - Worker to register.
+ * @returns {void}
+ */
+function registerWorker(worker) {
+  registeredWorkers.add(worker);
+}
+
+const queueDepthGauge = new client.Gauge({
+  name: 'liquifact_job_queue_depth',
+  help: 'Number of pending jobs currently waiting in background queues',
+  registers: [registry],
+});
+
+const retryQueueSizeGauge = new client.Gauge({
+  name: 'liquifact_job_retry_queue_size',
+  help: 'Number of jobs waiting in retry queues for background processing',
+  registers: [registry],
+});
+
+const workerInFlightGauge = new client.Gauge({
+  name: 'liquifact_worker_inflight_count',
+  help: 'Number of jobs currently being processed by background workers',
+  registers: [registry],
+});
+
+// Cached metrics text for compatibility with test environments where
+// prom-client is not available (shim). In production with the real
+// prom-client, `metricsHandler` calls the real `registry.metrics()`
+// which returns the full Prometheus exposition of ALL registered metrics.
+let cachedMetrics = '# HELP liquifact_custom_metrics Placeholder\n';
+
+/**
+ * Bounded enum of allowed `reason` label values for maturity-reminder metrics.
+ * Any raw error/reason string must be mapped through {@link normalizeReminderReason}
+ * before being used as a Prometheus label to prevent time-series cardinality explosion.
+ *
+ * | Value            | Meaning                                              |
+ * |------------------|------------------------------------------------------|
+ * | smtp_timeout     | SMTP connection or send timed out                    |
+ * | smtp_reject      | SMTP server rejected the message (4xx/5xx response)  |
+ * | template_error   | Email template rendering failed                      |
+ * | unknown          | Any other / unmapped failure                         |
+ */
+const REMINDER_REASON_ENUM = Object.freeze([
+  'smtp_timeout',
+  'smtp_reject',
+  'template_error',
+  'unknown',
+]);
+
+/**
+ * Bounded enum of allowed `job_type` label values.
+ * Add new job types here when introducing new background job kinds.
+ */
+const JOB_TYPE_ENUM = Object.freeze(['maturity_reminder', 'webhook_replay', 'unknown']);
+
+/**
+ * Bounded enum of allowed `outcome` label values for webhook replay metrics.
+ * @readonly
+ */
+const WEBHOOK_REPLAY_OUTCOME_ENUM = Object.freeze([
+  'success',
+  'failure',
+  'not_found',
+  'already_resolved',
+]);
+
+/**
+ * Refreshes all registered job queues and workers metrics.
+ * @returns {void}
+ */
+function refreshMetrics() {
+  let queueLength = 0;
+  let retryQueueLength = 0;
+
+  for (const queue of registeredJobQueues) {
+    try {
+      const stats = queue.getStats();
+      if (stats) {
+        queueLength += Number(stats.queueLength || 0);
+        retryQueueLength += Number(stats.retryQueueLength || 0);
+      }
+    } catch {
+      // Preserve existing metrics if a registered queue becomes invalid.
+    }
+  }
+
+  let workerInFlight = 0;
+  for (const worker of registeredWorkers) {
+    try {
+      const stats = worker.getStats();
+      if (stats && typeof stats.processingCount === 'number') {
+        workerInFlight += stats.processingCount;
+      }
+    } catch {
+      // Preserve existing metrics if a registered worker becomes invalid.
+    }
+  }
+
+  queueDepthGauge.set(queueLength);
+  retryQueueSizeGauge.set(retryQueueLength);
+  workerInFlightGauge.set(workerInFlight);
+
+  // Build a minimal Prometheus text exposition that includes our gauges.
+  // Keep labels bounded and avoid including payloads or per-job ids.
+  // The body-size-limit counter is read from the prom-client hashMap so it
+  // reflects all .inc() calls made since process start (or shim default 0).
+  let bodySizeRejectionsByType = '';
+  const hashMap = bodySizeLimitRejectionsTotal.hashMap || {};
+  for (const entry of Object.values(hashMap)) {
+    if (entry && typeof entry.value === 'number' && entry.value > 0) {
+      const labels = entry.labels || {};
+      const typeLabel = labels.type || 'unknown';
+      bodySizeRejectionsByType += `body_size_limit_rejections_total{type="${typeLabel}"} ${entry.value}\n`;
+    }
+  }
+
+  cachedMetrics = '' +
+    '# HELP liquifact_job_queue_depth Number of pending jobs waiting in queues\n' +
+    '# TYPE liquifact_job_queue_depth gauge\n' +
+    `liquifact_job_queue_depth ${queueLength}\n` +
+    '# HELP liquifact_job_retry_queue_size Number of jobs waiting in retry queues\n' +
+    '# TYPE liquifact_job_retry_queue_size gauge\n' +
+    `liquifact_job_retry_queue_size ${retryQueueLength}\n` +
+    '# HELP liquifact_worker_inflight_count Number of jobs currently being processed\n' +
+    '# TYPE liquifact_worker_inflight_count gauge\n' +
+    `liquifact_worker_inflight_count ${workerInFlight}\n` +
+    '# HELP body_size_limit_rejections_total Total number of request body-size limit rejections (413 Payload Too Large), labelled by limit type for DoS detection\n' +
+    '# TYPE body_size_limit_rejections_total counter\n' +
+    bodySizeRejectionsByType;
+}
+
+/**
+ * Starts the periodic metrics refresh interval timer.
+ * The timer is created once and automatically unref'd so it does not
+ * keep the Node.js process alive.
+ * @returns {void}
+ */
+function startMetricsRefresh() {
+  if (refreshTimer) {
+    return;
+  }
+
+  refreshTimer = setInterval(refreshMetrics, METRIC_REFRESH_INTERVAL_MS);
+  if (typeof refreshTimer.unref === 'function') {
+    refreshTimer.unref();
+  }
+}
+
+/**
+ * Stops the periodic metrics refresh interval timer.
+ * @returns {void}
+ */
+function stopMetricsRefresh() {
+  if (!refreshTimer) {
+    return;
+  }
+
+  clearInterval(refreshTimer);
+  refreshTimer = null;
+}
+
+/**
+ * Maps a raw job type string to a bounded Prometheus label value.
+ *
+ * @param {unknown} raw - Raw job type string.
+ * @returns {string} Bounded label value from {@link JOB_TYPE_ENUM}.
+ */
+function normalizeJobType(raw) {
+  const str = typeof raw === 'string' ? raw : '';
+  return JOB_TYPE_ENUM.includes(str) ? str : 'unknown';
+}
+
+/**
+ * Normalizes a raw SMTP/delivery error string to one of the bounded REMINDER_REASON_ENUM values.
+ * Parses common error patterns to prevent cardinality explosion in Prometheus.
+ *
+ * @param {Error|string|*} raw - The raw error thrown during email delivery.
+ * @returns {string} One of REMINDER_REASON_ENUM ('smtp_timeout', 'smtp_reject', 'template_error', 'unknown').
+ */
+function normalizeReminderReason(raw) {
+  if (!raw) { return 'unknown'; }
+  const msg = (raw instanceof Error ? raw.message : String(raw)).toLowerCase();
+  if (msg.includes('timeout') || msg.includes('etimedout')) {
+    return 'smtp_timeout';
+  }
+  if (msg.includes('reject') || msg.includes('invalid recipient') || /^[45]\d{2}\b/.test(msg)) {
+    return 'smtp_reject';
+  }
+  if (msg.includes('template') || msg.includes('render') || msg.includes('missing key')) {
+    return 'template_error';
+  }
+  return 'unknown';
+}
+
+// ── Maturity-reminder counters ────────────────────────────────────────────────
+
+/**
+ * Total maturity-reminder delivery attempts, labelled by bounded `reason` and `job_type`.
+ * @type {import('prom-client').Counter}
+ */
+const maturityReminderDeliveryAttemptsTotal = new client.Counter({
+  name: 'maturity_reminder_delivery_attempts_total',
+  help: 'Total number of maturity-reminder delivery attempts',
+  labelNames: ['reason', 'job_type'],
+  registers: [],
+});
+
+/**
+ * Total maturity-reminder dead-letter events, labelled by bounded `reason` and `job_type`.
+ * @type {import('prom-client').Counter}
+ */
+const maturityReminderDeadLetterTotal = new client.Counter({
+  name: 'maturity_reminder_dead_letter_total',
+  help: 'Total number of maturity-reminder messages moved to the dead-letter queue',
+  labelNames: ['reason', 'job_type'],
+  registers: [],
+});
+
+/**
+ * Total webhook replay attempts, labelled by bounded `outcome`.
+ * Outcomes: success | failure | not_found | already_resolved
+ * @type {import('prom-client').Counter}
+ */
+const webhookReplayTotal = new client.Counter({
+  name: 'webhook_replay_total',
+  help: 'Total number of webhook dead-letter replay attempts',
+  labelNames: ['outcome'],
+  registers: [],
+});
+
+/**
+ * Counter: Legal hold state processing errors.
+ * @type {import('prom-client').Counter}
+ */
+const legalHoldProcessingErrorsTotal = new client.Counter({
+  name: 'legal_hold_processing_errors_total',
+  help: 'Total number of processing errors encountered during legal hold evaluations',
+  labelNames: ['reason'],
+  registers: [],
+});
+
+/**
+ * Counter: Legal hold blocks processed.
+ * @type {import('prom-client').Counter}
+ */
+const legalHoldBlocksTotal = new client.Counter({
+  name: 'legal_hold_blocks_processed_total',
+  help: 'Total number of blocks evaluated with valid legal hold statuses',
+  labelNames: ['status'],
+  registers: [],
+});
+
+/**
+ * Counter: Redis fallback fail-open actions.
+ * @type {import('prom-client').Counter}
+ */
+const redisCacheFailOpenTotal = new client.Counter({
+  name: 'redis_cache_fail_open_total',
+  help: 'Total number of times redis queries failed and fell back to db/fail-open gracefully',
+  registers: [],
+});
+
+/**
+ * Counter: Cache store errors.
+ * @type {import('prom-client').Counter}
+ */
+const cacheStoreErrorsTotal = new client.Counter({
+  name: 'cache_store_errors_total',
+  help: 'Total number of errors encountered during cache operations',
+  labelNames: ['operation', 'error_type'],
+  registers: [],
+});
+
+/**
+ * Counter: Escrow creation request preflight rejections.
+ * @type {import('prom-client').Counter}
+ */
+const escrowPreflightRejectedTotal = new client.Counter({
+  name: 'escrow_preflight_rejected_total',
+  help: 'Total number of escrow creation requests rejected during preflight validation',
+  labelNames: ['reason'],
+  registers: [],
+});
+
+/**
+ * Counter: Body size limit rejections.
+ * Incremented when a request payload exceeds defined size limits.
+ * @type {import('prom-client').Counter}
+ */
+const bodySizeLimitRejectionsTotal = new client.Counter({
+  name: 'body_size_limit_rejections_total',
+  help: 'Total number of request payloads rejected for exceeding size limits',
+  labelNames: ['limit_type'],
+  registers: [],
+});
+
+/**
+ * Increment the count of blocks processed where the legal hold state is unknown.
+ * @returns {void}
+ */
+function incrementLegalHoldUnknownBlocks() {
+  legalHoldProcessingErrorsTotal.inc({ reason: 'unknown_hold_state' });
+}
+
+/**
+ * Increment the count of blocks processed with a valid legal hold status.
+ * @param {string} status - Bounded status value.
+ * @returns {void}
+ */
+function incrementLegalHoldBlocks(status) {
+  legalHoldBlocksTotal.inc({ status });
+}
+
+/**
+ * Resets all metrics state for test isolation.
+ * Clears registered queues, workers, and resets gauge values to zero.
+ * @returns {void}
+ */
+function resetMetricsForTests() {
+  registeredJobQueues.clear();
+  registeredWorkers.clear();
+  queueDepthGauge.set(0);
+  retryQueueSizeGauge.set(0);
+  workerInFlightGauge.set(0);
+  stopMetricsRefresh();
+}
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ *
+ * Returns `false` early when lengths differ (public info leaked by content-length
+ * rather than timing), but still performs a full-length XOR when lengths match
+ * so that a timing attacker cannot distinguish _where_ the difference occurs.
+ *
+ * @param {string} a - First string to compare.
+ * @param {string} b - Second string to compare.
+ * @returns {boolean} `true` when the strings are equal, `false` otherwise.
+ *
+ * @example
+ * safeEqual('secret', 'secret'); // true
+ * safeEqual('secret', 'wrong');  // false
+ */
+function safeEqual(a, b) {
+  if (a.length !== b.length) { return false; }
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}
+
+// Register bounded counters with the shared registry
+registry.registerMetric(maturityReminderDeliveryAttemptsTotal);
+registry.registerMetric(maturityReminderDeadLetterTotal);
+registry.registerMetric(webhookReplayTotal);
+registry.registerMetric(legalHoldProcessingErrorsTotal);
+registry.registerMetric(legalHoldBlocksTotal);
+registry.registerMetric(redisCacheFailOpenTotal);
+registry.registerMetric(cacheStoreErrorsTotal);
+registry.registerMetric(escrowPreflightRejectedTotal);
+registry.registerMetric(bodySizeLimitRejectionsTotal);
+
+/**
+ * Set of loopback IP addresses that are allowed when no bearer token is
+ * configured. Includes IPv4, IPv6, and IPv4-mapped IPv6 representations.
+ *
+ * @type {ReadonlySet<string>}
+ */
+const LOOPBACK = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+/**
+ * Extracts the direct TCP connection IP address from the request.
+ *
+ * Reads `req.socket.remoteAddress` first — this is the actual TCP socket peer
+ * and cannot be spoofed via `X-Forwarded-For` or any other HTTP header. Falls
+ * back to `req.ip` when the socket address is unavailable (edge case in some
+ * test environments or HTTP/2 proxies).
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @returns {string} The client IP address string, or empty string if
+ *   neither source is available.
+ *
+ * @example
+ * extractClientIp(req); // '127.0.0.1'
+ */
+function extractClientIp(req) {
+  return (req.socket && req.socket.remoteAddress) || req.ip || '';
+}
+
+/**
+ * Express middleware that enforces metrics endpoint authentication.
+ *
+ * ## Auth decision flow
+ *
+ * ```
+ * METRICS_BEARER_TOKEN set?
+ *   ├── YES → constant-time compare Authorization header
+ *   │         ├── match  → next()
+ *   │         └── no match → 401 (no detail)
+ *   └── NO  → extractClientIp(req) in LOOPBACK set?
+ *             ├── yes → next()
+ *             └── no  → 401 (no detail)
+ * ```
+ *
+ * The response is **always** a plain `{ error: 'Unauthorized' }` with no
+ * indication of whether the failure was a missing token, wrong token, or
+ * non-loopback origin.
+ *
+ * @param {import('express').Request} req - Express request.
+ * @param {import('express').Response} res - Express response.
+ * @param {import('express').NextFunction} next - Express next callback.
+ * @returns {void}
+ */
+function metricsAuth(req, res, next) {
+  const token = process.env.METRICS_BEARER_TOKEN;
+
+  if (token) {
+    const auth = req.headers['authorization'] || '';
+    if (safeEqual(auth, `Bearer ${token}`)) { return next(); }
+    const authFallback = req.headers['Authorization'] || '';
+    if (safeEqual(authFallback, `Bearer ${token}`)) { return next(); }
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  // No token configured — allow loopback only, using the direct TCP socket IP.
+  // X-Forwarded-For is NEVER trusted for this check.
+  const ip = extractClientIp(req);
+  if (LOOPBACK.has(ip)) { return next(); }
+
+  res.status(401).json({ error: 'Unauthorized' });
+}
+
+/**
+ * Express route handler that returns Prometheus metrics in plain-text format.
+ *
+ * @param {import('express').Request} _req - Express request (unused).
+ * @param {import('express').Response} res - Express response.
+ * @returns {Promise<void>}
+ */
+async function metricsHandler(_req, res) {
+  res.set('Content-Type', registry.contentType);
+  // Use the real prom-client registry.metrics() when available (production),
+  // which returns the full Prometheus exposition including ALL registered
+  // counters and gauges. Fall back to cachedMetrics for the shim (tests).
+  const metricsText = typeof client.Gauge !== 'function' || client.Gauge.name === 'GaugeShim'
+    ? cachedMetrics
+    : await registry.metrics();
+  res.end(metricsText);
+}
+
+/**
+ * Counter: Escrow events successfully processed by the indexer per cycle.
+ * Incremented by the number of events persisted in each indexer cycle.
+ * @type {import('prom-client').Counter}
+ */
+const escrowIndexerEventsProcessedTotal = new client.Counter({
+  name: 'escrow_indexer_events_processed_total',
+  help: 'Total number of escrow events successfully processed and persisted by the indexer',
+  registers: [registry],
+});
+
+/**
+ * Counter: Escrow events skipped (invalid) by the indexer per cycle.
+ * Incremented when an event fails validation or persistence.
+ * @type {import('prom-client').Counter}
+ */
+const escrowIndexerEventsSkippedTotal = new client.Counter({
+  name: 'escrow_indexer_events_skipped_total',
+  help: 'Total number of escrow events skipped due to validation or persistence errors',
+  registers: [registry],
+});
+
+/**
+ * Counter: Escrow indexer cycle failures.
+ * Incremented when a cycle throws an unhandled exception or receives invalid metric data.
+ * @type {import('prom-client').Counter}
+ */
+const escrowIndexerCycleFailuresTotal = new client.Counter({
+  name: 'escrow_indexer_cycle_failures_total',
+  help: 'Total number of escrow indexer cycles that failed with an exception',
+  registers: [registry],
+});
+
+/**
+ * Gauge: Unix timestamp (seconds) of the last successful cursor advance.
+ * Updated when a cycle completes and cursorAfter !== cursorBefore.
+ * Used by health check to detect indexer staleness.
+ * @type {import('prom-client').Gauge}
+ */
+const escrowIndexerLastCursorAdvanceTimestampSeconds = new client.Gauge({
+  name: 'escrow_indexer_last_cursor_advance_timestamp_seconds',
+  help: 'Unix timestamp (seconds) of the last cycle where the cursor advanced (cursorAfter !== cursorBefore)',
+  registers: [registry],
+});
+
+/**
+ * Counter: Escrow reconciliation mismatches.
+ * Incremented each time a reconcileInvoice call detects a discrepancy
+ * between the DB funded total and the on-chain funded amount.
+ * @type {import('prom-client').Counter}
+ */
+const escrowReconciliationMismatches = new client.Counter({
+  name: 'escrow_reconciliation_mismatches_total',
+  help: 'Total number of escrow reconciliation mismatches detected',
+  registers: [registry],
+});
+
+/**
+ * Gauge: Count of mismatched invoices from the most recent reconciliation run.
+ * Updated after each performReconciliation run completes.
+ * @type {import('prom-client').Gauge}
+ */
+const escrowReconciliationMismatchedInvoicesGauge = new client.Gauge({
+  name: 'escrow_reconciliation_mismatched_invoices',
+  help: 'Number of mismatched invoices from the most recent reconciliation run',
+  registers: [registry],
+});
+
+/**
+ * Gauge: Total absolute drift magnitude (sum of |DB - onChain|) from the most
+ * recent reconciliation run. Higher values indicate larger financial discrepancies.
+ * @type {import('prom-client').Gauge}
+ */
+const escrowReconciliationDriftMagnitudeGauge = new client.Gauge({
+  name: 'escrow_reconciliation_drift_magnitude',
+  help: 'Total absolute drift magnitude from the most recent reconciliation run',
+  registers: [registry],
+});
+
+/**
+ * Counter: Reconciliation runs that breached the configured drift threshold.
+ * Incremented when mismatches >= RECONCILIATION_DRIFT_THRESHOLD.
+ * @type {import('prom-client').Counter}
+ */
+const escrowReconciliationDriftAlertsTotal = new client.Counter({
+  name: 'escrow_reconciliation_drift_alerts_total',
+  help: 'Total number of reconciliation runs that breached the drift threshold',
+  registers: [registry],
+});
+
+
+
+/**
+ * Counter: Footprint cache hits.
+ * @type {import('prom-client').Counter}
+ */
+const footprintCacheHitsTotal = new client.Counter({
+  name: 'soroban_footprint_cache_hits_total',
+  help: 'Total number of Soroban footprint cache hits',
+  registers: [registry],
+});
+
+/**
+ * Counter: Footprint cache misses.
+ * @type {import('prom-client').Counter}
+ */
+const footprintCacheMissesTotal = new client.Counter({
+  name: 'soroban_footprint_cache_misses_total',
+  help: 'Total number of Soroban footprint cache misses',
+  registers: [registry],
+});
+
+/**
+ * Counter: Footprint cache evictions (LRU or TTL).
+ * @type {import('prom-client').Counter}
+ */
+const footprintCacheEvictionsTotal = new client.Counter({
+  name: 'soroban_footprint_cache_evictions_total',
+  help: 'Total number of Soroban footprint cache evictions (LRU or TTL expiry)',
+  registers: [registry],
+});
+
+/**
+ * Counter: Soroban circuit breaker state transitions.
+ * Labelled by the new state name to allow counting transitions into each state.
+ * @type {import('prom-client').Counter}
+ */
+const sorobanCircuitBreakerStateTransitionsTotal = new client.Counter({
+  name: 'soroban_circuit_breaker_state_transitions_total',
+  help: 'Total number of Soroban circuit breaker state transitions, labelled by state',
+  labelNames: ['state'],
+  registers: [registry],
+});
+
+/**
+ * Gauge: Readiness state (1 = ready, 0 = not ready).
+ * Updated by performReadinessChecks() in the health service.
+ * @type {import('prom-client').Gauge}
+ */
+const readinessGauge = new client.Gauge({
+  name: 'readiness_gauge',
+  help: 'Readiness state of the service: 1 = ready to serve traffic, 0 = not ready',
+  registers: [registry],
+});
+
+/**
+ * Counter: operator alerts raised when `contractListRefresh` detects an on-chain
+ * LiquifactEscrow wasm `SCHEMA_VERSION` that diverges from the expected/known
+ * registry version.
+ *
+ * Labelled by the comparison `status` (`ahead` — contract is newer than anything
+ * the backend tracks; `unknown` — version not present in the registry) so ops can
+ * distinguish an upgrade from an unexpected/rolled-back deployment. A non-zero
+ * value is an actionable signal that the backend may not yet support the on-chain
+ * contract — see `docs/wasm-ops.md`.
+ *
+ * @type {import('prom-client').Counter}
+ */
+const contractWasmVersionMismatchAlertsTotal = new client.Counter({
+  name: 'contract_wasm_version_mismatch_alerts_total',
+  help: 'Total operator alerts raised when contractListRefresh detects an on-chain wasm SCHEMA_VERSION mismatch',
+  labelNames: ['status'],
+  registers: [registry],
+});
+
+module.exports = {
+  registry,
+  metricsAuth,
+  metricsHandler,
+  registerJobQueue,
+  registerWorker,
+  refreshMetrics,
+  resetMetricsForTests,
+  contractWasmVersionMismatchAlertsTotal,
+  readinessGauge,
+  escrowIndexerEventsProcessedTotal,
+  escrowIndexerEventsSkippedTotal,
+  escrowIndexerCycleFailuresTotal,
+  escrowIndexerLastCursorAdvanceTimestampSeconds,
+  maturityReminderDeliveryAttemptsTotal,
+  maturityReminderDeadLetterTotal,
+  normalizeReminderReason,
+  normalizeJobType,
+  escrowReconciliationMismatches,
+  escrowReconciliationMismatchedInvoicesGauge,
+  escrowReconciliationDriftMagnitudeGauge,
+  escrowReconciliationDriftAlertsTotal,
+  incrementLegalHoldUnknownBlocks,
+  incrementLegalHoldBlocks,
+  footprintCacheHitsTotal,
+  footprintCacheMissesTotal,
+  footprintCacheEvictionsTotal,
+  redisCacheFailOpenTotal,
+  cacheStoreErrorsTotal,
+  escrowPreflightRejectedTotal,
+  bodySizeLimitRejectionsTotal,
+  webhookReplayTotal,
+};

--- a/src/services/health.js
+++ b/src/services/health.js
@@ -1,0 +1,343 @@
+'use strict';
+
+/**
+ * Health check service for dependency monitoring.
+ * @module services/health
+ */
+
+const { getKycProviderConfig } = require('./kycService');
+const { escrowIndexerLastCursorAdvanceTimestampSeconds, readinessGauge } = require('../metrics');
+const db = require('../db/knex');
+const cfg = require('../config');
+
+/**
+ * Classify Soroban RPC latency against configurable thresholds.
+ * Returns "healthy" for latency <= warn, "degraded" for latency > warn && <= fail,
+ * and "unhealthy" for latency > fail.
+ * @param {number} latencyMs Measured latency in milliseconds.
+ * @returns {'healthy'|'degraded'|'unhealthy'}
+ */
+function classifySorobanLatency(latencyMs) {
+  const warnMs = parseInt(process.env.SOROBAN_LATENCY_WARN_MS, 10) || 200;
+  const failMs = parseInt(process.env.SOROBAN_LATENCY_FAIL_MS, 10) || 500;
+  if (latencyMs <= warnMs) return 'healthy';
+  if (latencyMs <= failMs) return 'degraded';
+  return 'unhealthy';
+}
+
+/**
+ * Checks if the Soroban RPC endpoint is reachable and classifies latency.
+ * @returns {Promise<{status: string, latency?: number, error?: string}>}
+ */
+async function checkSorobanHealth() {
+  const url = process.env.SOROBAN_RPC_URL;
+  if (!url) {
+    return { status: 'unknown', error: 'SOROBAN_RPC_URL not configured' };
+  }
+
+  const start = Date.now();
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getHealth' }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+    const latency = Date.now() - start;
+
+    if (response.ok) {
+      const classification = classifySorobanLatency(latency);
+      return { status: classification, latency };
+    }
+    return { status: 'unhealthy', latency, error: `HTTP ${response.status}` };
+  } catch (error) {
+    const latency = Date.now() - start;
+    return { status: 'unhealthy', latency, error: error.message };
+  }
+}
+
+/**
+ * Checks if the database is reachable via a raw query.
+ * Uses knex to run `SELECT 1` and measures latency.
+ * Does not expose connection strings or hostnames in the response.
+ * @returns {Promise<{status: string, latency?: number, error?: string}>}
+ */
+async function checkDatabaseHealth() {
+  if (!process.env.DATABASE_URL) {
+    return { status: 'not_configured' };
+  }
+
+  const pool = db.client && db.client.pool;
+  if (pool) {
+    const used = typeof pool.numUsed === 'function' ? pool.numUsed() : 0;
+    const pending = typeof pool.numPendingAcquires === 'function' ? pool.numPendingAcquires() : 0;
+    const max = pool.max || 10;
+
+    if (used >= max || pending > 0) {
+      const start = Date.now();
+      try {
+        await db.raw('SELECT 1');
+        const latency = Date.now() - start;
+        return { status: 'saturated', latency, error: 'Database connection pool exhausted' };
+      } catch (_error) {
+        const latency = Date.now() - start;
+        return { status: 'unhealthy', latency, error: 'Database unreachable' };
+      }
+    }
+  }
+
+  const start = Date.now();
+  try {
+    await db.raw('SELECT 1');
+    const latency = Date.now() - start;
+    return { status: 'healthy', latency };
+  } catch (_error) {
+    const latency = Date.now() - start;
+    return { status: 'unhealthy', latency, error: 'Database unreachable' };
+  }
+}
+
+/**
+ * Checks escrow reconciliation status.
+ * 
+ * @returns {Promise<{status: string, lastRun?: string, mismatches?: number, error?: string}>} Reconciliation health status.
+ */
+async function checkReconciliationHealth() {
+  try {
+    const { getReconciliationSummary } = require('../jobs/reconcileEscrow');
+    const summary = await getReconciliationSummary();
+
+    if (!summary) {
+      return { status: 'not_run', error: 'Reconciliation has not been run yet' };
+    }
+
+    const lastRun = new Date(summary.reconciledAt);
+    const hoursSinceLastRun = (Date.now() - lastRun.getTime()) / (1000 * 60 * 60);
+
+    // Consider unhealthy if last run was more than 25 hours ago (allowing 1 hour grace)
+    if (hoursSinceLastRun > 25) {
+      return { status: 'stale', lastRun: summary.reconciledAt, error: 'Reconciliation not run recently' };
+    }
+
+    // Unhealthy if there are mismatches
+    if (summary.mismatches > 0) {
+      return { status: 'mismatches', lastRun: summary.reconciledAt, mismatches: summary.mismatches };
+    }
+
+    return { status: 'healthy', lastRun: summary.reconciledAt };
+  } catch (error) {
+    return { status: 'error', error: error.message };
+  }
+}
+
+/**
+ * Checks if the KYC provider is reachable.
+ * Only runs when the provider is enabled (URL + API key configured).
+ * The API key is sent in the Authorization header and never included in the response.
+ * @returns {Promise<{status: string, latency?: number, error?: string}>}
+ */
+async function checkKycHealth() {
+  const kycCfg = getKycProviderConfig();
+  if (!kycCfg.enabled) {
+    return { status: 'disabled' };
+  }
+
+  const start = Date.now();
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    const response = await fetch(kycCfg.baseUrl, {
+      method: 'HEAD',
+      headers: { Authorization: `Bearer ${kycCfg.apiKey}` },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+    const latency = Date.now() - start;
+
+    // Any HTTP response (even 4xx) means the host is reachable
+    return response.ok || response.status < 500
+      ? { status: 'healthy', latency }
+      : { status: 'unhealthy', latency, error: `HTTP ${response.status}` };
+  } catch (error) {
+    const latency = Date.now() - start;
+    return { status: 'unhealthy', latency, error: error.message };
+  }
+}
+
+/**
+ * Checks escrow indexer staleness.
+ * Returns 'disabled' when the indexer is not enabled.
+ * Returns 'stale' when the cursor hasn't advanced within the configured threshold.
+ * Returns 'healthy' when the cursor has advanced recently or initially (gauge not yet set).
+ *
+ * @returns {Promise<{status: string, elapsedSeconds?: number, lastAdvanceTimestamp?: number, threshold?: number, error?: string}>} Indexer staleness health status.
+ */
+async function checkIndexerStaleness() {
+  try {
+    const config = cfg.get();
+
+    // Check if indexer is enabled
+    if (config.ESCROW_INDEXER_ENABLED !== 'true') {
+      return { status: 'disabled' };
+    }
+
+    // Get the last advance timestamp from gauge
+    const lastAdvanceTimestamp = escrowIndexerLastCursorAdvanceTimestampSeconds.get();
+
+    // If gauge has never been set, treat as healthy (no false positive on startup)
+    if (lastAdvanceTimestamp === undefined || lastAdvanceTimestamp === 0) {
+      return { status: 'healthy', lastAdvanceTimestamp: 0, threshold: config.ESCROW_INDEXER_STALE_THRESHOLD_SECONDS };
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const elapsedSeconds = now - (lastAdvanceTimestamp || 0);
+    const threshold = config.ESCROW_INDEXER_STALE_THRESHOLD_SECONDS || 300;
+
+    if (elapsedSeconds > threshold) {
+      return {
+        status: 'stale',
+        elapsedSeconds,
+        lastAdvanceTimestamp,
+        threshold,
+        error: `Cursor has not advanced for ${elapsedSeconds} seconds (threshold: ${threshold})`,
+      };
+    }
+
+    return {
+      status: 'healthy',
+      elapsedSeconds,
+      lastAdvanceTimestamp,
+      threshold,
+    };
+  } catch (error) {
+    return { status: 'error', error: error.message };
+  }
+}
+
+/**
+ * Checks if the configured S3 bucket is reachable using the connectivity
+ * probe defined by the storage service. The result is the raw probe output:
+ * status plus optional latency and a sanitized error descriptor. Credentials,
+ * endpoint URLs, and signed request headers are stripped before the result
+ * is returned.
+ *
+ * Operator-visible statuses:
+ *
+ * - `'healthy'` — bucket is reachable and credentials authorize access.
+ * - `'in_memory'` — in-memory fallback active; probe skipped.
+ * - `'disabled'` — operator opted out via `S3_HEALTHCHECK_ENABLED=false`.
+ * - `'not_configured'` — bucket name or credentials are missing.
+ * - `'unhealthy'` — `HeadBucket` failed; `error.code` is an AWS error name.
+ *
+ * @returns {Promise<{
+ *   status: string,
+ *   latency?: number,
+ *   error?: {code: string, hint: string},
+ *   bucketConfigured?: boolean,
+ *   credentialsConfigured?: boolean
+ * }>}
+ */
+async function checkStorageHealth() {
+  const storage = require('./storage');
+  return storage.probeS3Connectivity();
+}
+
+/**
+ * Performs all dependency health checks.
+ * @returns {Promise<{healthy: boolean, checks: Object}>}
+ */
+async function performHealthChecks() {
+  const [soroban, database, kyc, indexerStaleness, storage] = await Promise.all([
+    checkSorobanHealth(),
+    checkDatabaseHealth(),
+    checkKycHealth(),
+    checkIndexerStaleness(),
+    checkStorageHealth(),
+  ]);
+
+  const checks = { soroban, database, kyc, indexerStaleness, storage };
+  const healthy =
+    (soroban.status === 'healthy' || soroban.status === 'unknown') &&
+    (kyc.status === 'healthy' || kyc.status === 'disabled') &&
+    (indexerStaleness.status === 'healthy' || indexerStaleness.status === 'disabled') &&
+    // Storage is in-memory or opted out → non-blocking. Missing config or
+    // unreachable buckets → blocking for `/ready` because uploads will fail.
+    storage.status !== 'not_configured' &&
+    storage.status !== 'unhealthy';
+
+  return { healthy, checks };
+}
+
+/**
+ * Performs critical-dependency readiness checks (DB, Soroban RPC, storage).
+ * The KYC and indexer staleness checks are omitted because they are not
+ * required for the process to serve *most* traffic — only critical
+ * upstream dependencies that would prevent any business request from
+ * completing are included.
+ *
+ * The S3 storage probe is included so a misconfigured bucket (wrong
+ * endpoint, bad credentials, deleted bucket) is surfaced on the readiness
+ * probe rather than at the first invoice upload.
+ *
+ * Updates the `readiness_gauge` Prometheus metric (1 = ready, 0 = not
+ * ready). Degraded Soroban RPC (slow) does NOT block readiness.
+ *
+ * @returns {Promise<{
+ *   healthy: boolean,
+ *   checks: {
+ *     database: Object,
+ *     soroban: Object,
+ *     storage: Object
+ *   }
+ * }>}
+ */
+async function performReadinessChecks() {
+  const [database, soroban, storage] = await Promise.all([
+    checkDatabaseHealth(),
+    checkSorobanHealth(),
+    checkStorageHealth(),
+  ]);
+
+  const checks = { database, soroban, storage };
+  // In-memory and explicitly-disabled probes are treated as readiness-OK.
+  // Production deployments missing the bucket or with an unreachable
+  // bucket DO block readiness.
+  const storageOk =
+    storage.status === 'healthy' ||
+    storage.status === 'in_memory' ||
+    storage.status === 'disabled';
+
+  // Determine overall readiness. Degraded Soroban RPC (slow) does NOT block readiness.
+  const healthy =
+    database.status === 'healthy' &&
+    (soroban.status === 'healthy' || soroban.status === 'degraded' || soroban.status === 'unknown') &&
+    storageOk;
+
+  // Set gauge: 1 = ready, 0.5 = degraded, 0 = not ready
+  if (database.status !== 'healthy' || !storageOk) {
+    readinessGauge.set(0);
+  } else if (soroban.status === 'degraded') {
+    readinessGauge.set(0.5);
+  } else {
+    readinessGauge.set(healthy ? 1 : 0);
+  }
+
+  return { healthy, checks };
+}
+
+module.exports = {
+  checkSorobanHealth,
+  checkDatabaseHealth,
+  checkKycHealth,
+  checkStorageHealth,
+  checkIndexerStaleness,
+  performHealthChecks,
+  performReadinessChecks,
+};

--- a/src/utils/cursorPagination.js
+++ b/src/utils/cursorPagination.js
@@ -1,0 +1,155 @@
+'use strict';
+
+/**
+ * @fileoverview Opaque cursor encoding/decoding for marketplace keyset pagination.
+ *
+ * Cursors are base64url-encoded JSON objects containing the last-seen value for
+ * the active sort field and the row `id` tiebreaker. They are HMAC-signed so
+ * that any modification — or reuse with a different sort field — is detected
+ * and rejected with a 400 before it reaches the database layer.
+ *
+ * Opaque cursor payload shape:
+ * ```json
+ * { "sortField": "yield_bps", "sortValue": 450, "id": "inv_abc123", "iat": 1719187200 }
+ * ```
+ *
+ * @module utils/cursorPagination
+ */
+
+const crypto = require('crypto');
+
+/**
+ * Secret used to sign cursors.
+ * @type {string}
+ */
+const CURSOR_SECRET = process.env.CURSOR_SECRET || process.env.JWT_SECRET || 'dev-cursor-secret-change-in-prod';
+
+/**
+ * Allowed sort fields for marketplace queries.
+ * @type {ReadonlyArray<string>}
+ */
+const ALLOWED_SORT_FIELDS = Object.freeze(['yield_bps', 'maturity_date', 'funded_ratio', 'amount', 'created_at']);
+
+/**
+ * Computes HMAC-SHA-256 digest over payload.
+ *
+ * @param {string} payload - The string to sign.
+ * @returns {string} Hex-encoded HMAC digest.
+ */
+function _sign(payload) {
+  return crypto.createHmac('sha256', CURSOR_SECRET).update(payload).digest('hex');
+}
+
+/**
+ * Encodes a cursor from the last row returned in a page.
+ *
+ * @param {Object} params
+ * @param {string} params.sortField - The active sort column.
+ * @param {*}      params.sortValue - The sort-column value from the last row.
+ * @param {string} params.id        - The `id` of the last row.
+ * @returns {string} Opaque base64url cursor string.
+ */
+function encodeCursor({ sortField, sortValue, id }) {
+  if (!ALLOWED_SORT_FIELDS.includes(sortField)) {
+    throw new Error(`encodeCursor: unsupported sortField "${sortField}"`);
+  }
+  if (!id || typeof id !== 'string') {
+    throw new Error('encodeCursor: id must be a non-empty string');
+  }
+
+  const payload = JSON.stringify({
+    sortField,
+    sortValue,
+    id,
+    iat: Math.floor(Date.now() / 1000),
+  });
+
+  const b64 = Buffer.from(payload).toString('base64url');
+  const sig = _sign(b64);
+  return `${b64}.${sig}`;
+}
+
+/**
+ * Decodes and validates an opaque cursor string.
+ *
+ * @param {string} cursor            - The opaque cursor from the client.
+ * @param {string} expectedSortField - The sort field in the current request.
+ * @returns {{ sortField: string, sortValue: *, id: string, iat: number }}
+ * @throws {CursorError} When the cursor is malformed, tampered, or mismatched.
+ */
+function decodeCursor(cursor, expectedSortField) {
+  if (typeof cursor !== 'string' || !cursor.includes('.')) {
+    throw new CursorError('Malformed cursor: expected base64url.signature format');
+  }
+
+  const dotIdx = cursor.lastIndexOf('.');
+  const b64 = cursor.slice(0, dotIdx);
+  const sig = cursor.slice(dotIdx + 1);
+
+  const expectedSig = _sign(b64);
+  const sigBuf = Buffer.from(sig, 'hex');
+  const expectedBuf = Buffer.from(expectedSig, 'hex');
+
+  if (
+    sigBuf.length !== expectedBuf.length ||
+    !crypto.timingSafeEqual(sigBuf, expectedBuf)
+  ) {
+    throw new CursorError('Invalid cursor signature');
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(b64, 'base64url').toString('utf8'));
+  } catch {
+    throw new CursorError('Malformed cursor: payload is not valid JSON');
+  }
+
+  const { sortField, sortValue, id, iat } = parsed;
+
+  if (!ALLOWED_SORT_FIELDS.includes(sortField)) {
+    throw new CursorError(`Cursor contains unknown sort field "${sortField}"`);
+  }
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new CursorError('Cursor is missing a valid id tiebreaker');
+  }
+  if (typeof iat !== 'number') {
+    throw new CursorError('Cursor is missing issued-at timestamp');
+  }
+
+  if (process.env.CURSOR_TTL_ENABLED === 'true') {
+    const ttl = parseInt(process.env.CURSOR_TTL_SECONDS || '3600', 10);
+    const now = Math.floor(Date.now() / 1000);
+    if (iat && (now - iat) > ttl) {
+      throw new CursorError('Cursor has expired');
+    }
+  }
+
+  if (sortField !== expectedSortField) {
+    throw new CursorError(
+      `Cursor sort field "${sortField}" does not match requested sort field "${expectedSortField}"`
+    );
+  }
+
+  return { sortField, sortValue, id, iat };
+}
+
+/**
+ * Domain error for cursor-related failures.
+ */
+class CursorError extends Error {
+  /**
+   * Creates an instance of CursorError.
+   * @param {string} message The error message.
+   */
+  constructor(message) {
+    super(message);
+    this.name = 'CursorError';
+  }
+}
+
+module.exports = {
+  encodeCursor,
+  decodeCursor,
+  CursorError,
+  ALLOWED_SORT_FIELDS,
+};

--- a/tests/health.readiness.test.js
+++ b/tests/health.readiness.test.js
@@ -1,0 +1,395 @@
+'use strict';
+
+const request = require('supertest');
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Keypair: { fromSecret: jest.fn(), random: jest.fn() },
+}), { virtual: true });
+
+jest.mock('@stellar/stellar-sdk/rpc', () => ({
+  Server: jest.fn(),
+}), { virtual: true });
+
+jest.mock('../src/services/escrowRead', () => ({
+  readEscrowState: jest.fn(),
+  readEscrowStateWithAttestations: jest.fn(),
+  readFundedAmount: jest.fn(),
+  fetchLegalHold: jest.fn(),
+  fetchAttestationAppendLog: jest.fn(),
+  validateInvoiceId: jest.fn(),
+  getEscrowStateWithProjection: jest.fn(),
+}));
+
+const mockStorageProbe = jest.fn();
+jest.mock('../src/services/storage', () => {
+  const actual = jest.requireActual('../src/services/storage');
+  return {
+    ...actual,
+    probeS3Connectivity: (...args) => mockStorageProbe(...args),
+    runStartupStorageProbe: () => Promise.resolve({ status: 'in_memory' }),
+  };
+});
+
+jest.mock('../src/services/marketplaceService', () => ({
+  getMarketplaceInvoices: jest.fn(),
+  PUBLIC_INVESTABLE_INVOICE_STATUSES: ['open', 'funded'],
+}));
+
+jest.mock('../src/services/escrowSubmit', () => ({
+  submitFundEscrow: jest.fn(),
+  EscrowSubmitError: class EscrowSubmitError extends Error {},
+}));
+
+jest.mock('../src/services/investorCommitment', () => ({
+  persistCommitment: jest.fn(),
+}));
+
+jest.mock('../src/config/escrowVersions', () => ({
+  getOnChainSchemaVersion: jest.fn(),
+  compareVersions: jest.fn(),
+}));
+
+jest.mock('../src/jobs/retentionPurge', () => ({
+  scheduleRetentionPurge: jest.fn(),
+  validatePiiFields: jest.fn(),
+  getActivePolicies: jest.fn(),
+  getEligibleInvoices: jest.fn(),
+  getExecutionStatus: jest.fn(),
+  getRecentExecutions: jest.fn(),
+}));
+
+jest.mock('../src/jobs/contractListRefresh', () => ({
+  runContractListRefresh: jest.fn(),
+}));
+
+const { createApp } = require('../src/app');
+const db = require('../src/db/knex');
+const { registry, readinessGauge } = require('../src/metrics');
+
+describe('Readiness probe (/readyz)', () => {
+  let app;
+  let originalEnv;
+
+  beforeAll(() => {
+    originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      JWT_SECRET: 'supersecret32characterlongstringforzod',
+      DATABASE_URL: 'postgres://user:pass@localhost:5432/test',
+      SOROBAN_RPC_URL: 'http://localhost:8000',
+      NODE_ENV: 'test',
+    };
+    app = createApp();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  beforeEach(() => {
+    process.env.SOROBAN_RPC_URL = 'http://localhost:8000';
+    process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/test';
+    mockStorageProbe.mockResolvedValue({ status: 'healthy' });
+    registry.registerMetric(readinessGauge);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    registry.clear();
+  });
+
+  describe('GET /healthz (liveness)', () => {
+    it('should return 200 with status ok without touching external dependencies', async () => {
+      const res = await request(app).get('/healthz');
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('ok');
+      expect(res.body.service).toBe('liquifact-api');
+      expect(res.body).not.toHaveProperty('checks');
+      expect(res.body).not.toHaveProperty('database');
+      expect(res.body).not.toHaveProperty('soroban');
+    });
+  });
+
+  describe('GET /readyz (readiness)', () => {
+    it('should return 200 when DB and Soroban RPC are healthy', async () => {
+      db.raw.mockResolvedValue([{ '1': 1 }]);
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ result: 'ok' }),
+        })
+      );
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(200);
+      expect(res.body.ready).toBe(true);
+      expect(res.body.checks.database.status).toBe('healthy');
+      expect(res.body.checks.soroban.status).toBe('healthy');
+
+      const metric = await readinessGauge.get();
+      expect(metric.values[0].value).toBe(1);
+    });
+
+    it('should return 503 when DB is unreachable', async () => {
+      db.raw.mockRejectedValue(new Error('Connection refused'));
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ result: 'ok' }),
+        })
+      );
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(503);
+      expect(res.body.ready).toBe(false);
+      expect(res.body.checks.database.status).toBe('unhealthy');
+      expect(res.body.checks.database.error).toBe('Database unreachable');
+
+      const metric = await readinessGauge.get();
+      expect(metric.values[0].value).toBe(0);
+    });
+
+    it('should return 503 when Soroban RPC is unreachable', async () => {
+      db.raw.mockResolvedValue([{ '1': 1 }]);
+      global.fetch = jest.fn(() => Promise.reject(new Error('Network error')));
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(503);
+      expect(res.body.ready).toBe(false);
+      expect(res.body.checks.database.status).toBe('healthy');
+      expect(res.body.checks.soroban.status).toBe('unhealthy');
+      expect(res.body.checks.soroban.error).toBe('Network error');
+
+      const metric = await readinessGauge.get();
+      expect(metric.values[0].value).toBe(0);
+    });
+
+    it('should return 503 when both DB and Soroban are down', async () => {
+      db.raw.mockRejectedValue(new Error('Connection refused'));
+      global.fetch = jest.fn(() => Promise.reject(new Error('Network error')));
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(503);
+      expect(res.body.ready).toBe(false);
+      expect(res.body.checks.database.status).toBe('unhealthy');
+      expect(res.body.checks.soroban.status).toBe('unhealthy');
+
+      const metric = await readinessGauge.get();
+      expect(metric.values[0].value).toBe(0);
+    });
+
+    it('should return 200 when DB is healthy and Soroban is not configured', async () => {
+      process.env.SOROBAN_RPC_URL = '';
+      db.raw.mockResolvedValue([{ '1': 1 }]);
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(200);
+      expect(res.body.ready).toBe(true);
+      expect(res.body.checks.database.status).toBe('healthy');
+      expect(res.body.checks.soroban.status).toBe('unknown');
+
+      const metric = await readinessGauge.get();
+      expect(metric.values[0].value).toBe(1);
+    });
+
+    it('should report database as not_configured when DATABASE_URL is missing', async () => {
+      delete process.env.DATABASE_URL;
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ result: 'ok' }),
+        })
+      );
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(503);
+      expect(res.body.ready).toBe(false);
+      expect(res.body.checks.database.status).toBe('not_configured');
+
+      const metric = await readinessGauge.get();
+      expect(metric.values[0].value).toBe(0);
+    });
+
+    it('should return 503 when DB connection pool is exhausted', async () => {
+      db.client = db.client || {};
+      const originalPool = db.client.pool;
+      db.client.pool = {
+        max: 10,
+        numUsed: jest.fn().mockReturnValue(10),
+        numFree: jest.fn().mockReturnValue(0),
+        numPendingAcquires: jest.fn().mockReturnValue(1),
+      };
+
+      db.raw.mockResolvedValue([{ '1': 1 }]);
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ result: 'ok' }),
+        })
+      );
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(503);
+      expect(res.body.ready).toBe(false);
+      expect(res.body.checks.database.status).toBe('saturated');
+      expect(res.body.checks.database.error).toBe('Database connection pool exhausted');
+
+      const metric = await readinessGauge.get();
+      expect(metric.values[0].value).toBe(0);
+
+      db.client.pool = originalPool;
+    });
+
+    describe('S3 storage readiness (issue #452)', () => {
+      afterEach(() => {
+        mockStorageProbe.mockReset();
+      });
+
+      it('returns 503 when S3 storage probe is unhealthy', async () => {
+        mockStorageProbe.mockResolvedValue({
+          status: 'unhealthy',
+          latency: 12,
+          error: { code: 'NoSuchBucket', hint: 'configured bucket not found' },
+        });
+        db.raw.mockResolvedValue([{ '1': 1 }]);
+        global.fetch = jest.fn(() =>
+          Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ result: 'ok' }) })
+        );
+
+        const res = await request(app).get('/readyz');
+        expect(res.status).toBe(503);
+        expect(res.body.ready).toBe(false);
+        expect(res.body.checks.storage.status).toBe('unhealthy');
+        expect(res.body.checks.storage.error).toEqual({
+          code: 'NoSuchBucket',
+          hint: 'configured bucket not found',
+        });
+        // The error string MUST NOT leak endpoint or credential material.
+        const logString = JSON.stringify(res.body);
+        expect(logString).not.toMatch(/AKIA[A-Z0-9]+/);
+        expect(logString).not.toContain('AWS_SECRET');
+        expect(logString).not.toContain('AWS_ACCESS_KEY');
+
+        const metric = await readinessGauge.get();
+        expect(metric.values[0].value).toBe(0);
+      });
+
+      it('returns 503 when S3 storage is not_configured', async () => {
+        mockStorageProbe.mockResolvedValue({
+          status: 'not_configured',
+          bucketConfigured: false,
+          credentialsConfigured: false,
+        });
+        db.raw.mockResolvedValue([{ '1': 1 }]);
+        global.fetch = jest.fn(() =>
+          Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ result: 'ok' }) })
+        );
+
+        const res = await request(app).get('/readyz');
+        expect(res.status).toBe(503);
+        expect(res.body.ready).toBe(false);
+        expect(res.body.checks.storage.status).toBe('not_configured');
+
+        const metric = await readinessGauge.get();
+        expect(metric.values[0].value).toBe(0);
+      });
+
+      it('returns 200 when S3 storage probe is explicitly disabled', async () => {
+        mockStorageProbe.mockResolvedValue({
+          status: 'disabled',
+          bucketConfigured: true,
+          credentialsConfigured: true,
+        });
+        db.raw.mockResolvedValue([{ '1': 1 }]);
+        global.fetch = jest.fn(() =>
+          Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ result: 'ok' }) })
+        );
+
+        const res = await request(app).get('/readyz');
+        expect(res.status).toBe(200);
+        expect(res.body.ready).toBe(true);
+        expect(res.body.checks.storage.status).toBe('disabled');
+
+        const metric = await readinessGauge.get();
+        expect(metric.values[0].value).toBe(1);
+      });
+
+      it('returns 200 when S3 storage probe is in_memory (test mode)', async () => {
+        mockStorageProbe.mockResolvedValue({
+          status: 'in_memory',
+          bucketConfigured: false,
+          credentialsConfigured: false,
+        });
+        db.raw.mockResolvedValue([{ '1': 1 }]);
+        global.fetch = jest.fn(() =>
+          Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ result: 'ok' }) })
+        );
+
+        const res = await request(app).get('/readyz');
+        expect(res.status).toBe(200);
+        expect(res.body.ready).toBe(true);
+        expect(res.body.checks.storage.status).toBe('in_memory');
+
+        const metric = await readinessGauge.get();
+        expect(metric.values[0].value).toBe(1);
+      });
+
+      it('returns 200 when S3 storage probe is healthy', async () => {
+        mockStorageProbe.mockResolvedValue({
+          status: 'healthy',
+          latency: 8,
+          bucketConfigured: true,
+          credentialsConfigured: true,
+        });
+        db.raw.mockResolvedValue([{ '1': 1 }]);
+        global.fetch = jest.fn(() =>
+          Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ result: 'ok' }) })
+        );
+
+        const res = await request(app).get('/readyz');
+        expect(res.status).toBe(200);
+        expect(res.body.ready).toBe(true);
+        expect(res.body.checks.storage.status).toBe('healthy');
+      });
+    });
+
+    it('should not leak database connection strings or hostnames in error responses', async () => {
+      process.env.SOROBAN_RPC_URL = 'http://localhost:8000';
+      db.raw.mockRejectedValue(new Error('Connection refused'));
+      global.fetch = jest.fn(() => Promise.reject(new Error('connect ECONNREFUSED localhost:8000')));
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(503);
+      const body = JSON.stringify(res.body);
+
+      expect(body).not.toMatch(/postgres:\/\//);
+      expect(body).not.toMatch(/user:pass/);
+      expect(body).not.toMatch(/DATABASE_URL/i);
+      expect(res.body.checks.database.status).toBe('unhealthy');
+      expect(res.body.checks.database.error).toBe('Database unreachable');
+    });
+
+    it('should report database as not_configured when DATABASE_URL is missing', async () => {
+      delete process.env.DATABASE_URL;
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ result: 'ok' }),
+        })
+      );
+
+      const res = await request(app).get('/readyz');
+      expect(res.status).toBe(503);
+      expect(res.body.ready).toBe(false);
+      expect(res.body.checks.database.status).toBe('not_configured');
+
+      const metric = await readinessGauge.get();
+      expect(metric.values[0].value).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Problem Description
The database health probe in `src/services/health.js` previously evaluated database health solely by executing a raw `SELECT 1` query. If the query succeeded, the probe reported a status of `healthy`. 

However, during database connection pool exhaustion (when all connections are checked out and active), any new incoming query/request is queued and hangs indefinitely until a connection is returned to the pool. Because the health check query itself might be run on an already acquired or active connection (or because it executes quickly once acquired), the health check would report `healthy` while the rest of the application was effectively unresponsive. This prevented load balancers and orchestrators (like Kubernetes) from detecting pool saturation and routing traffic away or restarting containers.

## Proposed Changes
This PR updates the database health check to inspect the state of the Knex Tarn connection pool:

1. **Pool Saturation Check in [health.js](file:///c:/Users/enwer/OneDrive/Documents/Code%20Projects/OS%20Contributions/Liquifact-backend/src/services/health.js):**
   - Retrieves the Knex connection pool client metrics (`numUsed()`, `numPendingAcquires()`, and `max`).
   - If the number of checked-out connections meets or exceeds the maximum configured pool size, or if there are pending acquire requests (`numPendingAcquires() > 0`), the probe reports a status of `saturated` with `error: 'Database connection pool exhausted'`.
   
2. **Readiness Probe Update:**
   - If the database status is `saturated`, the `/readyz` endpoint returns a `503 Service Unavailable` response.
   - The Prometheus `readiness_gauge` metric is set to `0` (not ready).

3. **Mock Fixes in [health.readiness.test.js](file:///c:/Users/enwer/OneDrive/Documents/Code%20Projects/OS%20Contributions/Liquifact-backend/tests/health.readiness.test.js):**
   - Added a default `{ status: 'healthy' }` resolved value to the `mockStorageProbe` mock in the `beforeEach` setup. This resolves a `TypeError` that was crashing unrelated readiness tests (due to the S3 storage probe returning `undefined`).
   - Added a dedicated test case that mocks the Tarn connection pool under `db.client.pool` to simulate saturation, asserting that it correctly triggers a `503` with a status of `saturated` and sets the readiness gauge to `0`.

4. **Import Clean Up in [app.js](file:///c:/Users/enwer/OneDrive/Documents/Code%20Projects/OS%20Contributions/Liquifact-backend/src/app.js):**
   - Removed a duplicate declaration of `reconciliationRoutes` that was causing syntax parsing failures during testing.

## Verification Plan

### Automated Tests
Ran the full test suite to ensure that 100% of all tests pass and there are no regressions:
```bash
npm test
```
* **Result:** All 69 test suites and 734 test cases passed successfully.

Ran the readiness-specific tests:
```bash
node node_modules/jest/bin/jest.js tests/health.readiness.test.js --runInBand --forceExit
```
* **Result:** All 15 readiness check tests passed, including the new database pool saturation case.

Closes #445