### PR TITLE
feat: Add a global pause switch independent of the compliance legal hold

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ liquifact-contracts/
 | `sweep_terminal_dust` | Treasury | Treasury sweeps rounding residue from a terminal escrow. |
 | `migrate` | Admin | Schema version gate — **typed errors on all paths** in the current release (codes 90–92). |
 | `set_legal_hold` | Admin | Admin activates/clears compliance hold. |
+| `set_paused` | Admin | Admin toggles a lightweight operational pause (incident response) that blocks `fund`, `settle`, `withdraw`, and `claim_investor_payout`. Orthogonal to legal hold; single-call toggle with no clear delay. |
+| `is_paused` | — | Read the current operational pause flag (defaults to `false`). |
 | `set_allowlist_active` | Admin | Admin enables/disables the investor allowlist gate. |
 | `set_investor_allowlisted` | Admin | Admin sets per-address allowlist status. |
 | `set_investors_allowlisted` | Admin | Admin batch-sets allowlist status for multiple addresses. |
@@ -284,6 +286,11 @@ The escrow supports cancellation by the admin under specific criteria, unlocking
 - **Legal hold:** governance-controlled; misuse risk is mitigated by using a
   multisig `admin` and operational policy (see
   [`docs/OPERATOR_RUNBOOK.md`](docs/OPERATOR_RUNBOOK.md)).
+- **Operational pause:** admin-only `set_paused` is a lightweight incident-response
+  circuit breaker, **orthogonal to legal hold** — no compliance semantics and no
+  clear delay. It gates `fund`, `settle`, `withdraw`, and `claim_investor_payout`
+  as a read-only precondition before `require_auth` (typed errors 201–204). Either
+  flag blocks independently; clearing one never clears the other.
 - **Collateral record:** SME-reported metadata only; not proof of custody,
   token movement, reserved balance, or an enforceable on-chain claim.
 - **Token integration:** fee-on-transfer, rebasing, and hook tokens are

--- a/docs/escrow-events.md
+++ b/docs/escrow-events.md
@@ -193,6 +193,18 @@ Emitted when an admin toggles the compliance hold.
 **Data Payload:**
 - `active` (u32): `1` for enabled, `0` for cleared.
 
+### `PausedChanged`
+Emitted when an admin toggles the lightweight operational pause via `set_paused`.
+Orthogonal to `LegalHoldChanged` — it signals the incident-response circuit
+breaker (no compliance semantics, no clear delay), not the compliance hold.
+
+**Topics:**
+1. `paused` (Symbol)
+2. `invoice_id` (Symbol)
+
+**Data Payload:**
+- `active` (u32): `1` for enabled, `0` for cleared.
+
 ---
 
 ## 🛠️ Indexing Recommendations

--- a/docs/escrow-security-checklist.md
+++ b/docs/escrow-security-checklist.md
@@ -18,6 +18,7 @@ Every state-mutating entrypoint and the identity required to authorize it.
 | `update_maturity` | `escrow.admin` | `escrow.admin.require_auth()` | Only in `status == 0` |
 | `update_funding_target` | `escrow.admin` | `escrow.admin.require_auth()` | Only in `status == 0`; `new_target >= funded_amount` |
 | `set_legal_hold` / `clear_legal_hold` | `escrow.admin` | `escrow.admin.require_auth()` | No timelock; no multisig enforced on-chain |
+| `set_paused` | `escrow.admin` | `escrow.admin.require_auth()` | Operational pause, orthogonal to legal hold; single-call toggle, **no** clear delay |
 | `set_allowlist_active` | `escrow.admin` | `escrow.admin.require_auth()` | Enables/disables `AllowlistActive` gate |
 | `set_investor_allowlisted` | `escrow.admin` | `escrow.admin.require_auth()` | Writes to **persistent** storage (see §5.4) |
 | `bind_primary_attestation_hash` | `escrow.admin` | `escrow.admin.require_auth()` | Single-set; second call panics |
@@ -225,6 +226,26 @@ See `docs/escrow-legal-hold.md` § "Failure mode: hold + lost admin key".
 
 `claim_investor_payout` marks an investor as claimed and emits `InvestorPayoutClaimed`. It does not transfer tokens. Off-chain systems that release principal or yield based on this event must implement their own idempotency and replay guards. A re-emitted or replayed event must not trigger a second disbursement.
 
+### 5.10 Operational pause is orthogonal to legal hold
+
+`DataKey::Paused` is a lightweight incident-response circuit breaker toggled by
+the **current** `escrow.admin` via `set_paused(active)` and read via `is_paused()`.
+It is **independent** of `LegalHold`:
+
+- It carries **no compliance semantics** and has **no** two-phase clear delay — a
+  single authorized call flips it on or off, suitable for fast incident response
+  (e.g. a suspected token bug).
+- It gates `fund`, `settle`, `withdraw`, and `claim_investor_payout` as a read-only
+  precondition **before** `require_auth` (ADR-002 / §6 ordering), with dedicated
+  typed errors (`PausedBlocksFunding`, `PausedBlocksSettlement`,
+  `PausedBlocksWithdrawal`, `PausedBlocksInvestorClaims`).
+- Either flag blocks a gated entrypoint **on its own**. Clearing one does not clear
+  the other; `set_paused` never reads or writes any legal-hold key, and the legal-hold
+  entrypoints never touch `DataKey::Paused`.
+
+Same custody caveat as §5.3: a compromised or lost admin can pause indefinitely.
+Production deployments **must** use a governed admin so the pause cannot strand funds.
+
 ---
 
 ## 6. Authorization guard ordering (issue #265)
@@ -256,15 +277,16 @@ and does not weaken the auth boundary. Refactors must not move step 3 above step
 | `update_maturity` | `escrow.admin` | `get_escrow` | line ~1400 | `DataKey::Escrow` set |
 | `update_funding_target` | `escrow.admin` | `get_escrow` | line ~1007 | `DataKey::Escrow` set |
 | `set_legal_hold` / `clear_legal_hold` | current `escrow.admin` | `get_escrow` | line ~940 | `DataKey::LegalHold` set |
+| `set_paused` | current `escrow.admin` | `get_escrow` | `escrow.admin` (via `load_escrow_require_admin`) | `DataKey::Paused` set |
 | `set_allowlist_active` | `escrow.admin` | `get_escrow` | line ~956 | `DataKey::AllowlistActive` set |
 | `set_investor_allowlisted` | `escrow.admin` | `get_escrow` | line ~978 | persistent allowlist set |
 | `bind_primary_attestation_hash` | `escrow.admin` | `get_escrow`, `has` check | line ~791 | `PrimaryAttestationHash` set |
 | `append_attestation_digest` | `escrow.admin` | `get_escrow`, log read | line ~820 | log append + set |
 | `fund` / `fund_with_commitment` | `investor` | floor read | line ~1119 (`investor`) | per-investor keys |
 | `record_sme_collateral_commitment` | `escrow.sme_address` | `get_escrow` | line ~911 | collateral set |
-| `settle` | `escrow.sme_address` | legal hold, `get_escrow` | line ~1282 | `DataKey::Escrow` set |
-| `withdraw` | `escrow.sme_address` | legal hold, `get_escrow` | line ~1321 | `DataKey::Escrow` set |
-| `claim_investor_payout` | `investor` | legal hold, contribution read | line ~1350 | `InvestorClaimed` set |
+| `settle` | `escrow.sme_address` | pause, legal hold, `get_escrow` | line ~1282 | `DataKey::Escrow` set |
+| `withdraw` | `escrow.sme_address` | pause, legal hold, `get_escrow` | line ~1321 | `DataKey::Escrow` set |
+| `claim_investor_payout` | `investor` | pause, legal hold, contribution read | line ~1350 | `InvestorClaimed` set |
 | `sweep_terminal_dust` | `treasury` | legal hold, `get_escrow`, treasury read | line ~702 | SEP-41 transfer |
 | `migrate` | **none** (panics) | version read only | — | none (all paths panic) |
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -446,6 +446,14 @@ pub enum EscrowError {
     NewFloorNotPositive = 175,
     /// Caller is not authorized to perform partial settlement.
     PartialSettleUnauthorizedCaller = 200,
+    /// Operational pause is active; [`LiquifactEscrow::fund`] is blocked. Orthogonal to legal hold.
+    PausedBlocksFunding = 201,
+    /// Operational pause is active; [`LiquifactEscrow::settle`] is blocked. Orthogonal to legal hold.
+    PausedBlocksSettlement = 202,
+    /// Operational pause is active; [`LiquifactEscrow::withdraw`] is blocked. Orthogonal to legal hold.
+    PausedBlocksWithdrawal = 203,
+    /// Operational pause is active; [`LiquifactEscrow::claim_investor_payout`] is blocked. Orthogonal to legal hold.
+    PausedBlocksInvestorClaims = 204,
     MaxPerInvestorCapNotConfigured = 24, // new
     MaxPerInvestorCapNotRaised = 25,     // new
 }
@@ -607,6 +615,14 @@ pub enum DataKey {
     /// Ledger timestamp recorded when [`LiquifactEscrow::settle`] transitions status to 2.
     /// Absent ⇒ not yet settled, or legacy instance. Read via [`LiquifactEscrow::get_settled_at`].
     SettledAt,
+    /// When true, a lightweight **operational pause** blocks risk-bearing entrypoints
+    /// (`fund`, `settle`, `withdraw`, `claim_investor_payout`) for incident response.
+    /// Absent ⇒ `false` (not paused). Toggled by admin via [`LiquifactEscrow::set_paused`].
+    ///
+    /// Orthogonal to [`DataKey::LegalHold`]: the pause has **no** compliance semantics and
+    /// **no** two-phase clear delay — it is a single-call admin switch for incidents such as a
+    /// suspected token bug. Either flag independently blocks the gated entrypoints.
+    Paused,
 }
 
 // --- Data types ---
@@ -929,6 +945,20 @@ pub struct LegalHoldChanged {
     pub active: u32,
 }
 
+/// Emitted by [`LiquifactEscrow::set_paused`] whenever the operational pause flag is written.
+///
+/// Independent of [`LegalHoldChanged`]: this signals the lightweight incident-response switch,
+/// not the compliance hold.
+#[contractevent]
+pub struct PausedChanged {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    /// `1` = pause enabled, `0` = cleared.
+    pub active: u32,
+}
+
 #[contractevent]
 pub struct LegalHoldClearRequested {
     #[topic]
@@ -1183,6 +1213,16 @@ impl LiquifactEscrow {
         env.storage()
             .instance()
             .get(&DataKey::LegalHold)
+            .unwrap_or(false)
+    }
+
+    /// Read the operational pause flag ([`DataKey::Paused`]); defaults to `false` when unset.
+    ///
+    /// Orthogonal to [`LiquifactEscrow::legal_hold_active`] — neither flag affects the other.
+    fn paused_active(env: &Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
             .unwrap_or(false)
     }
 
@@ -1794,6 +1834,14 @@ impl LiquifactEscrow {
     /// Whether a compliance/legal hold is active (defaults to `false` if unset).
     pub fn get_legal_hold(env: Env) -> bool {
         Self::legal_hold_active(&env)
+    }
+
+    /// Whether the lightweight operational pause is active (defaults to `false` if unset).
+    ///
+    /// Independent of [`LiquifactEscrow::get_legal_hold`]: this reports the incident-response
+    /// switch toggled by [`LiquifactEscrow::set_paused`], not the compliance hold.
+    pub fn is_paused(env: Env) -> bool {
+        Self::paused_active(&env)
     }
 
     /// Configured minimum delay between [`LiquifactEscrow::request_clear_legal_hold`]
@@ -2439,6 +2487,30 @@ impl LiquifactEscrow {
         commitment
     }
 
+    /// Set or clear the lightweight **operational pause**. Only the **current**
+    /// [`InvoiceEscrow::admin`] may call.
+    ///
+    /// This is an incident-response circuit breaker (e.g. a suspected token bug) that is
+    /// **orthogonal to the compliance legal hold**: it carries no compliance semantics and,
+    /// unlike [`LiquifactEscrow::set_legal_hold`], has **no** two-phase clear delay — a single
+    /// authorized call toggles it on or off. While active it blocks [`LiquifactEscrow::fund`],
+    /// [`LiquifactEscrow::settle`], [`LiquifactEscrow::withdraw`], and
+    /// [`LiquifactEscrow::claim_investor_payout`]. Legal-hold state is neither read nor written.
+    ///
+    /// Emits [`PausedChanged`].
+    pub fn set_paused(env: Env, active: bool) {
+        let escrow = Self::load_escrow_require_admin(&env);
+
+        env.storage().instance().set(&DataKey::Paused, &active);
+
+        PausedChanged {
+            name: symbol_short!("paused"),
+            invoice_id: escrow.invoice_id.clone(),
+            active: if active { 1 } else { 0 },
+        }
+        .publish(&env);
+    }
+
     /// Set or clear compliance hold. Only the **current** [`InvoiceEscrow::admin`] may call.
     ///
     /// **Clearing:** always requires the current admin's authorization — there is no timelock,
@@ -2917,7 +2989,11 @@ impl LiquifactEscrow {
         // Actually, reusing EscrowError::EscrowNotOpenForFunding since CapLowerNotOpen is specific to lower.
         // But wait, the issue said "parallel guards" and "open-state-only".
         // Let's use EscrowError::EscrowNotOpenForFunding.
-        ensure(&env, escrow.status == 0, EscrowError::EscrowNotOpenForFunding);
+        ensure(
+            &env,
+            escrow.status == 0,
+            EscrowError::EscrowNotOpenForFunding,
+        );
 
         let old_cap: Option<u32> = env
             .storage()
@@ -3311,6 +3387,12 @@ impl LiquifactEscrow {
 
         // env.clone(): env is used again after this call for storage writes and publish.
         let mut escrow = Self::get_escrow(env.clone());
+        // Operational pause gate (read-only), independent of the compliance legal hold below.
+        ensure(
+            &env,
+            !Self::paused_active(&env),
+            EscrowError::PausedBlocksFunding,
+        );
         // Legal hold check is intentionally after the escrow read: the escrow is needed for
         // status and yield_bps regardless, and hoisting the hold check before the escrow read
         // would not reduce storage operations (both keys are always read on this path).
@@ -3576,6 +3658,12 @@ impl LiquifactEscrow {
     }
 
     pub fn settle(env: Env) -> InvoiceEscrow {
+        // Operational pause gate (read-only), before require_auth and orthogonal to legal hold.
+        ensure(
+            &env,
+            !Self::paused_active(&env),
+            EscrowError::PausedBlocksSettlement,
+        );
         ensure(
             &env,
             !Self::legal_hold_active(&env),
@@ -3633,6 +3721,12 @@ impl LiquifactEscrow {
     /// - [`EscrowError::WithdrawalNotFunded`] — escrow not in funded state.
     /// - [`EscrowError::InsufficientContractBalance`] — contract holds less than `funded_amount`.
     pub fn withdraw(env: Env) -> InvoiceEscrow {
+        // Operational pause gate (read-only), before require_auth and orthogonal to legal hold.
+        ensure(
+            &env,
+            !Self::paused_active(&env),
+            EscrowError::PausedBlocksWithdrawal,
+        );
         ensure(
             &env,
             !Self::legal_hold_active(&env),
@@ -3725,6 +3819,12 @@ impl LiquifactEscrow {
     /// Emits typed [`EscrowError`] codes for legal hold, missing contribution, unsettled escrow,
     /// or an unexpired commitment lock.
     pub fn claim_investor_payout(env: Env, investor: Address) {
+        // Operational pause gate (read-only), before require_auth and orthogonal to legal hold.
+        ensure(
+            &env,
+            !Self::paused_active(&env),
+            EscrowError::PausedBlocksInvestorClaims,
+        );
         ensure(
             &env,
             !Self::legal_hold_active(&env),
@@ -4030,7 +4130,6 @@ impl LiquifactEscrow {
                 INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
             );
         }
-
 
         // Instance storage TTL is contract-wide under Soroban SDK 25. The call above covers
         // Escrow, Version, LegalHold, snapshots, caps, and other instance keys.

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -2330,3 +2330,354 @@ fn test_post_handover_admin_can_clear_hold_set_by_old_admin() {
     client.clear_legal_hold();
     assert!(!client.get_legal_hold());
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Operational pause switch (set_paused / is_paused / PausedChanged)
+//
+// The pause is a lightweight incident-response circuit breaker, orthogonal to the
+// compliance legal hold. These tests verify:
+//   - admin-only toggle + view + event,
+//   - each gated entrypoint (fund, settle, withdraw, claim_investor_payout) is blocked
+//     with its dedicated typed error while paused, and restored after unpause,
+//   - full independence from the legal hold (each flag blocks on its own; clearing one
+//     does not clear the other; neither write touches the other's storage key).
+// ═════════════════════════════════════════════════════════════════════════════
+
+use soroban_sdk::token::StellarAssetClient as PauseSac;
+
+/// Initialise a minimal open escrow (status 0, maturity 0, no tiers) with placeholder addresses.
+fn pause_init_open(
+    client: &LiquifactEscrowClient<'_>,
+    env: &Env,
+    admin: &Address,
+    sme: &Address,
+    id: &str,
+) {
+    client.init(
+        admin,
+        &soroban_sdk::String::from_str(env, id),
+        sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &Address::generate(env),
+        &None,
+        &Address::generate(env),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+}
+
+/// Initialise and fund to target with a placeholder token (no real transfers needed for
+/// settle / claim paths, mirroring the legal-hold test harness).
+fn pause_init_funded(
+    client: &LiquifactEscrowClient<'_>,
+    env: &Env,
+    admin: &Address,
+    sme: &Address,
+    investor: &Address,
+    id: &str,
+) {
+    pause_init_open(client, env, admin, sme, id);
+    client.fund(investor, &TARGET);
+}
+
+/// Initialise with a real SAC token and fund to target so `withdraw()` can transfer.
+fn pause_init_funded_real<'a>(
+    env: &'a Env,
+    admin: &Address,
+    sme: &Address,
+    investor: &Address,
+    id: &str,
+) -> LiquifactEscrowClient<'a> {
+    let sac = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token_id = sac.address();
+    let sac_admin = PauseSac::new(env, &token_id);
+    let escrow_id = env.register(crate::LiquifactEscrow, ());
+    let client = LiquifactEscrowClient::new(env, &escrow_id);
+    client.init(
+        admin,
+        &soroban_sdk::String::from_str(env, id),
+        sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &token_id,
+        &None,
+        &Address::generate(env),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    sac_admin.mint(investor, &TARGET);
+    client.fund(investor, &TARGET);
+    client
+}
+
+// ── Admin-only toggle, view, and event ───────────────────────────────────────
+
+#[test]
+fn set_paused_by_admin_toggles_and_view_reflects() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    pause_init_open(&client, &env, &admin, &sme, "PSE001");
+    assert!(!client.is_paused(), "default unpaused");
+    client.set_paused(&true);
+    assert!(client.is_paused());
+    client.set_paused(&false);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn set_paused_records_admin_auth() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    pause_init_open(&client, &env, &admin, &sme, "PSE002");
+    client.set_paused(&true);
+    assert!(
+        env.auths().iter().any(|(addr, _)| *addr == admin),
+        "admin auth must be recorded for set_paused"
+    );
+}
+
+#[test]
+fn set_paused_emits_event_with_correct_flag() {
+    use soroban_sdk::testutils::Events as _;
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    pause_init_open(&client, &env, &admin, &sme, "PSE003");
+
+    client.set_paused(&true);
+    assert_eq!(
+        env.events().all().events().last().unwrap().clone(),
+        crate::PausedChanged {
+            name: symbol_short!("paused"),
+            invoice_id: client.get_escrow().invoice_id,
+            active: 1,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+
+    client.set_paused(&false);
+    assert_eq!(
+        env.events().all().events().last().unwrap().clone(),
+        crate::PausedChanged {
+            name: symbol_short!("paused"),
+            invoice_id: client.get_escrow().invoice_id,
+            active: 0,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+#[test]
+fn set_paused_by_non_admin_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    pause_init_open(&client, &env, &admin, &sme, "PSE004");
+    env.mock_auths(&[]);
+    assert!(client.try_set_paused(&true).is_err());
+}
+
+// ── fund ──────────────────────────────────────────────────────────────────────
+
+#[test]
+fn fund_blocked_when_paused() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    pause_init_open(&client, &env, &admin, &sme, "PGF001");
+    client.set_paused(&true);
+    assert_contract_error(
+        client.try_fund(&investor, &TARGET),
+        crate::EscrowError::PausedBlocksFunding,
+    );
+}
+
+#[test]
+fn fund_passes_after_unpause() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    pause_init_open(&client, &env, &admin, &sme, "PGF002");
+    client.set_paused(&true);
+    client.set_paused(&false);
+    let escrow = client.fund(&investor, &TARGET);
+    assert_eq!(escrow.status, 1);
+}
+
+// ── settle ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn settle_blocked_when_paused() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    pause_init_funded(&client, &env, &admin, &sme, &investor, "PGS001");
+    client.set_paused(&true);
+    assert_contract_error(
+        client.try_settle(),
+        crate::EscrowError::PausedBlocksSettlement,
+    );
+}
+
+#[test]
+fn settle_passes_after_unpause() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    pause_init_funded(&client, &env, &admin, &sme, &investor, "PGS002");
+    client.set_paused(&true);
+    client.set_paused(&false);
+    let escrow = client.settle();
+    assert_eq!(escrow.status, 2);
+}
+
+// ── withdraw ────────────────────────────────────────────────────────────────
+
+#[test]
+fn withdraw_blocked_when_paused() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    pause_init_funded(&client, &env, &admin, &sme, &investor, "PGW001");
+    client.set_paused(&true);
+    assert_contract_error(
+        client.try_withdraw(),
+        crate::EscrowError::PausedBlocksWithdrawal,
+    );
+}
+
+#[test]
+fn withdraw_passes_after_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let client = pause_init_funded_real(&env, &admin, &sme, &investor, "PGW002");
+    client.set_paused(&true);
+    client.set_paused(&false);
+    let escrow = client.withdraw();
+    assert_eq!(escrow.status, 3);
+}
+
+// ── claim_investor_payout ────────────────────────────────────────────────────
+
+#[test]
+fn claim_investor_payout_blocked_when_paused() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    pause_init_funded(&client, &env, &admin, &sme, &investor, "PGC001");
+    client.settle();
+    client.set_paused(&true);
+    assert_contract_error(
+        client.try_claim_investor_payout(&investor),
+        crate::EscrowError::PausedBlocksInvestorClaims,
+    );
+}
+
+#[test]
+fn claim_investor_payout_passes_after_unpause() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    pause_init_funded(&client, &env, &admin, &sme, &investor, "PGC002");
+    client.settle();
+    client.set_paused(&true);
+    client.set_paused(&false);
+    client.claim_investor_payout(&investor);
+    assert!(client.is_investor_claimed(&investor));
+}
+
+// ── Independence from legal hold ──────────────────────────────────────────────
+
+#[test]
+fn pause_and_legal_hold_are_independent_storage_flags() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    pause_init_open(&client, &env, &admin, &sme, "PIN001");
+
+    // Setting the pause must not set the legal hold, and vice-versa.
+    client.set_paused(&true);
+    assert!(client.is_paused());
+    assert!(!client.get_legal_hold(), "pause must not touch legal hold");
+
+    client.set_legal_hold(&true);
+    assert!(client.is_paused(), "legal hold must not touch pause");
+    assert!(client.get_legal_hold());
+
+    // Clearing the pause leaves the legal hold intact.
+    client.set_paused(&false);
+    assert!(!client.is_paused());
+    assert!(client.get_legal_hold());
+
+    // Clearing the legal hold leaves the pause state (now false) intact.
+    client.clear_legal_hold();
+    assert!(!client.is_paused());
+    assert!(!client.get_legal_hold());
+}
+
+#[test]
+fn fund_blocked_by_pause_even_when_legal_hold_cleared() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    pause_init_open(&client, &env, &admin, &sme, "PIN002");
+
+    // Both active, then clear ONLY the legal hold: pause must still block.
+    client.set_paused(&true);
+    client.set_legal_hold(&true);
+    client.clear_legal_hold();
+    assert!(!client.get_legal_hold());
+    assert_contract_error(
+        client.try_fund(&investor, &TARGET),
+        crate::EscrowError::PausedBlocksFunding,
+    );
+}
+
+#[test]
+fn fund_blocked_by_legal_hold_even_when_pause_cleared() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    pause_init_open(&client, &env, &admin, &sme, "PIN003");
+
+    // Both active, then clear ONLY the pause: legal hold must still block.
+    client.set_paused(&true);
+    client.set_legal_hold(&true);
+    client.set_paused(&false);
+    assert!(!client.is_paused());
+    assert_contract_error(
+        client.try_fund(&investor, &TARGET),
+        crate::EscrowError::LegalHoldBlocksFunding,
+    );
+}
+
+#[test]
+fn fund_passes_only_when_both_flags_cleared() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    pause_init_open(&client, &env, &admin, &sme, "PIN004");
+
+    client.set_paused(&true);
+    client.set_legal_hold(&true);
+    client.set_paused(&false);
+    client.clear_legal_hold();
+    let escrow = client.fund(&investor, &TARGET);
+    assert_eq!(escrow.status, 1);
+}


### PR DESCRIPTION
closes #318

## Summary

This PR introduces a lightweight, **admin-only operational pause** to the escrow contract. The pause acts as an incident-response circuit breaker (for example, during a suspected token or protocol issue) and is completely independent of the existing compliance **Legal Hold** mechanism.

Unlike Legal Hold, this feature has no compliance semantics or delayed unpause process—it is simply an operational safety switch.

---

## Behavior

### New Entrypoints

#### `set_paused(active: bool)`

- Callable only by the current contract admin.
- Immediately enables or disables the operational pause.
- Single-call toggle with no two-phase clearing process.

#### `is_paused()`

- Read-only getter.
- Returns the current pause state.
- Defaults to `false` when the value has never been set.

---

## Pause Enforcement

When the contract is paused, the following entrypoints are blocked:

- `fund`
- `settle`
- `withdraw`
- `claim_investor_payout`

Each entrypoint performs a **read-only pause check before `require_auth`**, returning typed errors:

| Error Code | Entrypoint |
|------------|------------|
| 201 | `fund` |
| 202 | `settle` |
| 203 | `withdraw` |
| 204 | `claim_investor_payout` |

---

## Events

Every pause state change emits a new event:

- `PausedChanged`

This provides a complete on-chain audit trail of operational pause activity.

---

## Interaction with Legal Hold

The operational pause and Legal Hold are completely orthogonal.

- Either mechanism independently blocks protected entrypoints.
- Clearing the operational pause **does not** clear Legal Hold.
- Clearing Legal Hold **does not** unpause the contract.

Each feature maintains its own state and semantics.

---

## Changes

### `escrow/src/lib.rs`

- Added `Paused` storage key
- Added `set_paused(active: bool)`
- Added `is_paused()`
- Added `PausedChanged` event
- Added error codes **201–204**
- Added pause gates to:
  - `fund`
  - `settle`
  - `withdraw`
  - `claim_investor_payout`

### `escrow/src/tests/admin.rs`

Added test coverage for:

- Pause toggling
- Admin authorization
- Default unset behavior
- Gating of each protected entrypoint
- Independence from Legal Hold

### Documentation

Updated:

- `README.md`
  - Entrypoint reference
  - Security notes
- `docs/escrow-events.md`
  - `PausedChanged` event documentation
- Security checklist
