### PR TITLE
fix: replace partial_settle reused error codes with dedicated typed E…

### DIFF
--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -146,6 +146,9 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 165 | `ClaimBatchEmpty` | `claim_payouts_batch` | `investors` vec is empty | Pass at least one investor | typed |
 | 166 | `ClaimBatchTooLarge` | `claim_payouts_batch` | `investors` vec exceeds `MAX_CLAIM_BATCH` (32) | Split into smaller batches | typed |
 | 167 | `FundingDeadlinePassed` | `init`, `fund`, `fund_with_commitment`, `fund_batch` | `funding_deadline` configured and `ledger.timestamp()` past deadline | Funding window closed; do not retry deposits | typed |
+| 200 | `PartialSettleUnauthorizedCaller` | `partial_settle` | `caller` is neither `sme_address` nor `admin` | Call as the SME or admin | typed |
+| 201 | `LegalHoldBlocksPartialSettle` | `partial_settle` | legal hold active | Complete legal-hold clear workflow | typed |
+| 202 | `PartialSettleNotOpen` | `partial_settle` | escrow status `!= 0` (open) | Partial settle only while open | typed |
 
 ### Legacy panic strings (migration aid)
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -445,7 +445,12 @@ pub enum EscrowError {
     /// [`LiquifactEscrow::lower_min_contribution_floor`] received a non-positive floor.
     NewFloorNotPositive = 175,
     /// Caller is not authorized to perform partial settlement.
+    /// Only the escrow's `sme_address` or `admin` may call [`LiquifactEscrow::partial_settle`].
     PartialSettleUnauthorizedCaller = 200,
+    /// [`LiquifactEscrow::partial_settle`] blocked while a legal hold is active.
+    LegalHoldBlocksPartialSettle = 201,
+    /// [`LiquifactEscrow::partial_settle`] called while escrow is not in open status (`status != 0`).
+    PartialSettleNotOpen = 202,
     MaxPerInvestorCapNotConfigured = 24, // new
     MaxPerInvestorCapNotRaised = 25,     // new
 }
@@ -3530,7 +3535,7 @@ impl LiquifactEscrow {
         ensure(
             &env,
             !Self::legal_hold_active(&env),
-            EscrowError::LegalHoldBlocksSettlement,
+            EscrowError::LegalHoldBlocksPartialSettle,
         );
 
         let mut escrow = Self::get_escrow(env.clone());
@@ -3541,11 +3546,7 @@ impl LiquifactEscrow {
             EscrowError::PartialSettleUnauthorizedCaller,
         );
 
-        ensure(
-            &env,
-            escrow.status == 0,
-            EscrowError::EscrowNotOpenForFunding,
-        );
+        ensure(&env, escrow.status == 0, EscrowError::PartialSettleNotOpen);
 
         // Transition to funded status early.
         escrow.status = 1;

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2922,7 +2922,11 @@ impl LiquifactEscrow {
         // Actually, reusing EscrowError::EscrowNotOpenForFunding since CapLowerNotOpen is specific to lower.
         // But wait, the issue said "parallel guards" and "open-state-only".
         // Let's use EscrowError::EscrowNotOpenForFunding.
-        ensure(&env, escrow.status == 0, EscrowError::EscrowNotOpenForFunding);
+        ensure(
+            &env,
+            escrow.status == 0,
+            EscrowError::EscrowNotOpenForFunding,
+        );
 
         let old_cap: Option<u32> = env
             .storage()
@@ -4031,7 +4035,6 @@ impl LiquifactEscrow {
                 INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
             );
         }
-
 
         // Instance storage TTL is contract-wide under Soroban SDK 25. The call above covers
         // Escrow, Version, LegalHold, snapshots, caps, and other instance keys.

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -2330,3 +2330,64 @@ fn test_post_handover_admin_can_clear_hold_set_by_old_admin() {
     client.clear_legal_hold();
     assert!(!client.get_legal_hold());
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// `partial_settle` typed-error coverage
+//
+// `partial_settle` reverts with stable, append-only `EscrowError` codes (not panic
+// strings) so client SDKs can branch on the numeric code. These tests assert each
+// revert condition via `try_partial_settle`, mirroring the guard order in the
+// contract: legal hold → caller authorization → open-status.
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A legal hold blocks `partial_settle` with the dedicated
+/// [`EscrowError::LegalHoldBlocksPartialSettle`] code (not the borrowed
+/// settlement code).
+#[test]
+fn test_partial_settle_legal_hold_typed_error() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    client.set_legal_hold(&true);
+
+    assert_contract_error(
+        client.try_partial_settle(&sme),
+        EscrowError::LegalHoldBlocksPartialSettle,
+    );
+}
+
+/// A caller that is neither the SME nor the admin is rejected with
+/// [`EscrowError::PartialSettleUnauthorizedCaller`].
+#[test]
+fn test_partial_settle_unauthorized_caller_typed_error() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let stranger = Address::generate(&env);
+
+    assert_contract_error(
+        client.try_partial_settle(&stranger),
+        EscrowError::PartialSettleUnauthorizedCaller,
+    );
+}
+
+/// `partial_settle` on a non-open escrow (already funded → status 1) is rejected
+/// with [`EscrowError::PartialSettleNotOpen`].
+#[test]
+fn test_partial_settle_not_open_typed_error() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    // Fund to target so status transitions 0 → 1; partial_settle requires status == 0.
+    let investor = Address::generate(&env);
+    client.fund(&investor, &TARGET);
+    assert_eq!(client.get_escrow().status, 1u32);
+
+    assert_contract_error(
+        client.try_partial_settle(&sme),
+        EscrowError::PartialSettleNotOpen,
+    );
+}


### PR DESCRIPTION
# fix: replace partial_settle reused error codes with dedicated typed `EscrowError` codes and tests

Closes #319 

## Summary

`partial_settle` was emitting **reused** error codes borrowed from other
entrypoints (`LegalHoldBlocksSettlement` from `settle`, `EscrowNotOpenForFunding`
from `fund`). This breaks the project's documented client-SDK contract that
callers "branch on the numeric code rather than legacy panic strings": an SDK
catching `EscrowNotOpenForFunding` could not distinguish a closed funding window
from a partial-settle-on-non-open-escrow rejection.

This PR gives `partial_settle` its own dedicated, append-only `EscrowError`
codes so it matches every other entrypoint.

> **Note on the original issue text:** the issue described `partial_settle` as
> using raw `assert!` with panic strings. On `main` it already used
> `ensure(...)`, but with the *wrong/reused* typed codes. The fix is therefore
> repointing those guards at dedicated codes — the same outcome the issue intends.

## Changes

| File | Change |
|------|--------|
| `escrow/src/lib.rs` | Added append-only variants `LegalHoldBlocksPartialSettle = 201` and `PartialSettleNotOpen = 202` (with NatSpec `///` comments); repointed the legal-hold and open-status guards. The unauthorized-caller guard already had its own dedicated code `PartialSettleUnauthorizedCaller = 200`. |
| `escrow/src/tests/admin.rs` | Added 3 typed-error tests using `try_partial_settle`. |
| `docs/escrow-error-messages.md` | Documented codes 200–202. |

### Error code mapping

| Guard | Before | After |
|-------|--------|-------|
| Legal hold active | `LegalHoldBlocksSettlement` (120) | **`LegalHoldBlocksPartialSettle` (201)** |
| Caller ≠ SME/admin | `PartialSettleUnauthorizedCaller` (200) | unchanged (already dedicated) |
| Escrow not open (`status != 0`) | `EscrowNotOpenForFunding` (103) | **`PartialSettleNotOpen` (202)** |

## Security notes

- **Identical revert conditions.** Only the *error type* changed; every guard
  fires on exactly the same condition as before. No new code path, no relaxed
  check, no change to the `status 0 → 1` transition.
- **Guard ordering preserved.** `caller.require_auth()` → legal-hold → caller
  authorization → open-status, matching ADR-002.
- **Event unchanged.** `EscrowPartialSettle` is emitted as before.
- **Append-only codes.** New variants take the next free numbers (201, 202);
  no existing code was renumbered, preserving SDK compatibility.

## Tests

Added to `escrow/src/tests/admin.rs`, each asserting the exact typed code via
`try_partial_settle`:

- `test_partial_settle_legal_hold_typed_error` → `LegalHoldBlocksPartialSettle`
- `test_partial_settle_unauthorized_caller_typed_error` → `PartialSettleUnauthorizedCaller`
- `test_partial_settle_not_open_typed_error` → `PartialSettleNotOpen`

These cover all three edge cases requested: hold active, wrong caller, non-open status.

## ⚠️ CI / build caveat (not introduced by this PR)

`main` does not currently compile — there are pre-existing, unrelated errors
(a duplicate `rotate_beneficiary` definition + duplicate `BeneficiaryRotated`
event, calls to undefined `guard_status_eq`/`guard_status_in` helpers, and a
reference to a non-existent `EscrowError::SweepNotTerminal` variant). Because of
this, `cargo build` / `cargo test` cannot currently run to completion on the
branch, so full test output is not included here.