### PR TITLE
feat: emit detailed collateral clear event

### DIFF
--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -33,7 +33,7 @@ short routing symbol passed with `symbol_short!(...)`, such as `funded` or
 
 ## Event Catalog
 
-The current contract defines 36 event structs.
+The current contract defines 37 event structs.
 
 | Rust event | `name` symbol | Entrypoint(s) |
 |---|---:|---|
@@ -47,6 +47,7 @@ The current contract defines 36 event structs.
 | `AttestationDigestUnrevoked` | `att_unrev` | `unrevoke_attestation_digest` |
 | `BeneficiaryRotated` | `ben_rot` | `rotate_beneficiary` |
 | `CollateralClearedEvt` | — | `clear_sme_collateral_commitment` |
+| `CollateralCommitmentCleared` | `coll_clr` | `clear_sme_collateral_commitment` |
 | `CollateralRecordedEvt` | `coll_rec` | `record_sme_collateral_commitment` |
 | `ContractUpgraded` | `upgrade` | `upgrade` |
 | `DeprecatedTransferAdminUsed` | `depr_xfer` | `transfer_admin` |
@@ -322,6 +323,32 @@ Data:
 Note: this event records SME-reported collateral metadata only. It is not proof
 of custody, token movement, lien, or enforceable on-chain collateral.
 
+### `CollateralCommitmentCleared`
+
+Emitted after successful `clear_sme_collateral_commitment`, alongside the
+legacy `CollateralClearedEvt`. It carries the cleared commitment identity so
+off-chain indexers can reconstruct the record-to-clear lifecycle from events
+alone after the storage entry has been removed.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `collateral_commitment_cleared` |
+| 1 | `name` | `Symbol` | `coll_clr` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `asset` | `Symbol` |
+| `amount` | `i128` |
+| `recorded_at` | `u64` |
+
+Note: this event records SME-reported collateral metadata only. It is not proof
+of custody, token movement, lien, or enforceable on-chain collateral.
+
 ### `SmeWithdrew`
 
 Emitted after successful `withdraw`.
@@ -590,3 +617,4 @@ Status values:
 | 2026-06-24 | v0.4 | Added `settled_at_ledger_timestamp` field to `EscrowSettled` event; added `is_settleable` view |
 | 2026-06-26 | v0.5 | Issue #379: Added `InvestorAllowlistBatchApplied` (`al_batch`) event emitted once per `set_investors_allowlisted` call for indexer disambiguation |
 | 2026-06-29 | v0.6 | Added `DeprecatedTransferAdminUsed` (`depr_xfer`) for deprecated one-step admin transfer shim; renamed `EscrowInitialized.name` from `escrow` to `escrow_ii` to fix upstream collision; fixed duplicate `BeneficiaryRotated` struct; added missing event struct sections (`AdminAcceptedEvent`, `AdminProposalCancelled`, `CollateralClearedEvt`, `ContractUpgraded`, `EscrowPartialSettle`, `LegalHoldClearCancelled`, `LegalHoldClearRequested`, `MaturityMaxHorizonUpdated`, `MaxPerInvestorCapRaised`, `MaxUniqueInvestorsCapRaised`, `MinContributionFloorLowered`, `RegistryRefRebound`) |
+| 2026-07-04 | v0.7 | Added `CollateralCommitmentCleared` (`coll_clr`) with the cleared SME collateral asset, amount, and original record timestamp |

--- a/docs/escrow-indexer.md
+++ b/docs/escrow-indexer.md
@@ -36,6 +36,7 @@ Contract event names (`symbol_short`) emitted by `escrow/src/lib.rs`:
 - `maturity` - maturity updated
 - `fund_tgt` - funding target updated
 - `coll_rec` - SME collateral commitment recorded
+- `coll_clr` - SME collateral commitment cleared, including the cleared asset, amount, and original record timestamp
 - `att_bind` - primary attestation hash bound
 - `att_app` - attestation append-log updated
 - `al_ena` - allowlist mode enabled/disabled

--- a/docs/escrow-sme-collateral.md
+++ b/docs/escrow-sme-collateral.md
@@ -86,6 +86,14 @@ pub struct CollateralClearedEvt {
     pub invoice_id: Symbol,
     pub amount: i128,   // carried from the pledge at the time of removal
 }
+
+pub struct CollateralCommitmentCleared {
+    pub name: Symbol,   // coll_clr
+    pub invoice_id: Symbol,
+    pub asset: Symbol,
+    pub amount: i128,
+    pub recorded_at: u64,
+}
 ```
 
 ---
@@ -125,4 +133,5 @@ SME calls record_sme_collateral_commitment(5_000_0000000)
 SME calls clear_sme_collateral_commitment()
   → DataKey::SmeCollateralPledge removed
   → CollateralClearedEvt { invoice_id: "INV001", amount: 5_000_0000000 } emitted
+  → CollateralCommitmentCleared { name: coll_clr, invoice_id: "INV001", asset: "USDC", amount: 5_000_0000000, recorded_at } emitted
 ```

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1086,6 +1086,23 @@ pub struct CollateralClearedEvt {
     pub amount: i128,
 }
 
+/// Emitted after [`LiquifactEscrow::clear_sme_collateral_commitment`] removes
+/// the SME-reported collateral metadata.
+///
+/// This supplements [`CollateralClearedEvt`] with a short event name and the
+/// full cleared commitment identity so indexers can reconstruct the
+/// record-to-clear lifecycle without a storage read after removal.
+#[contractevent]
+pub struct CollateralCommitmentCleared {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub asset: Symbol,
+    pub amount: i128,
+    pub recorded_at: u64,
+}
+
 #[contractevent]
 pub struct SmeWithdrew {
     #[topic]
@@ -2308,6 +2325,15 @@ impl LiquifactEscrow {
         CollateralClearedEvt {
             invoice_id: escrow.invoice_id.clone(),
             amount: commitment.amount,
+        }
+        .publish(&env);
+
+        CollateralCommitmentCleared {
+            name: symbol_short!("coll_clr"),
+            invoice_id: escrow.invoice_id.clone(),
+            asset: commitment.asset.clone(),
+            amount: commitment.amount,
+            recorded_at: commitment.recorded_at,
         }
         .publish(&env);
     }

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -1,6 +1,7 @@
 ﻿use crate::{
-    AttestationDigestAppended, CollateralClearedEvt, CollateralCommitmentSnapshot,
-    CollateralRecordedEvt, DataKey, EscrowCloseSnapshot, EscrowError, FundingCancelled,
+    AttestationDigestAppended, CollateralClearedEvt, CollateralCommitmentCleared,
+    CollateralCommitmentSnapshot, CollateralRecordedEvt, DataKey, EscrowCloseSnapshot,
+    EscrowError, FundingCancelled,
     InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient, PrimaryAttestationBound,
     RegistryRefRebound, TreasuryDustSwept, YieldTier, DEFAULT_MATURITY_MAX_HORIZON_SECS,
     MAX_ATTESTATION_APPEND_ENTRIES, SCHEMA_VERSION,
@@ -4495,14 +4496,35 @@ fn test_event_collateral_cleared_struct() {
     );
 
     let asset = Symbol::new(&env, "USDC");
-    client.record_sme_collateral_commitment(&asset, &5000);
+    let commitment = client.record_sme_collateral_commitment(&asset, &5000);
     client.clear_sme_collateral_commitment();
 
-    // CollateralClearedEvt has no name topic ÔÇö only invoice_id as #[topic].
-    // Verify the event exists by checking topic[0].
+    let invoice_id = client.get_escrow().invoice_id;
+    let legacy = CollateralClearedEvt {
+        invoice_id: invoice_id.clone(),
+        amount: 5000,
+    };
+    let detailed = CollateralCommitmentCleared {
+        name: symbol_short!("coll_clr"),
+        invoice_id,
+        asset,
+        amount: 5000,
+        recorded_at: commitment.recorded_at,
+    };
+
     let events = env.events().all();
     let all_events = events.events();
-    assert!(!all_events.is_empty(), "must emit at least one event");
+    assert!(
+        all_events
+            .iter()
+            .any(|event| *event == legacy.to_xdr(&env, &contract_id)),
+        "legacy CollateralClearedEvt must still be emitted"
+    );
+    assert_eq!(
+        all_events.last().unwrap().clone(),
+        detailed.to_xdr(&env, &contract_id),
+        "CollateralCommitmentCleared must emit symbol 'coll_clr' with the cleared commitment identity"
+    );
 }
 
 // ÔöÇÔöÇ SmeWithdrew ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
@@ -5332,20 +5354,20 @@ fn test_all_event_symbols_are_unique_across_struct_types() {
         "escrow_ii", "inv_cap", "raise_cap", "floor_lo", "funded", "ben_rot",
         "part_set", "escrow_sd", "maturity", "admin", "adm_acc", "adm_prop",
         "adm_can", "depr_xfer", "fund_tgt", "legalhld", "lh_req", "coll_rec",
-        "sme_wd", "inv_claim", "fund_can", "refunded", "reg_rebind", "dust_sw",
-        "att_bind", "att_app", "att_rev", "att_unrev", "mtry_max", "al_ena",
-        "al_set", "lh_cancel", "upgrade",
+        "coll_clr", "sme_wd", "inv_claim", "fund_can", "refunded", "reg_rebind",
+        "dust_sw", "att_bind", "att_app", "att_rev", "att_unrev", "mtry_max",
+        "al_ena", "al_set", "lh_cancel", "upgrade",
     ]
     .iter()
     .cloned()
     .collect();
 
-    // 33 unique symbols across 36 defined event structs.
+    // 34 unique symbols across 37 defined event structs.
     // CollateralClearedEvt has no name field, LegalHoldClearDelayUpdated has no hardcoded symbol,
     // and inv_cap is shared by MaxUniqueInvestorsCapLowered and MaxPerInvestorCapRaised.
     assert_eq!(
         symbols.len(),
-        33,
+        34,
         "each event struct must have a unique name symbol"
     );
 }
@@ -5369,6 +5391,10 @@ fn test_event_topic0_follows_snake_case_convention() {
         ("AttestationDigestUnrevoked", "attestation_digest_unrevoked"),
         ("BeneficiaryRotated", "beneficiary_rotated"),
         ("CollateralClearedEvt", "collateral_cleared_evt"),
+        (
+            "CollateralCommitmentCleared",
+            "collateral_commitment_cleared",
+        ),
         ("CollateralRecordedEvt", "collateral_recorded_evt"),
         ("ContractUpgraded", "contract_upgraded"),
         ("DeprecatedTransferAdminUsed", "deprecated_transfer_admin_used"),


### PR DESCRIPTION
## Summary

Closes #554.

This PR adds an additive collateral-clear audit event for `clear_sme_collateral_commitment`.

The existing `CollateralClearedEvt` is still emitted unchanged for backward compatibility. A new `CollateralCommitmentCleared` event is emitted after it with:

- `name = coll_clr`
- `invoice_id`
- cleared `asset`
- cleared `amount`
- original `recorded_at`

That gives indexers enough information to reconstruct the collateral record-to-clear lifecycle after the storage entry has been removed.

## Changes

- Add `CollateralCommitmentCleared` contract event.
- Emit it from `clear_sme_collateral_commitment` after removing the stored commitment.
- Extend coverage tests to assert:
  - legacy `CollateralClearedEvt` still emits,
  - the detailed `coll_clr` event is emitted with the cleared commitment identity,
  - event symbol/topic mapping coverage includes the new event.
- Update event/indexer/collateral docs.

## Security notes

- Additive event only; no auth, state transition, or storage semantics are changed.
- SME auth and `NoCollateralToClear` behavior stay unchanged.
- The event records SME-reported collateral metadata only. It is not proof of custody, token movement, lien, or enforceable on-chain collateral.

## Verification

- `git diff --check` passes locally.
- `cargo fmt --all -- --check` and `cargo test` could not be run in this local environment because `cargo` is not installed on this machine. Please rely on CI for Rust formatting/build/test verification.
