### PR TITLE
Add an admin entrypoint to raise the maturity-max-horizon ceiling with a forward-only guard

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -448,6 +448,9 @@ pub enum EscrowError {
     PartialSettleUnauthorizedCaller = 200,
     MaxPerInvestorCapNotConfigured = 24, // new
     MaxPerInvestorCapNotRaised = 25,     // new
+    /// [`LiquifactEscrow::raise_maturity_max_horizon`] received a `new_horizon` that is
+    /// not strictly greater than the current stored horizon.
+    HorizonNotRaised = 201,
 }
 
 #[inline(always)]
@@ -1074,6 +1077,18 @@ pub struct AttestationDigestUnrevoked {
 
 #[contractevent]
 pub struct MaturityMaxHorizonUpdated {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub old_horizon: u64,
+    pub new_horizon: u64,
+}
+
+/// Emitted by [`LiquifactEscrow::raise_maturity_max_horizon`] when the maturity ceiling is
+/// monotonically raised. Carries the `invoice_id` and the old/new horizon values.
+#[contractevent]
+pub struct MaturityMaxHorizonRaised {
     #[topic]
     pub name: Symbol,
     #[topic]
@@ -3986,6 +4001,56 @@ impl LiquifactEscrow {
 
         MaturityMaxHorizonUpdated {
             name: symbol_short!("mtry_max"),
+            invoice_id: escrow.invoice_id,
+            old_horizon,
+            new_horizon,
+        }
+        .publish(&env);
+
+        new_horizon
+    }
+
+    /// Monotonically **raise** the maturity-max-horizon ceiling — a forward-only governance lever.
+    ///
+    /// Unlike the general [`LiquifactEscrow::update_maturity_max_horizon`] setter (which accepts any
+    /// value), this entrypoint guarantees the horizon can only ever be raised, never lowered or held
+    /// equal. This supports a "term-extension only" policy and avoids the confusing invalid
+    /// configuration that arises when a horizon is lowered below an already-set maturity.
+    ///
+    /// # Authorization
+    /// Requires the signature of the current [`InvoiceEscrow::admin`].
+    ///
+    /// # Errors
+    /// - [`EscrowError::HorizonNotRaised`] if `new_horizon` is not strictly greater than the current
+    ///   stored horizon (rejects equal or lower values).
+    ///
+    /// # Events
+    /// Emits [`MaturityMaxHorizonRaised`] carrying `invoice_id`, the old horizon, and the new horizon.
+    ///
+    /// # Returns
+    /// The newly stored horizon.
+    pub fn raise_maturity_max_horizon(env: Env, new_horizon: u64) -> u64 {
+        let escrow = Self::load_escrow_require_admin(&env);
+
+        let old_horizon = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&DataKey::MaturityMaxHorizon)
+            .unwrap_or(DEFAULT_MATURITY_MAX_HORIZON_SECS);
+
+        // Forward-only guard: strictly greater than the current ceiling.
+        ensure(
+            &env,
+            new_horizon > old_horizon,
+            EscrowError::HorizonNotRaised,
+        );
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MaturityMaxHorizon, &new_horizon);
+
+        MaturityMaxHorizonRaised {
+            name: symbol_short!("mtry_rse"),
             invoice_id: escrow.invoice_id,
             old_horizon,
             new_horizon,

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::{
     AdminAcceptedEvent, AdminProposalCancelled, AdminProposedEvent, EscrowCloseSnapshot,
-    FundingTargetUpdated, RegistryRefRebound, DEFAULT_MATURITY_MAX_HORIZON_SECS,
+    FundingTargetUpdated, MaturityMaxHorizonRaised, RegistryRefRebound,
+    DEFAULT_MATURITY_MAX_HORIZON_SECS,
 };
 
 use soroban_sdk::Event;
@@ -2329,4 +2330,140 @@ fn test_post_handover_admin_can_clear_hold_set_by_old_admin() {
     }]);
     client.clear_legal_hold();
     assert!(!client.get_legal_hold());
+}
+
+// ── raise_maturity_max_horizon forward-only lever coverage (issue #559) ───────
+
+/// Helper: deploy + init an escrow (no maturity lock) at ledger time `now`, returning
+/// the client and current admin. Centralises the 17-argument `init` boilerplate.
+fn init_for_raise_horizon<'a>(
+    env: &'a Env,
+    label: &str,
+    now: u64,
+) -> (LiquifactEscrowClient<'a>, Address) {
+    let (client, admin, sme) = setup(env);
+    let (token, treasury) = free_addresses(env);
+    env.ledger().set_timestamp(now);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, label),
+        &sme,
+        &1_000i128,
+        &500i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    (client, admin)
+}
+
+/// A strictly greater horizon is accepted, persisted, returned, and emits
+/// `MaturityMaxHorizonRaised` with the old/new values.
+#[test]
+fn test_raise_maturity_max_horizon_success_and_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = init_for_raise_horizon(&env, "HORI_RS", 1_000);
+    let contract_id = client.address.clone();
+
+    let old = client.get_maturity_max_horizon();
+    let new_horizon = old + 1_000;
+
+    let returned = client.raise_maturity_max_horizon(&new_horizon);
+    assert_eq!(returned, new_horizon);
+    assert_eq!(client.get_maturity_max_horizon(), new_horizon);
+
+    assert_eq!(
+        env.events().all().events().last().unwrap().clone(),
+        MaturityMaxHorizonRaised {
+            name: symbol_short!("mtry_rse"),
+            invoice_id: client.get_escrow().invoice_id,
+            old_horizon: old,
+            new_horizon,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+/// An equal horizon is rejected with `HorizonNotRaised` (#201); the stored value is unchanged.
+#[test]
+#[should_panic(expected = "Error(Contract, #201)")]
+fn test_raise_maturity_max_horizon_rejects_equal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = init_for_raise_horizon(&env, "HORI_EQ", 1_000);
+
+    let current = client.get_maturity_max_horizon();
+    client.raise_maturity_max_horizon(&current);
+}
+
+/// A lower horizon is rejected with `HorizonNotRaised` (#201).
+#[test]
+#[should_panic(expected = "Error(Contract, #201)")]
+fn test_raise_maturity_max_horizon_rejects_lower() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = init_for_raise_horizon(&env, "HORI_LO", 1_000);
+
+    let current = client.get_maturity_max_horizon();
+    client.raise_maturity_max_horizon(&(current - 1));
+}
+
+/// A rejected raise must not mutate the stored horizon.
+#[test]
+fn test_raise_maturity_max_horizon_rejection_leaves_state_intact() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = init_for_raise_horizon(&env, "HORI_NS", 1_000);
+
+    let current = client.get_maturity_max_horizon();
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.raise_maturity_max_horizon(&current);
+    }));
+    assert!(res.is_err(), "equal horizon must be rejected");
+    assert_eq!(
+        client.get_maturity_max_horizon(),
+        current,
+        "rejected raise must not alter the stored horizon"
+    );
+}
+
+/// `raise_maturity_max_horizon` is admin-gated: an unauthorized caller fails.
+#[test]
+#[should_panic]
+fn test_raise_maturity_max_horizon_requires_admin_auth() {
+    let env = Env::default();
+    let (client, _admin) = init_for_raise_horizon(&env, "HORI_AU", 1_000);
+
+    let current = client.get_maturity_max_horizon();
+    env.mock_auths(&[]);
+    client.raise_maturity_max_horizon(&(current + 1));
+}
+
+/// After raising the ceiling, a later `update_maturity` may target a timestamp within
+/// the newly raised horizon (i.e. beyond the previous default ceiling).
+#[test]
+fn test_raise_maturity_max_horizon_enables_far_maturity_update() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let now = 1_000u64;
+    let (client, _admin) = init_for_raise_horizon(&env, "HORI_FU", now);
+
+    let old = client.get_maturity_max_horizon();
+    let raised = old + 10_000;
+    client.raise_maturity_max_horizon(&raised);
+
+    // A maturity at now + old + 1 sits beyond the previous ceiling but within the new one.
+    let target = now + old + 1;
+    client.update_maturity(&target);
+    assert_eq!(client.get_escrow().maturity, target);
 }


### PR DESCRIPTION
Adds a monotonic, policy-safe lever distinct from the general setter:

- New `raise_maturity_max_horizon(new_horizon: u64) -> u64`, admin-gated via `load_escrow_require_admin`.
- Rejects any value not strictly greater than the current horizon with new typed error `HorizonNotRaised` (#201, append-only).
- Emits new structured event `MaturityMaxHorizonRaised` carrying `invoice_id`, old, and new horizon.
- `update_maturity_max_horizon` behaviour left unchanged.

Tests (escrow/src/tests/admin.rs): success + event payload, rejection of equal and lower horizons, state intact on rejection, admin-auth gate, and a subsequent `update_maturity` using the raised ceiling.

Note: the repo `main` currently has pre-existing compile errors unrelated to this change (duplicate `rotate_beneficiary`/`BeneficiaryRotated` and missing `guard_status_*` helpers); this change adds no new errors.

Closes #559