### PR TITLE
feat: add bounded batch contribution read view

### DIFF
--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -42,6 +42,9 @@ Codes are grouped by domain so SDKs can map coarse categories without parsing va
 | Legal-hold clear (two-phase) | 150–152 | Delayed compliance-hold lift workflow | 150, 152 |
 | Beneficiary rotation | 160–162 | Governed SME address rotation | 160, 162 |
 | Funding deadline / balance | 163–164 | Post-deadline funding and contract balance sufficiency | 163, 164 |
+| Operational pause | 180–183 | Lightweight incident-response pause gates | 180, 183 |
+| Read batch views | 203 | Bounded read API batch sizes | 203 |
+| Maturity horizon governance | 204 | Forward-only maturity horizon raise guard | 204 |
 
 See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 [`docs/ESCROW_BENEFICIARY_ROTATION.md`](ESCROW_BENEFICIARY_ROTATION.md), and
@@ -146,9 +149,15 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 165 | `ClaimBatchEmpty` | `claim_payouts_batch` | `investors` vec is empty | Pass at least one investor | typed |
 | 166 | `ClaimBatchTooLarge` | `claim_payouts_batch` | `investors` vec exceeds `MAX_CLAIM_BATCH` (32) | Split into smaller batches | typed |
 | 167 | `FundingDeadlinePassed` | `init`, `fund`, `fund_with_commitment`, `fund_batch` | `funding_deadline` configured and `ledger.timestamp()` past deadline | Funding window closed; do not retry deposits | typed |
+| 180 | `PausedBlocksFunding` | `fund`, `fund_with_commitment`, `fund_batch` | operational pause active | Clear the operational pause before funding | typed |
+| 181 | `PausedBlocksSettlement` | `settle` | operational pause active | Clear the operational pause before settlement | typed |
+| 182 | `PausedBlocksWithdrawal` | `withdraw` | operational pause active | Clear the operational pause before withdrawal | typed |
+| 183 | `PausedBlocksInvestorClaims` | `claim_investor_payout` | operational pause active | Clear the operational pause before investor claims | typed |
 | 200 | `PartialSettleUnauthorizedCaller` | `partial_settle` | `caller` is neither `sme_address` nor `admin` | Call as the SME or admin | typed |
 | 201 | `LegalHoldBlocksPartialSettle` | `partial_settle` | legal hold active | Complete legal-hold clear workflow | typed |
 | 202 | `PartialSettleNotOpen` | `partial_settle` | escrow status `!= 0` (open) | Partial settle only while open | typed |
+| 203 | `ContributionReadBatchTooLarge` | `get_contributions` | `investors.len() > MAX_INVESTOR_READ_BATCH` | Split the read into smaller batches | typed |
+| 204 | `HorizonNotRaised` | `raise_maturity_max_horizon` | `new_horizon <= current horizon` | Pass a strictly higher horizon | typed |
 
 ### Legacy panic strings (migration aid)
 
@@ -244,6 +253,12 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 162 | `New SME address must differ from current beneficiary` |
 | 163 | `Funding deadline has passed` |
 | 164 | `Contract balance below funded amount` |
+| 180 | `Operational pause blocks funding` |
+| 181 | `Operational pause blocks settlement` |
+| 182 | `Operational pause blocks withdrawal` |
+| 183 | `Operational pause blocks investor claims` |
+| 203 | `get_contributions investors vector length exceeds MAX_INVESTOR_READ_BATCH` |
+| 204 | `maturity max horizon was not raised` |
 
 ## Client Guidance
 
@@ -267,6 +282,9 @@ Recommended SDK category mappings:
 | 140–143 | Cancellation or refund failure |
 | 150–152 | Legal-hold clear workflow failure |
 | 160–162 | Beneficiary rotation failure |
+| 180–183 | Operational pause failure |
+| 203 | Read API batch bound failure |
+| 204 | Maturity horizon governance failure |
 
 ## Security Notes
 

--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -525,6 +525,22 @@ Returns the cumulative principal contributed by `investor` in token base units.
 
 ---
 
+### `get_contributions(investors: Vec<Address>) → Vec<i128>`
+
+**Storage key:** `DataKey::InvestorContribution(investor)` (persistent, one read per input)
+**Signature:** `pub fn get_contributions(env: Env, investors: Vec<Address>) -> Vec<i128>`
+
+Returns one contribution amount per supplied address, preserving input order. Unknown addresses
+return `0`, matching `get_contribution`.
+
+**Requires initialization:** No
+**Default when absent:** `0` per address
+**Batch bound:** `investors.len() <= MAX_INVESTOR_READ_BATCH` (50)
+**Error:** `EscrowError::ContributionReadBatchTooLarge` when the input exceeds the bound
+**Security note:** Pure read-only; performs no authorization, storage writes, or TTL extension.
+
+---
+
 ### `get_unique_funder_count() → u32`
 
 **Storage key:** `DataKey::UniqueFunderCount`  

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -181,6 +181,9 @@ pub const MAX_INVOICE_AMOUNT: i128 = i128::MAX / 10_000;
 /// Mirrors the spirit of `MAX_ATTESTATION_APPEND_ENTRIES` to limit per-call work.
 pub const MAX_FUND_BATCH: u32 = 50;
 
+/// Upper bound on investor read batches/pages to keep view-call work bounded.
+pub const MAX_INVESTOR_READ_BATCH: u32 = 50;
+
 /// Upper bound on [`LiquifactEscrow::set_investors_allowlisted`] batch size.
 pub const MAX_INVESTOR_ALLOWLIST_BATCH: u32 = 32;
 
@@ -315,6 +318,8 @@ pub enum EscrowError {
     FundingBatchEmpty = 82,
     /// [`LiquifactEscrow::fund_batch`] exceeded [`MAX_FUND_BATCH`].
     FundingBatchTooLarge = 83,
+    /// [`LiquifactEscrow::get_contributions`] exceeded [`MAX_INVESTOR_READ_BATCH`].
+    ContributionReadBatchTooLarge = 203,
     /// [`LiquifactEscrow::update_funding_target`] received a non-positive target.
     TargetNotPositive = 72,
     /// [`LiquifactEscrow::update_funding_target`] called while escrow is not open.
@@ -438,6 +443,15 @@ pub enum EscrowError {
     /// `update_funding_deadline` was called on a non-open escrow (status != 0).
     FundingDeadlineUpdateNotOpen = 171,
 
+    /// [`LiquifactEscrow::fund`] / [`LiquifactEscrow::fund_with_commitment`] blocked by operational pause.
+    PausedBlocksFunding = 180,
+    /// [`LiquifactEscrow::settle`] blocked by operational pause.
+    PausedBlocksSettlement = 181,
+    /// [`LiquifactEscrow::withdraw`] blocked by operational pause.
+    PausedBlocksWithdrawal = 182,
+    /// [`LiquifactEscrow::claim_investor_payout`] blocked by operational pause.
+    PausedBlocksInvestorClaims = 183,
+
     /// [`LiquifactEscrow::lower_min_contribution_floor`] called while escrow is not open.
     FloorLowerNotOpen = 173,
     /// [`LiquifactEscrow::lower_min_contribution_floor`] did not strictly lower the floor.
@@ -451,11 +465,11 @@ pub enum EscrowError {
     LegalHoldBlocksPartialSettle = 201,
     /// [`LiquifactEscrow::partial_settle`] called while escrow is not in open status (`status != 0`).
     PartialSettleNotOpen = 202,
-    MaxPerInvestorCapNotConfigured = 24, // new
-    MaxPerInvestorCapNotRaised = 25,     // new
+    MaxPerInvestorCapNotConfigured = 24,
+    MaxPerInvestorCapNotRaised = 25,
     /// [`LiquifactEscrow::raise_maturity_max_horizon`] received a `new_horizon` that is
     /// not strictly greater than the current stored horizon.
-    HorizonNotRaised = 201,
+    HorizonNotRaised = 204,
 }
 
 #[inline(always)]
@@ -476,7 +490,12 @@ pub(crate) fn ensure(env: &Env, condition: bool, error: EscrowError) {
 /// specific named status check (e.g. [`require_funding_open`]) delegate here so the
 /// exact error code is preserved at every call site.
 #[inline(always)]
-pub(crate) fn guard_status_eq(env: &Env, actual_status: u32, expected_status: u32, error: EscrowError) {
+pub(crate) fn guard_status_eq(
+    env: &Env,
+    actual_status: u32,
+    expected_status: u32,
+    error: EscrowError,
+) {
     ensure(env, actual_status == expected_status, error);
 }
 
@@ -2172,13 +2191,37 @@ impl LiquifactEscrow {
         Self::get_persistent_investor_contribution(&env, investor)
     }
 
+    /// Public API: contributions recorded for `investors` in the same order as the input.
+    ///
+    /// This bounded read batches the same persistent-storage lookup used by
+    /// [`LiquifactEscrow::get_contribution`]. Unknown addresses return `0`.
+    ///
+    /// # Errors
+    /// Panics with [`EscrowError::ContributionReadBatchTooLarge`] when `investors.len()`
+    /// exceeds [`MAX_INVESTOR_READ_BATCH`].
+    pub fn get_contributions(env: Env, investors: Vec<Address>) -> Vec<i128> {
+        let len = investors.len();
+        ensure(
+            &env,
+            len <= MAX_INVESTOR_READ_BATCH,
+            EscrowError::ContributionReadBatchTooLarge,
+        );
+
+        let mut result = Vec::new(&env);
+        for i in 0..len {
+            let investor = investors.get(i).unwrap();
+            result.push_back(Self::get_persistent_investor_contribution(&env, investor));
+        }
+        result
+    }
+
     /// Returns a paginated list of investor addresses who have contributed to this escrow.
     ///
     /// Legacy instances that predate this feature will return an empty list (backward compatible under ADR-007).
     ///
     /// # Arguments
     /// * `start` - The starting index (0-based) of the pagination.
-    /// * `limit` - The maximum number of investor addresses to return (capped at a hard limit of 50).
+    /// * `limit` - The maximum number of investor addresses to return (capped at [`MAX_INVESTOR_READ_BATCH`]).
     ///
     /// # Returns
     /// A `Vec<Address>` containing the investor addresses within the requested page.
@@ -2194,7 +2237,7 @@ impl LiquifactEscrow {
             return Vec::new(&env);
         }
 
-        let actual_limit = limit.min(50);
+        let actual_limit = limit.min(MAX_INVESTOR_READ_BATCH);
         let end = (start + actual_limit).min(len);
 
         let mut result = Vec::new(&env);
@@ -2525,8 +2568,7 @@ impl LiquifactEscrow {
     pub fn get_settlement_readiness(env: Env) -> SettlementReadiness {
         let legal_hold_active = Self::legal_hold_active(&env);
         let escrow = Self::get_escrow(env.clone());
-        let maturity_reached =
-            escrow.maturity == 0 || env.ledger().timestamp() >= escrow.maturity;
+        let maturity_reached = escrow.maturity == 0 || env.ledger().timestamp() >= escrow.maturity;
 
         // Reuse the single-source-of-truth gate so this view cannot drift from `settle`.
         let is_settleable = Self::settleable_now(&env);
@@ -4763,28 +4805,13 @@ impl DefaultMockToken {
         let from_bal = balances
             .get(from.clone())
             .unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
-        let to_bal = balances.get(to.clone()).unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
+        let to_bal = balances
+            .get(to.clone())
+            .unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
         balances.set(from.clone(), from_bal - amount);
         balances.set(to.clone(), to_bal + amount);
         env.storage().instance().set(&key, &balances);
     }
-}
-
-#[inline(always)]
-pub fn guard_status_eq(env: &Env, actual: u32, expected: u32, err: EscrowError) {
-    ensure(env, actual == expected, err);
-}
-
-#[inline(always)]
-pub fn guard_status_in(env: &Env, actual: u32, expected: &[u32], err: EscrowError) {
-    let mut found = false;
-    for e in expected.iter() {
-        if actual == *e {
-            found = true;
-            break;
-        }
-    }
-    ensure(env, found, err);
 }
 
 #[cfg(any(test, feature = "testutils"))]

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -3647,35 +3647,29 @@ impl LiquifactEscrow {
 
         // Capture the effective yield and tier lock threshold in locals so event fields can
         // be populated without post-write storage reads.
-        let investor_effective_yield_bps: i64;
-        let tier_lock_secs: u64;
-
-        if simple_fund {
+        let (investor_effective_yield_bps, tier_lock_secs) = if simple_fund {
             // Non-tiered deposits never carry a commitment lock.
-            tier_lock_secs = 0;
             if prev == 0 {
-                investor_effective_yield_bps = escrow.yield_bps;
                 Self::set_persistent_investor_effective_yield(
                     &env,
                     investor.clone(),
                     escrow.yield_bps,
                 );
                 Self::set_persistent_investor_claim_not_before(&env, investor.clone(), 0u64);
-                tier_lock_secs = 0;
+                (escrow.yield_bps, 0u64)
             } else {
                 // Returning investor: yield was set on first deposit; read it for the event.
-                investor_effective_yield_bps =
+                (
                     Self::get_persistent_investor_effective_yield(&env, investor.clone())
-                        .unwrap_or(escrow.yield_bps);
-                tier_lock_secs = 0;
+                        .unwrap_or(escrow.yield_bps),
+                    0u64,
+                )
             }
             // If prev > 0, preserve existing effective yield and claim lock
         } else {
             ensure(&env, prev == 0, EscrowError::TieredSecondDeposit);
             let (eff, lock) =
                 Self::effective_yield_for_commitment(&env, escrow.yield_bps, committed_lock_secs);
-            investor_effective_yield_bps = eff;
-            tier_lock_secs = lock;
             Self::set_persistent_investor_effective_yield(&env, investor.clone(), eff);
             let now = env.ledger().timestamp();
             let claim_nb = if committed_lock_secs == 0 {
@@ -3694,7 +3688,8 @@ impl LiquifactEscrow {
                 );
             }
             Self::set_persistent_investor_claim_not_before(&env, investor.clone(), claim_nb);
-        }
+            (eff, lock)
+        };
 
         escrow.funded_amount = escrow
             .funded_amount

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -14,7 +14,7 @@ use super::{
     LiquifactEscrow, LiquifactEscrowClient, MaturityMaxHorizonUpdated,
     MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept,
     YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH,
-    SCHEMA_VERSION,
+    MAX_INVESTOR_READ_BATCH, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -2082,7 +2082,10 @@ fn test_registry_ref_does_not_affect_settlement_or_funding() {
         registry: None,
     }
     .to_xdr(&env, &contract_id);
-    assert_eq!(last, expected_clear, "last event must be reg_rebind with None");
+    assert_eq!(
+        last, expected_clear,
+        "last event must be reg_rebind with None"
+    );
 }
 
 fn test_error_code_uniqueness() {

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -4132,6 +4132,79 @@ fn test_get_investors_legacy_compatibility() {
     assert_eq!(investors.len(), 0);
 }
 
+#[test]
+fn test_get_contributions_preserves_input_order_and_zero_for_unknowns() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    client.fund(&inv_a, &10_000i128);
+    client.fund(&inv_b, &20_000i128);
+
+    let mut addresses = SorobanVec::new(&env);
+    addresses.push_back(inv_b.clone());
+    addresses.push_back(stranger.clone());
+    addresses.push_back(inv_a.clone());
+    addresses.push_back(inv_a.clone());
+
+    let amounts = client.get_contributions(&addresses);
+    assert_eq!(amounts.len(), 4);
+    assert_eq!(amounts.get(0).unwrap(), client.get_contribution(&inv_b));
+    assert_eq!(amounts.get(1).unwrap(), 0);
+    assert_eq!(amounts.get(2).unwrap(), client.get_contribution(&inv_a));
+    assert_eq!(amounts.get(3).unwrap(), client.get_contribution(&inv_a));
+}
+
+#[test]
+fn test_get_contributions_empty_input_returns_empty_vec() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let addresses = SorobanVec::new(&env);
+    let amounts = client.get_contributions(&addresses);
+    assert_eq!(amounts.len(), 0);
+}
+
+#[test]
+fn test_get_contributions_accepts_exact_batch_cap() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let mut addresses = SorobanVec::new(&env);
+    for _ in 0..MAX_INVESTOR_READ_BATCH {
+        addresses.push_back(Address::generate(&env));
+    }
+
+    let amounts = client.get_contributions(&addresses);
+    assert_eq!(amounts.len(), MAX_INVESTOR_READ_BATCH);
+    for i in 0..MAX_INVESTOR_READ_BATCH {
+        assert_eq!(amounts.get(i).unwrap(), 0);
+    }
+}
+
+#[test]
+fn test_get_contributions_rejects_oversized_batch_with_typed_error() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let mut addresses = SorobanVec::new(&env);
+    for _ in 0..=MAX_INVESTOR_READ_BATCH {
+        addresses.push_back(Address::generate(&env));
+    }
+
+    assert_contract_error(
+        client.try_get_contributions(&addresses),
+        EscrowError::ContributionReadBatchTooLarge,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // update_funding_target: rejection bounds and mid-update funded promotion
 // ---------------------------------------------------------------------------
@@ -4617,11 +4690,7 @@ fn test_get_yield_tiers_is_pure_read_no_state_change() {
 
 /// Helper: initialise an escrow with three tiers (30s / 60s / 90s) and a base
 /// yield of 500 bps.  Returns the client ready for use; all auth is mocked.
-fn setup_three_tier_escrow(
-    env: &Env,
-    invoice_id: &str,
-    target: i128,
-) -> LiquifactEscrowClient {
+fn setup_three_tier_escrow(env: &Env, invoice_id: &str, target: i128) -> LiquifactEscrowClient {
     let admin = Address::generate(env);
     let sme = Address::generate(env);
     let (tok, tre) = free_addresses(env);

--- a/escrow/src/tests/integration_status_guards.rs
+++ b/escrow/src/tests/integration_status_guards.rs
@@ -16,7 +16,15 @@ fn make_env() -> Env {
     env
 }
 
-fn setup_open(env: &Env) -> (LiquifactEscrowClient<'_>, Address, Address, Address, Address) {
+fn setup_open(
+    env: &Env,
+) -> (
+    LiquifactEscrowClient<'_>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     let client = LiquifactEscrowClient::new(env, &env.register(LiquifactEscrow, ()));
     let admin = Address::generate(env);
     let sme = Address::generate(env);

--- a/escrow/src/tests/properties.rs
+++ b/escrow/src/tests/properties.rs
@@ -2088,10 +2088,7 @@ fn snapshot_denominator_consistent_across_all_payout_reads() {
 ///
 /// When a cap is present: `count + remaining == cap` and `remaining >= 0`.
 /// When no cap: `get_remaining_investor_slots` returns `None`.
-fn assert_slots_invariant(
-    client: &super::LiquifactEscrowClient<'_>,
-    label: &str,
-) {
+fn assert_slots_invariant(client: &super::LiquifactEscrowClient<'_>, label: &str) {
     match client.get_remaining_investor_slots() {
         None => {
             // No cap — correct; nothing more to assert.
@@ -2139,7 +2136,7 @@ fn slots_no_cap_is_none_after_multiple_funds() {
         &Address::generate(&env),
         &None,
         &None,
-        &None,  // no max_unique_investors
+        &None, // no max_unique_investors
         &None,
         &None,
         &None,
@@ -2394,7 +2391,10 @@ fn slots_lower_cap_mid_sequence_invariant() {
 
     assert_eq!(cap_after_lower, 3);
     assert_eq!(count_after_lower, 3);
-    assert_eq!(remaining_after_lower, 0, "remaining must be 0 when cap == count");
+    assert_eq!(
+        remaining_after_lower, 0,
+        "remaining must be 0 when cap == count"
+    );
 
     // Further lower to mid-range (cap = 5, count stays 3).
     // First reset cap to 6, then lower to 5.
@@ -2723,15 +2723,16 @@ fn slots_cap_exactly_hit_remaining_is_zero() {
         &None,
     );
 
-    let investors: Vec<Address> = (0..cap as usize)
-        .map(|_| Address::generate(&env))
-        .collect();
+    let investors: Vec<Address> = (0..cap as usize).map(|_| Address::generate(&env)).collect();
 
     for (i, inv) in investors.iter().enumerate() {
         client.fund(inv, &100_000i128);
         let remaining = client.get_remaining_investor_slots().unwrap();
         let count = client.get_unique_funder_count();
-        assert!(remaining >= 0, "remaining must not underflow after investor {i}");
+        assert!(
+            remaining >= 0,
+            "remaining must not underflow after investor {i}"
+        );
         assert_eq!(
             count + remaining,
             cap,
@@ -2741,6 +2742,9 @@ fn slots_cap_exactly_hit_remaining_is_zero() {
 
     // After all cap slots consumed: remaining must be 0.
     let final_remaining = client.get_remaining_investor_slots().unwrap();
-    assert_eq!(final_remaining, 0, "remaining must be exactly 0 when cap is fully consumed");
+    assert_eq!(
+        final_remaining, 0,
+        "remaining must be exactly 0 when cap is fully consumed"
+    );
     assert_slots_invariant(&client, "cap exactly hit");
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -2097,14 +2097,20 @@ fn test_settlement_readiness_funded_but_held_blocks_ready() {
     let r = client.get_settlement_readiness();
     assert!(r.legal_hold_active);
     assert!(r.maturity_reached);
-    assert!(!r.is_settleable, "a legal hold makes the escrow not settleable");
+    assert!(
+        !r.is_settleable,
+        "a legal hold makes the escrow not settleable"
+    );
     assert!(!r.ready_now, "ready_now must be false under an active hold");
 
     // Parity: ready_now == false ⇒ settle fails.
     let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.settle();
     }));
-    assert!(res.is_err(), "settle must fail while a legal hold is active");
+    assert!(
+        res.is_err(),
+        "settle must fail while a legal hold is active"
+    );
 }
 
 /// Funded with a future maturity: pre-maturity `maturity_reached` is false and


### PR DESCRIPTION
Closes #553.

## Summary
- Added `MAX_INVESTOR_READ_BATCH` and a pure read-only `get_contributions(Vec<Address>) -> Vec<i128>` view.
- The new view preserves input order, mirrors `get_contribution` storage reads, returns `0` for unknown addresses, and rejects oversized batches with `EscrowError::ContributionReadBatchTooLarge`.
- Added funding tests for order preservation, unknown/duplicate addresses, empty input, exact cap, and over-cap typed error handling.
- Documented the new read API and error code.

## CI unblock notes
- Ran `cargo fmt -p liquifact_escrow` because CI checks the whole escrow package and main currently contains rustfmt diffs.
- Removed duplicate trailing `guard_status_eq` / `guard_status_in` helper definitions and added missing operational-pause typed errors so whole-package clippy can compile this branch.
- Moved `HorizonNotRaised` to a non-conflicting code (`204`) to avoid the existing duplicate discriminant with `LegalHoldBlocksPartialSettle`.
- Derived tier event fields from a single expression instead of reassignment so clippy does not fail on immutable/unused assignment diagnostics.

## Security notes
- No authorization is required because the entrypoint only reads existing contribution records.
- The function does not write storage, emit events, or bump TTL.
- The input vector is bounded at 50 entries to cap per-call persistent reads.
- Unknown addresses are handled with the same `0` default as `get_contribution`, so the view cannot panic on absent contribution storage.

## Validation
- `cargo fmt -p liquifact_escrow -- --check`
- `git diff --check`
- Attempted `cargo test -p liquifact_escrow get_contributions -- --nocapture`, but this local machine has Cargo 1.84.0 and fails before compiling because `base64ct v1.8.3` requires edition2024 / Cargo 1.85+.
