### PR TITLE
Add a settlement-readiness view bundling settleable, legal-hold, and maturity state in one call

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -734,6 +734,32 @@ pub struct EscrowSummary {
     pub attestation_log_length: u32,
 }
 
+/// Bundled settlement-readiness snapshot returned by
+/// [`LiquifactEscrow::get_settlement_readiness`].
+///
+/// Lets an integrator decide whether [`LiquifactEscrow::settle`] will succeed on the current
+/// ledger with a single host invocation, instead of stitching together [`LiquifactEscrow::is_settleable`],
+/// [`LiquifactEscrow::get_legal_hold`], [`LiquifactEscrow::has_maturity_lock`], and the maturity
+/// timestamp — and re-deriving the contract's own precedence rules off-chain (which drifts).
+///
+/// # Precedence
+/// `ready_now` is computed from the **same** single-source-of-truth gate `settle`/`partial_settle`
+/// apply (legal hold blocks first, then funded status, then maturity). A `true` value reliably
+/// predicts a successful `settle` on the current ledger.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SettlementReadiness {
+    /// Mirrors [`LiquifactEscrow::is_settleable`]: funded, matured, and not on legal hold.
+    pub is_settleable: bool,
+    /// `true` when a legal/compliance hold is currently active (blocks settlement).
+    pub legal_hold_active: bool,
+    /// `true` when there is no maturity lock (`maturity == 0`) or the maturity timestamp has
+    /// been reached (`now >= maturity`).
+    pub maturity_reached: bool,
+    /// Single derived flag: `true` exactly when `settle` would succeed on the current ledger.
+    pub ready_now: bool,
+}
+
 // --- Events ---
 
 #[contractevent]
@@ -2367,6 +2393,40 @@ impl LiquifactEscrow {
     /// - no active legal hold
     pub fn is_settleable(env: Env) -> bool {
         Self::settleable_now(&env)
+    }
+
+    /// Bundle the settleable flag, legal-hold state, maturity-reached state, and a single derived
+    /// `ready_now` boolean into one [`SettlementReadiness`] result.
+    ///
+    /// Integrators otherwise have to call [`LiquifactEscrow::is_settleable`],
+    /// [`LiquifactEscrow::get_legal_hold`], [`LiquifactEscrow::has_maturity_lock`], and read the
+    /// maturity timestamp separately, then replicate the contract's precedence rules — which drifts
+    /// out of sync and produces confusing UIs ("settleable" but blocked by a legal hold).
+    ///
+    /// # Precedence
+    /// `ready_now` and `is_settleable` are computed from the **same** single-source-of-truth gate
+    /// (`Self::settleable_now`) that [`LiquifactEscrow::settle`] and
+    /// [`LiquifactEscrow::partial_settle`] apply: a legal hold blocks first, then funded status,
+    /// then maturity. A `ready_now == true` value therefore reliably predicts a successful `settle`
+    /// on the current ledger.
+    ///
+    /// # Read-only
+    /// Pure view: no `require_auth`, no storage writes, and no TTL bump.
+    pub fn get_settlement_readiness(env: Env) -> SettlementReadiness {
+        let legal_hold_active = Self::legal_hold_active(&env);
+        let escrow = Self::get_escrow(env.clone());
+        let maturity_reached =
+            escrow.maturity == 0 || env.ledger().timestamp() >= escrow.maturity;
+
+        // Reuse the single-source-of-truth gate so this view cannot drift from `settle`.
+        let is_settleable = Self::settleable_now(&env);
+
+        SettlementReadiness {
+            is_settleable,
+            legal_hold_active,
+            maturity_reached,
+            ready_now: is_settleable,
+        }
     }
 
     /// Record or replace the optional SME collateral commitment metadata.

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -21,7 +21,7 @@ use super::{
     assert_contract_error, default_init, deploy, deploy_with_id, free_addresses,
     install_stellar_asset_token, setup, StellarTestToken, MAX_DUST_SWEEP_AMOUNT, TARGET,
 };
-use crate::{EscrowError, EscrowSettled, LiquifactEscrow, YieldTier};
+use crate::{EscrowError, EscrowSettled, LiquifactEscrow, SettlementReadiness, YieldTier};
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger as _},
     token::StellarAssetClient,
@@ -2038,4 +2038,127 @@ fn test_is_settleable_normal_successful() {
     default_init(&client, &env, &admin, &sme);
     fund_to_target(&client, &env);
     assert!(client.is_settleable(), "normal successful is settleable");
+}
+
+// ── get_settlement_readiness bundled view coverage (issue #558) ───────────────
+
+/// Open (not yet funded) escrow with no maturity lock: not settleable, no hold,
+/// maturity vacuously reached, and not ready.
+#[test]
+fn test_settlement_readiness_open_not_ready() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let r = client.get_settlement_readiness();
+    assert_eq!(
+        r,
+        SettlementReadiness {
+            is_settleable: false,
+            legal_hold_active: false,
+            maturity_reached: true, // maturity == 0 ⇒ vacuously reached
+            ready_now: false,
+        }
+    );
+    assert!(!r.ready_now);
+}
+
+/// Funded, no maturity lock, no hold: fully ready, and `ready_now == true` must
+/// predict a successful `settle`.
+#[test]
+fn test_settlement_readiness_funded_ready_predicts_settle() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    fund_to_target(&client, &env);
+
+    let r = client.get_settlement_readiness();
+    assert!(r.is_settleable);
+    assert!(!r.legal_hold_active);
+    assert!(r.maturity_reached);
+    assert!(r.ready_now);
+
+    // Parity: ready_now == true ⇒ settle succeeds on the current ledger.
+    let settled = client.settle();
+    assert_eq!(settled.status, 2);
+}
+
+/// Funded but on legal hold: `legal_hold_active` true and `ready_now` false even
+/// though maturity is reached. A `settle` would fail.
+#[test]
+fn test_settlement_readiness_funded_but_held_blocks_ready() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    fund_to_target(&client, &env);
+
+    client.set_legal_hold(&true);
+
+    let r = client.get_settlement_readiness();
+    assert!(r.legal_hold_active);
+    assert!(r.maturity_reached);
+    assert!(!r.is_settleable, "a legal hold makes the escrow not settleable");
+    assert!(!r.ready_now, "ready_now must be false under an active hold");
+
+    // Parity: ready_now == false ⇒ settle fails.
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.settle();
+    }));
+    assert!(res.is_err(), "settle must fail while a legal hold is active");
+}
+
+/// Funded with a future maturity: pre-maturity `maturity_reached` is false and
+/// `ready_now` is false; after the maturity timestamp both flip true and `settle`
+/// succeeds — exercising the maturity precedence branch.
+#[test]
+fn test_settlement_readiness_maturity_gate_parity() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    let maturity: u64 = 20_000;
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_RDY_MAT"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &maturity,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    fund_to_target(&client, &env);
+
+    // Pre-maturity: not reached, not ready.
+    env.ledger().with_mut(|l| l.timestamp = maturity - 1);
+    let pre = client.get_settlement_readiness();
+    assert!(!pre.maturity_reached);
+    assert!(!pre.is_settleable);
+    assert!(!pre.ready_now);
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.settle();
+    }));
+    assert!(res.is_err(), "settle must fail before maturity");
+
+    // At maturity (inclusive): reached and ready; settle succeeds.
+    env.ledger().with_mut(|l| l.timestamp = maturity);
+    let at = client.get_settlement_readiness();
+    assert!(at.maturity_reached);
+    assert!(at.is_settleable);
+    assert!(at.ready_now);
+    let settled = client.settle();
+    assert_eq!(settled.status, 2);
 }


### PR DESCRIPTION
Adds a single read-only view so integrators don't have to stitch together `is_settleable`, `get_legal_hold`, `has_maturity_lock`, and the maturity timestamp (and re-derive precedence off-chain).

- New `#[contracttype] SettlementReadiness { is_settleable, legal_hold_active, maturity_reached, ready_now }`.
- New `get_settlement_readiness()` view. `ready_now`/`is_settleable` reuse the single-source-of-truth `settleable_now` gate that `settle`/`partial_settle` apply (hold → funded → maturity precedence), so `ready_now == true` reliably predicts a successful `settle`.
- Pure read-only: no auth, no writes, no TTL bump.

Tests (escrow/src/tests/settlement.rs): open/not-ready, funded-ready (settle succeeds), funded-but-held (settle fails), and the maturity gate before/at maturity — each asserting `ready_now` parity with the actual `settle` outcome.

Note: repo `main` has pre-existing compile errors unrelated to this change (duplicate `rotate_beneficiary`/`BeneficiaryRotated`, missing `guard_status_*` helpers); this change adds no new errors.

Closes #558