### PR TITLE
Replace the magic-number default-balance literal in the mock token with a named constant

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -4397,6 +4397,17 @@ mod test_allowlist_tests;
 #[cfg(test)]
 mod tests;
 
+/// Default starting balance assigned to any address that has never been seen by the
+/// [`DefaultMockToken`] contract.
+///
+/// The value (100 trillion stroops, i.e. 10 000 000 XLM at 7 decimal places) is large
+/// enough that ordinary test escrow amounts never accidentally overdraw an account,
+/// while still being representable in a signed 64-bit integer.  Defined once here so
+/// that `balance` and `transfer` stay in sync and a single edit suffices to change the
+/// test-harness funding level.
+#[cfg(any(test, feature = "testutils"))]
+pub const MOCK_TOKEN_DEFAULT_BALANCE: i128 = 100_000_000_000_000i128;
+
 #[cfg(any(test, feature = "testutils"))]
 #[soroban_sdk::contract]
 pub struct DefaultMockToken;
@@ -4411,7 +4422,7 @@ impl DefaultMockToken {
             .instance()
             .get(&key)
             .unwrap_or_else(|| soroban_sdk::Map::new(&env));
-        balances.get(addr).unwrap_or(100_000_000_000_000i128)
+        balances.get(addr).unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE)
     }
 
     pub fn transfer(
@@ -4428,8 +4439,8 @@ impl DefaultMockToken {
             .unwrap_or_else(|| soroban_sdk::Map::new(&env));
         let from_bal = balances
             .get(from.clone())
-            .unwrap_or(100_000_000_000_000i128);
-        let to_bal = balances.get(to.clone()).unwrap_or(100_000_000_000_000i128);
+            .unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
+        let to_bal = balances.get(to.clone()).unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
         balances.set(from.clone(), from_bal - amount);
         balances.set(to.clone(), to_bal + amount);
         env.storage().instance().set(&key, &balances);

--- a/escrow/src/tests/external_calls_mocked.rs
+++ b/escrow/src/tests/external_calls_mocked.rs
@@ -686,3 +686,101 @@ fn test_inbound_compliant_token_passes() {
     assert_eq!(investor_before - investor_after, amount);
     assert_eq!(escrow_after - escrow_before, amount);
 }
+
+// ---------------------------------------------------------------------------
+// Tests: MOCK_TOKEN_DEFAULT_BALANCE constant — unseen-address semantics
+// ---------------------------------------------------------------------------
+
+/// An unseen address should report exactly MOCK_TOKEN_DEFAULT_BALANCE via the mock.
+#[test]
+fn test_mock_token_default_balance_unseen_address() {
+    use super::super::DefaultMockToken;
+    use super::super::MOCK_TOKEN_DEFAULT_BALANCE;
+    use soroban_sdk::token::TokenClient;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_id = env.register(DefaultMockToken, ());
+    let client = TokenClient::new(&env, &token_id);
+
+    let stranger = Address::generate(&env);
+
+    assert_eq!(
+        client.balance(&stranger),
+        MOCK_TOKEN_DEFAULT_BALANCE,
+        "unseen address must report MOCK_TOKEN_DEFAULT_BALANCE"
+    );
+}
+
+/// A transfer between two unseen addresses should produce symmetric deltas around
+/// MOCK_TOKEN_DEFAULT_BALANCE: sender loses `amount`, recipient gains `amount`.
+#[test]
+fn test_mock_token_transfer_between_two_unseen_addresses() {
+    use super::super::DefaultMockToken;
+    use super::super::MOCK_TOKEN_DEFAULT_BALANCE;
+    use soroban_sdk::token::TokenClient;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_id = env.register(DefaultMockToken, ());
+    let client = TokenClient::new(&env, &token_id);
+
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let amount = 1_000_000i128;
+
+    let sender_before = client.balance(&sender);
+    let recipient_before = client.balance(&recipient);
+
+    assert_eq!(sender_before, MOCK_TOKEN_DEFAULT_BALANCE);
+    assert_eq!(recipient_before, MOCK_TOKEN_DEFAULT_BALANCE);
+
+    client.transfer(&sender, &recipient, &amount);
+
+    assert_eq!(
+        client.balance(&sender),
+        MOCK_TOKEN_DEFAULT_BALANCE - amount,
+        "sender balance should decrease by amount"
+    );
+    assert_eq!(
+        client.balance(&recipient),
+        MOCK_TOKEN_DEFAULT_BALANCE + amount,
+        "recipient balance should increase by amount"
+    );
+}
+
+/// Repeated transfers from an unseen sender accumulate correctly against the default.
+#[test]
+fn test_mock_token_repeated_transfers_from_unseen_sender() {
+    use super::super::DefaultMockToken;
+    use super::super::MOCK_TOKEN_DEFAULT_BALANCE;
+    use soroban_sdk::token::TokenClient;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_id = env.register(DefaultMockToken, ());
+    let client = TokenClient::new(&env, &token_id);
+
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let amount = 500i128;
+    let rounds = 3i128;
+
+    for _ in 0..rounds {
+        client.transfer(&sender, &recipient, &amount);
+    }
+
+    assert_eq!(
+        client.balance(&sender),
+        MOCK_TOKEN_DEFAULT_BALANCE - amount * rounds,
+        "sender balance should decrease by total transferred"
+    );
+    assert_eq!(
+        client.balance(&recipient),
+        MOCK_TOKEN_DEFAULT_BALANCE + amount * rounds,
+        "recipient balance should increase by total transferred"
+    );
+}


### PR DESCRIPTION
Fixes #566

## Summary
- Defines a single named constant `MOCK_TOKEN_DEFAULT_BALANCE: i128` (100_000_000_000_000) in testutils scope with a doc comment explaining why this magnitude is chosen
- Replaces all three literal occurrences of `100_000_000_000_000i128` in `DefaultMockToken::balance` and `DefaultMockToken::transfer` with the constant
- Adds three new tests in `escrow/src/tests/external_calls_mocked.rs` asserting unseen-address default balance, symmetric transfer deltas between two unseen addresses, and correct accumulation across repeated transfers

## Changes
- `escrow/src/lib.rs`: Added `MOCK_TOKEN_DEFAULT_BALANCE` const with NatSpec-style doc comment; replaced three magic-number literals with the constant
- `escrow/src/tests/external_calls_mocked.rs`: Added `test_mock_token_default_balance_unseen_address`, `test_mock_token_transfer_between_two_unseen_addresses`, and `test_mock_token_repeated_transfers_from_unseen_sender`

## Security notes
Pure testutils/test-scope refactor. No production code path is touched. The constant is gated behind `#[cfg(any(test, feature = "testutils"))]`, identical to the existing mock token structs.