### PR TITLE
Add tests for lower_max_unique_investors rejecting a cap below the current funder count

### DIFF
--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -1810,3 +1810,272 @@ fn test_raise_when_closed() {
     // Now escrow not open; raise should panic
     client.raise_max_unique_investors(&4u32);
 }
+
+// --- lower_max_unique_investors floor-at-funder-count boundary tests (#563) ---
+
+/// Fund N distinct investors, then lower the cap exactly to N (cap == count).
+/// This is the floor boundary: it must succeed, leaving zero remaining slots.
+#[test]
+fn test_lower_cap_at_funder_count_succeeds_zero_remaining_slots() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    // Cap = 5, fund 3 distinct investors so unique_funder_count == 3.
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_BOUNDARY1"),
+        &sme,
+        &200_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(5u32),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let inv1 = Address::generate(&env);
+    let inv2 = Address::generate(&env);
+    let inv3 = Address::generate(&env);
+    client.fund(&inv1, &10_000_000_000i128);
+    client.fund(&inv2, &10_000_000_000i128);
+    client.fund(&inv3, &10_000_000_000i128);
+
+    let n = client.get_unique_funder_count();
+    assert_eq!(n, 3);
+
+    // lower cap to exactly N (3) — must succeed, this is the floor boundary.
+    let new_cap = client.lower_max_unique_investors(&3u32);
+    assert_eq!(new_cap, 3);
+    assert_eq!(client.get_max_unique_investors_cap(), Some(3));
+
+    // Remaining slots must be 0: cap(3) - count(3) = 0.
+    assert_eq!(client.get_remaining_investor_slots(), Some(0));
+}
+
+/// Fund N distinct investors, then attempt to lower the cap to N-1.
+/// This must be rejected with NewCapBelowCurrentFunderCount, preserving the
+/// "count <= cap" invariant and preventing slot underflow.
+#[test]
+#[should_panic(expected = "NewCapBelowCurrentFunderCount")]
+fn test_lower_cap_one_below_funder_count_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    // Cap = 5, fund 3 distinct investors so unique_funder_count == 3.
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_BOUNDARY2"),
+        &sme,
+        &200_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(5u32),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+
+    assert_eq!(client.get_unique_funder_count(), 3);
+
+    // lower to N-1 = 2 — must panic NewCapBelowCurrentFunderCount.
+    client.lower_max_unique_investors(&2u32);
+}
+
+/// Attempting to use lower_max_unique_investors to raise the cap must be
+/// rejected with NewCapNotLower (lower-only semantics enforced).
+#[test]
+#[should_panic(expected = "NewCapNotLower")]
+fn test_lower_max_unique_investors_raise_attempt_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_BOUNDARY3"),
+        &sme,
+        &200_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(3u32),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Attempt to raise cap from 3 to 5 via the lower entrypoint — must panic.
+    client.lower_max_unique_investors(&5u32);
+}
+
+/// Admin auth is required for lower_max_unique_investors.
+/// Calling without any auth must panic.
+#[test]
+#[should_panic]
+fn test_lower_cap_floor_boundary_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_BOUNDARY4"),
+        &sme,
+        &200_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(5u32),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+
+    // Strip all auth — call must be rejected.
+    env.mock_auths(&[]);
+    client.lower_max_unique_investors(&2u32);
+}
+
+/// Verify admin auth is recorded when lower_max_unique_investors is called
+/// at the floor boundary (cap lowered to exactly the current funder count).
+#[test]
+fn test_lower_cap_floor_boundary_admin_auth_recorded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_BOUNDARY5"),
+        &sme,
+        &200_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(5u32),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+    client.fund(&Address::generate(&env), &10_000_000_000i128);
+    assert_eq!(client.get_unique_funder_count(), 2);
+
+    // Lower cap to exactly the current funder count.
+    let new_cap = client.lower_max_unique_investors(&2u32);
+    assert_eq!(new_cap, 2);
+
+    assert!(
+        env.auths().iter().any(|(addr, _)| *addr == admin),
+        "admin auth was not recorded for lower_max_unique_investors at floor boundary"
+    );
+}
+
+/// Assert get_remaining_investor_slots remains consistent after a series of
+/// successful cap lowerings, always satisfying remaining = cap - count.
+#[test]
+fn test_lower_cap_remaining_slots_consistent_after_each_lowering() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+
+    // Start with cap = 10.
+    client.init(
+        &admin,
+        &String::from_str(&env, "FLOOR_BOUNDARY6"),
+        &sme,
+        &500_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &Some(10u32),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    // Fund 4 distinct investors.
+    for _ in 0..4 {
+        client.fund(&Address::generate(&env), &10_000_000_000i128);
+    }
+    assert_eq!(client.get_unique_funder_count(), 4);
+
+    // Initial remaining = 10 - 4 = 6.
+    assert_eq!(client.get_remaining_investor_slots(), Some(6));
+
+    // Lower to 8: remaining = 8 - 4 = 4.
+    client.lower_max_unique_investors(&8u32);
+    assert_eq!(client.get_max_unique_investors_cap(), Some(8));
+    assert_eq!(client.get_remaining_investor_slots(), Some(4));
+
+    // Lower to 6: remaining = 6 - 4 = 2.
+    client.lower_max_unique_investors(&6u32);
+    assert_eq!(client.get_max_unique_investors_cap(), Some(6));
+    assert_eq!(client.get_remaining_investor_slots(), Some(2));
+
+    // Lower to exactly the funder count (4): remaining = 4 - 4 = 0.
+    client.lower_max_unique_investors(&4u32);
+    assert_eq!(client.get_max_unique_investors_cap(), Some(4));
+    assert_eq!(client.get_remaining_investor_slots(), Some(0));
+}


### PR DESCRIPTION
Fixes #563

## Summary
- Adds boundary test asserting `lower_max_unique_investors(N)` succeeds when cap equals current funder count, yielding zero remaining slots
- Adds test asserting `lower_max_unique_investors(N-1)` is rejected with the typed `NewCapBelowCurrentFunderCount` error, preventing invariant violation and slot underflow
- Adds test verifying that raising via the lower-only entrypoint is rejected with `NewCapNotLower`
- Adds admin auth enforcement tests (non-admin caller rejected; admin auth recorded at floor boundary)
- Adds `get_remaining_investor_slots` consistency test across a series of successful lowerings

## Changes
Implements the test cases described in the issue in `escrow/src/tests/cap_validation.rs`, following existing code patterns for init, fund, and lower_max_unique_investors.

## Security notes
- The `NewCapBelowCurrentFunderCount` guard prevents the remaining-slots value from underflowing when `cap < count`
- The `NewCapNotLower` guard enforces the lower-only semantics of this entrypoint
- Admin auth is required for every invocation, preventing unauthorized cap manipulation