### PR TITLE
Reject zero-amount entries in fund_batch before mutating any escrow state

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -3271,14 +3271,42 @@ impl LiquifactEscrow {
         ensure(&env, n > 0, EscrowError::FundingBatchEmpty);
         ensure(&env, n <= MAX_FUND_BATCH, EscrowError::FundingBatchTooLarge);
 
+        // ── Atomicity guarantee (issue #557) ──────────────────────────────────
+        // Validate the per-entry positivity and min-contribution-floor invariants for
+        // EVERY entry up front, before any `fund_impl` call performs a storage write
+        // or counter increment. A single malformed entry (zero/negative amount, or an
+        // amount below the configured floor) at any position must fail the entire call
+        // atomically, leaving contributions, the unique-funder count, and the funded
+        // total unchanged. These are the same typed errors `fund_impl` raises per entry
+        // (`FundingAmountNotPositive`, `FundingBelowMinContribution`); checking them here
+        // first turns a half-applied batch into an all-or-nothing rejection.
+        //
+        // Stateful per-entry guards (per-investor cap, unique-investor cap, overflow)
+        // remain enforced inside `fund_impl` against the running accumulated state.
+        let floor: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinContributionFloor)
+            .unwrap_or(0);
+        for i in 0..n {
+            let (_, amount) = entries.get(i).unwrap();
+            ensure(&env, amount > 0, EscrowError::FundingAmountNotPositive);
+            if floor > 0 {
+                ensure(
+                    &env,
+                    amount >= floor,
+                    EscrowError::FundingBelowMinContribution,
+                );
+            }
+        }
+
         let mut escrow = Self::get_escrow(env.clone());
 
         for i in 0..n {
             let (investor, amount) = entries.get(i).unwrap();
 
-            // Call fund_impl for each entry, but we need to reconstruct the escrow
-            // after each call. However, fund_impl returns the updated escrow,
-            // so we capture it for the next iteration.
+            // Each entry is now known to satisfy positivity and the floor; remaining
+            // per-entry invariants (auth, caps, overflow) are enforced inside fund_impl.
             escrow = Self::fund_impl(env.clone(), investor, amount, true, 0);
         }
 

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -4610,3 +4610,189 @@ fn test_get_yield_tiers_is_pure_read_no_state_change() {
         "get_yield_tiers must not mutate state"
     );
 }
+
+// ── fund_batch atomic pre-validation coverage (issue #557) ────────────────────
+
+/// Deploy + init an open escrow with a generous target and no caps, returning the
+/// client and three fresh investor addresses for batch tests.
+fn init_for_fund_batch_prevalidate<'a>(
+    env: &'a Env,
+    label: &str,
+) -> (
+    super::LiquifactEscrowClient<'a>,
+    Address,
+    Address,
+    Address,
+) {
+    env.mock_all_auths();
+    let client = deploy(env);
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let (tok, tre) = free_addresses(env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, label),
+        &sme,
+        &1_000_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    (
+        client,
+        Address::generate(env),
+        Address::generate(env),
+        Address::generate(env),
+    )
+}
+
+/// Assert that a `fund_batch` call panics and leaves the escrow state completely
+/// unchanged: funded total, unique-funder count, and each investor's contribution.
+fn assert_fund_batch_atomic_noop(
+    client: &super::LiquifactEscrowClient<'_>,
+    entries: &SorobanVec<(Address, i128)>,
+    investors: &[&Address],
+) {
+    let funded_before = client.get_escrow().funded_amount;
+    let count_before = client.get_unique_funder_count();
+
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.fund_batch(entries);
+    }));
+    assert!(res.is_err(), "malformed batch must fail the entire call");
+
+    assert_eq!(
+        client.get_escrow().funded_amount,
+        funded_before,
+        "funded_amount must be unchanged after a rejected batch"
+    );
+    assert_eq!(
+        client.get_unique_funder_count(),
+        count_before,
+        "unique funder count must be unchanged after a rejected batch"
+    );
+    for inv in investors {
+        assert_eq!(
+            client.get_contribution(inv),
+            0i128,
+            "no contribution may be recorded after a rejected batch"
+        );
+    }
+}
+
+/// A zero-amount entry in the FIRST position must fail the whole batch with no
+/// partial mutation.
+#[test]
+fn test_fund_batch_zero_first_entry_is_atomic_noop() {
+    let env = Env::default();
+    let (client, a, b, c) = init_for_fund_batch_prevalidate(&env, "FB_Z_1");
+
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((a.clone(), 0i128)); // invalid, first
+    entries.push_back((b.clone(), 10_000i128));
+    entries.push_back((c.clone(), 20_000i128));
+
+    assert_fund_batch_atomic_noop(&client, &entries, &[&a, &b, &c]);
+}
+
+/// A zero-amount entry in the MIDDLE position must fail atomically; the valid
+/// first entry must NOT be partially applied.
+#[test]
+fn test_fund_batch_zero_middle_entry_is_atomic_noop() {
+    let env = Env::default();
+    let (client, a, b, c) = init_for_fund_batch_prevalidate(&env, "FB_Z_2");
+
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((a.clone(), 10_000i128)); // valid
+    entries.push_back((b.clone(), 0i128)); // invalid, middle
+    entries.push_back((c.clone(), 20_000i128));
+
+    assert_fund_batch_atomic_noop(&client, &entries, &[&a, &b, &c]);
+}
+
+/// A negative-amount entry in the LAST position must fail atomically; the valid
+/// earlier entries must NOT be partially applied.
+#[test]
+fn test_fund_batch_negative_last_entry_is_atomic_noop() {
+    let env = Env::default();
+    let (client, a, b, c) = init_for_fund_batch_prevalidate(&env, "FB_N_3");
+
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((a.clone(), 10_000i128)); // valid
+    entries.push_back((b.clone(), 20_000i128)); // valid
+    entries.push_back((c.clone(), -5i128)); // invalid, last
+
+    assert_fund_batch_atomic_noop(&client, &entries, &[&a, &b, &c]);
+}
+
+/// An all-valid batch is unaffected by the pre-validation pass: it records each
+/// contribution and advances the funded total exactly like sequential `fund` calls.
+#[test]
+fn test_fund_batch_all_valid_still_records_all_entries() {
+    let env = Env::default();
+    let (client, a, b, c) = init_for_fund_batch_prevalidate(&env, "FB_OK_4");
+
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((a.clone(), 10_000i128));
+    entries.push_back((b.clone(), 20_000i128));
+    entries.push_back((c.clone(), 30_000i128));
+
+    let result = client.fund_batch(&entries);
+
+    assert_eq!(result.funded_amount, 60_000i128);
+    assert_eq!(client.get_unique_funder_count(), 3);
+    assert_eq!(client.get_contribution(&a), 10_000i128);
+    assert_eq!(client.get_contribution(&b), 20_000i128);
+    assert_eq!(client.get_contribution(&c), 30_000i128);
+}
+
+/// A below-floor entry is rejected up front (same as the single-`fund` floor guard),
+/// leaving no partial mutation even though the other entries are valid.
+#[test]
+fn test_fund_batch_below_floor_entry_is_atomic_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let floor = 5_000i128;
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FB_FLR_5"),
+        &sme,
+        &1_000_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &Some(floor),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((a.clone(), 10_000i128)); // valid
+    entries.push_back((b.clone(), 1_000i128)); // below floor → reject whole batch
+
+    assert_fund_batch_atomic_noop(&client, &entries, &[&a, &b]);
+}


### PR DESCRIPTION
Adds an up-front validation pass over the whole `fund_batch` so any non-positive (or below-floor) entry fails the entire call atomically, before any storage write or counter increment.

- Pre-validates positivity (`FundingAmountNotPositive`) and the configured min-contribution floor (`FundingBelowMinContribution`) for every entry first, reusing the existing typed errors (no new error code).
- A malformed entry at any position (first/middle/last) now leaves contributions, the unique-funder count, and the funded total unchanged — no half-applied state.
- Stateful per-entry guards (per-investor cap, unique-investor cap, overflow) remain enforced inside `fund_impl` against the running accumulated state; valid-batch semantics (ordering, funded-target promotion, allowlist) are preserved.

Tests (escrow/src/tests/funding.rs): zero/negative entry at first/middle/last position each leaves state untouched, a below-floor entry is an atomic no-op, and an all-valid batch still records every contribution.

Note: repo `main` has pre-existing compile errors unrelated to this change (duplicate `rotate_beneficiary`/`BeneficiaryRotated`, missing `guard_status_*` helpers); this change adds no new errors.

Closes #557