### PR TITLE
Add tests for preview_yield_tier matching the tier actually assigned by fund_with_commitment

### DIFF
--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -4610,3 +4610,197 @@ fn test_get_yield_tiers_is_pure_read_no_state_change() {
         "get_yield_tiers must not mutate state"
     );
 }
+
+// ---------------------------------------------------------------------------
+// preview_yield_tier vs fund_with_commitment equivalence tests (issue #562)
+// ---------------------------------------------------------------------------
+
+/// Helper: initialise an escrow with three tiers (30s / 60s / 90s) and a base
+/// yield of 500 bps.  Returns the client ready for use; all auth is mocked.
+fn setup_three_tier_escrow(
+    env: &Env,
+    invoice_id: &str,
+    target: i128,
+) -> LiquifactEscrowClient {
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let (tok, tre) = free_addresses(env);
+    let client = deploy(env);
+
+    let mut tiers = SorobanVec::new(env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 30,
+        yield_bps: 700,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 60,
+        yield_bps: 900,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 90,
+        yield_bps: 1_200,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, invoice_id),
+        &sme,
+        &target,
+        &500i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    client
+}
+
+/// Assert that `preview_yield_tier(amount, lock)` exactly matches what
+/// `fund_with_commitment` later records for the same investor.
+///
+/// Uses a freshly-generated address for the investor so no prior deposit
+/// can interfere with tier selection.
+fn assert_preview_matches_actual(
+    client: &LiquifactEscrowClient,
+    env: &Env,
+    amount: i128,
+    lock: u64,
+) {
+    let (preview_bps, preview_lock) = client.preview_yield_tier(&amount, &lock);
+    let investor = Address::generate(env);
+    client.fund_with_commitment(&investor, &amount, &lock);
+    let actual_bps = client.get_investor_yield_bps(&investor);
+    let actual_lock = client.get_investor_claim_not_before(&investor);
+    assert_eq!(
+        preview_bps, actual_bps,
+        "preview_yield_tier bps mismatch for lock={lock}: preview={preview_bps} actual={actual_bps}"
+    );
+    assert_eq!(
+        preview_lock, actual_lock,
+        "preview_yield_tier lock mismatch for lock={lock}: preview={preview_lock} actual={actual_lock}"
+    );
+}
+
+/// Base / no-tier case: amount below the first tier threshold.
+/// Preview and actual must both return the escrow base yield (500 bps, lock 0).
+#[test]
+fn test_preview_matches_actual_base_case_no_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // Large target so we can fund multiple investors without hitting capacity.
+    let client = setup_three_tier_escrow(&env, "PV_BASE", 1_000_000i128);
+    assert_preview_matches_actual(&client, &env, 1_000i128, 0u64);
+    assert_preview_matches_actual(&client, &env, 1_000i128, 29u64);
+}
+
+/// Boundary triple for tier 0 (min_lock_secs = 30, yield_bps = 700):
+/// just below (29 s) → base, exactly at (30 s) → tier 0, just above (31 s) → tier 0.
+#[test]
+fn test_preview_matches_actual_tier0_boundary_triple() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup_three_tier_escrow(&env, "PV_T0", 1_000_000i128);
+    assert_preview_matches_actual(&client, &env, 1_000i128, 29u64); // just below
+    assert_preview_matches_actual(&client, &env, 1_000i128, 30u64); // exactly at
+    assert_preview_matches_actual(&client, &env, 1_000i128, 31u64); // just above
+}
+
+/// Boundary triple for tier 1 (min_lock_secs = 60, yield_bps = 900):
+/// just below (59 s) → tier 0, exactly at (60 s) → tier 1, just above (61 s) → tier 1.
+#[test]
+fn test_preview_matches_actual_tier1_boundary_triple() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup_three_tier_escrow(&env, "PV_T1", 1_000_000i128);
+    assert_preview_matches_actual(&client, &env, 1_000i128, 59u64); // just below
+    assert_preview_matches_actual(&client, &env, 1_000i128, 60u64); // exactly at
+    assert_preview_matches_actual(&client, &env, 1_000i128, 61u64); // just above
+}
+
+/// Boundary triple for tier 2 (min_lock_secs = 90, yield_bps = 1200):
+/// just below (89 s) → tier 1, exactly at (90 s) → tier 2, just above (91 s) → tier 2.
+#[test]
+fn test_preview_matches_actual_tier2_boundary_triple() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup_three_tier_escrow(&env, "PV_T2", 1_000_000i128);
+    assert_preview_matches_actual(&client, &env, 1_000i128, 89u64); // just below
+    assert_preview_matches_actual(&client, &env, 1_000i128, 90u64); // exactly at
+    assert_preview_matches_actual(&client, &env, 1_000i128, 91u64); // just above
+}
+
+/// Highest tier: a lock well above all thresholds must return the top-tier yield.
+#[test]
+fn test_preview_matches_actual_highest_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup_three_tier_escrow(&env, "PV_HIGH", 1_000_000i128);
+    assert_preview_matches_actual(&client, &env, 1_000i128, 9_999u64);
+}
+
+/// Zero lock: investor passes lock=0 even though tiers exist.
+/// Both preview and actual must fall back to the base yield with claim_not_before=0.
+#[test]
+fn test_preview_matches_actual_zero_lock_with_tiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup_three_tier_escrow(&env, "PV_ZERO", 1_000_000i128);
+    let (preview_bps, preview_lock) = client.preview_yield_tier(&1_000i128, &0u64);
+    assert_eq!(preview_bps, 500, "zero lock must return base yield");
+    assert_eq!(preview_lock, 0, "zero lock must return lock=0");
+    assert_preview_matches_actual(&client, &env, 1_000i128, 0u64);
+}
+
+/// No tiers configured at all: preview and actual must both return the escrow
+/// base yield regardless of the lock supplied.
+#[test]
+fn test_preview_matches_actual_no_tiers_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    let client = deploy(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "PV_NOTIER"),
+        &sme,
+        &1_000_000i128,
+        &600i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert_preview_matches_actual(&client, &env, 1_000i128, 0u64);
+    assert_preview_matches_actual(&client, &env, 1_000i128, 9_999u64);
+}
+
+/// Amount parameter is currently unused in tier selection (lock-only rule).
+/// Preview and actual must agree regardless of the amount supplied.
+#[test]
+fn test_preview_matches_actual_varying_amounts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup_three_tier_escrow(&env, "PV_AMT", 1_000_000i128);
+    for amount in [1i128, 100, 500, 5_000, 50_000] {
+        assert_preview_matches_actual(&client, &env, amount, 30u64);
+        assert_preview_matches_actual(&client, &env, amount, 60u64);
+    }
+}


### PR DESCRIPTION
Fixes #562

## Summary
- Adds a reusable `setup_three_tier_escrow` helper and `assert_preview_matches_actual` assertion helper for clean, DRY boundary tests
- Covers the base/no-tier case (lock=0, amount below first threshold)
- Tests boundary triples (just below / exactly at / just above) for each of the three configured tiers
- Tests the highest-tier case (lock well above all thresholds)
- Tests zero-lock with tiers present (must fall back to base yield)
- Tests no-tiers-configured scenario for both zero and large locks
- Tests varying amounts to confirm the lock-only selection rule is consistent between preview and actual

## Changes
Implements the feature/fix as described in the issue, following existing code patterns.