### PR TITLE
Emit collateral clear event metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ fee-on-transfer, rebasing, hook, and lying token behaviors at the host-call boun
 
 ## SME collateral metadata
 
-See [`docs/escrow-sme-collateral.md`](docs/escrow-sme-collateral.md) for the risk-team handling rules for `record_sme_collateral_commitment` and `CollateralRecordedEvt`. The record is SME-reported metadata only; it is not proof of custody, token movement, or an enforceable on-chain claim.
+See [`docs/escrow-sme-collateral.md`](docs/escrow-sme-collateral.md) for the risk-team handling rules for `record_sme_collateral_commitment`, `clear_sme_collateral_commitment`, `CollateralRecordedEvt`, and `CollateralClearedEvt`. The record is SME-reported metadata only; it is not proof of custody, token movement, or an enforceable on-chain claim.
 
 ## Investor allowlist
 

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -46,7 +46,7 @@ The current contract defines 36 event structs.
 | `AttestationDigestRevoked` | `att_rev` | `revoke_attestation_digest` |
 | `AttestationDigestUnrevoked` | `att_unrev` | `unrevoke_attestation_digest` |
 | `BeneficiaryRotated` | `ben_rot` | `rotate_beneficiary` |
-| `CollateralClearedEvt` | — | `clear_sme_collateral_commitment` |
+| `CollateralClearedEvt` | `coll_clr` | `clear_sme_collateral_commitment` |
 | `CollateralRecordedEvt` | `coll_rec` | `record_sme_collateral_commitment` |
 | `ContractUpgraded` | `upgrade` | `upgrade` |
 | `DeprecatedTransferAdminUsed` | `depr_xfer` | `transfer_admin` |
@@ -322,6 +322,30 @@ Data:
 Note: this event records SME-reported collateral metadata only. It is not proof
 of custody, token movement, lien, or enforceable on-chain collateral.
 
+### `CollateralClearedEvt`
+
+Emitted after successful `clear_sme_collateral_commitment`.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `collateral_cleared_evt` |
+| 1 | `name` | `Symbol` | `coll_clr` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `asset` | `Symbol` |
+| `amount` | `i128` |
+| `recorded_at` | `u64` |
+
+Note: this event clears SME-reported collateral metadata only. `asset`, `amount`,
+and `recorded_at` are copied from the stored commitment before removal so
+indexers can reconstruct the record -> clear lifecycle from events.
+
 ### `SmeWithdrew`
 
 Emitted after successful `withdraw`.
@@ -590,3 +614,4 @@ Status values:
 | 2026-06-24 | v0.4 | Added `settled_at_ledger_timestamp` field to `EscrowSettled` event; added `is_settleable` view |
 | 2026-06-26 | v0.5 | Issue #379: Added `InvestorAllowlistBatchApplied` (`al_batch`) event emitted once per `set_investors_allowlisted` call for indexer disambiguation |
 | 2026-06-29 | v0.6 | Added `DeprecatedTransferAdminUsed` (`depr_xfer`) for deprecated one-step admin transfer shim; renamed `EscrowInitialized.name` from `escrow` to `escrow_ii` to fix upstream collision; fixed duplicate `BeneficiaryRotated` struct; added missing event struct sections (`AdminAcceptedEvent`, `AdminProposalCancelled`, `CollateralClearedEvt`, `ContractUpgraded`, `EscrowPartialSettle`, `LegalHoldClearCancelled`, `LegalHoldClearRequested`, `MaturityMaxHorizonUpdated`, `MaxPerInvestorCapRaised`, `MaxUniqueInvestorsCapRaised`, `MinContributionFloorLowered`, `RegistryRefRebound`) |
+| 2026-07-09 | v0.7 | Added the `coll_clr` name topic and stored collateral metadata payload to `CollateralClearedEvt` for indexer reconstruction of clear events |

--- a/docs/audit-handoff-escrow.md
+++ b/docs/audit-handoff-escrow.md
@@ -106,6 +106,7 @@ Read-only getters are never blocked. Only `admin` can set or clear the hold. The
 | `accept_admin` | `AdminTransferredEvent` | `admin` | Update key registry and access control records; confirm pending proposal cleared |
 | `update_funding_target` | `FundingTargetUpdated` | `fund_tgt` | Update off-chain target display; re-evaluate investor communications |
 | `record_sme_collateral_commitment` | `CollateralRecordedEvt` | `coll_rec` | Store in compliance/risk system; **do not treat as enforced on-chain lock** |
+| `clear_sme_collateral_commitment` | `CollateralClearedEvt` | `coll_clr` | Retire the current metadata-only collateral commitment for the invoice |
 | `sweep_terminal_dust` | `TreasuryDustSwept` | `dust_sw` | Reconcile treasury balance; log sweep amount and token address |
 | `bind_primary_attestation_hash` | `PrimaryAttestationBound` | `att_bind` | Verify digest against known IPFS CID or document bundle; record binding in compliance system |
 | `append_attestation_digest` | `AttestationDigestAppended` | `att_app` | Append to off-chain audit log with `index` for ordering |

--- a/docs/escrow-events.md
+++ b/docs/escrow-events.md
@@ -244,6 +244,24 @@ breaker (no compliance semantics, no clear delay), not the compliance hold.
 **Data Payload:**
 - `active` (u32): `1` for enabled, `0` for cleared.
 
+### `CollateralClearedEvt`
+Emitted when the SME clears the metadata-only collateral commitment recorded under
+`DataKey::SmeCollateralPledge`.
+
+**Topics:**
+1. `coll_clr` (Symbol)
+2. `invoice_id` (Symbol)
+
+**Data Payload:**
+- `asset` (Symbol): SME-reported off-chain asset label from the stored commitment.
+- `amount` (i128): SME-reported amount from the stored commitment.
+- `recorded_at` (u64): ledger timestamp from the original commitment record.
+
+**Indexer guidance:**
+Use `coll_clr` to remove or mark retired the active collateral commitment for the
+invoice. This event is metadata-only and does not prove custody, asset movement,
+or enforceable collateral.
+
 ---
 
 ## 🛠️ Indexing Recommendations

--- a/docs/escrow-indexer.md
+++ b/docs/escrow-indexer.md
@@ -36,6 +36,7 @@ Contract event names (`symbol_short`) emitted by `escrow/src/lib.rs`:
 - `maturity` - maturity updated
 - `fund_tgt` - funding target updated
 - `coll_rec` - SME collateral commitment recorded
+- `coll_clr` - SME collateral commitment cleared
 - `att_bind` - primary attestation hash bound
 - `att_app` - attestation append-log updated
 - `al_ena` - allowlist mode enabled/disabled
@@ -148,4 +149,3 @@ Do not treat `RegistryRef` as a trust anchor in risk engines without independent
 - Indexers should surface these failures as integration alerts, not silently smooth them over.
 - Treat attestation and collateral entries as metadata records unless/until on-chain enforcement is
   explicitly introduced by contract APIs.
-

--- a/docs/escrow-sme-collateral.md
+++ b/docs/escrow-sme-collateral.md
@@ -31,6 +31,12 @@ Returns the current pledge record, or `None` if none has been recorded (or it wa
 
 Retires a previously recorded pledge, removing it from storage.
 
+- **Auth**: SME address (`sme_address` from the escrow record).
+- **Storage**: removes `DataKey::SmeCollateralPledge` (instance storage).
+- **Event**: emits `CollateralClearedEvt { name, invoice_id, asset, amount, recorded_at }`
+  under topic `(coll_clr, invoice_id)`.
+- **Token movement**: none.
+
 ## Test Coverage
 
 The scenarios below are covered by the focused collateral suite in
@@ -83,8 +89,11 @@ pub struct CollateralRecordedEvt {
 }
 
 pub struct CollateralClearedEvt {
+    pub name: Symbol,     // hardcoded coll_clr topic
     pub invoice_id: Symbol,
+    pub asset: Symbol,    // carried from the pledge at the time of removal
     pub amount: i128,   // carried from the pledge at the time of removal
+    pub recorded_at: u64, // original pledge ledger timestamp
 }
 ```
 
@@ -124,5 +133,5 @@ SME calls record_sme_collateral_commitment(5_000_0000000)
 
 SME calls clear_sme_collateral_commitment()
   → DataKey::SmeCollateralPledge removed
-  → CollateralClearedEvt { invoice_id: "INV001", amount: 5_000_0000000 } emitted
+  → CollateralClearedEvt { name: "coll_clr", invoice_id: "INV001", asset: "USDC", amount: 5_000_0000000, recorded_at } emitted
 ```

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -476,7 +476,12 @@ pub(crate) fn ensure(env: &Env, condition: bool, error: EscrowError) {
 /// specific named status check (e.g. [`require_funding_open`]) delegate here so the
 /// exact error code is preserved at every call site.
 #[inline(always)]
-pub(crate) fn guard_status_eq(env: &Env, actual_status: u32, expected_status: u32, error: EscrowError) {
+pub(crate) fn guard_status_eq(
+    env: &Env,
+    actual_status: u32,
+    expected_status: u32,
+    error: EscrowError,
+) {
     ensure(env, actual_status == expected_status, error);
 }
 
@@ -2548,8 +2553,7 @@ impl LiquifactEscrow {
     pub fn get_settlement_readiness(env: Env) -> SettlementReadiness {
         let legal_hold_active = Self::legal_hold_active(&env);
         let escrow = Self::get_escrow(env.clone());
-        let maturity_reached =
-            escrow.maturity == 0 || env.ledger().timestamp() >= escrow.maturity;
+        let maturity_reached = escrow.maturity == 0 || env.ledger().timestamp() >= escrow.maturity;
 
         // Reuse the single-source-of-truth gate so this view cannot drift from `settle`.
         let is_settleable = Self::settleable_now(&env);
@@ -4786,7 +4790,9 @@ impl DefaultMockToken {
         let from_bal = balances
             .get(from.clone())
             .unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
-        let to_bal = balances.get(to.clone()).unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
+        let to_bal = balances
+            .get(to.clone())
+            .unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
         balances.set(from.clone(), from_bal - amount);
         balances.set(to.clone(), to_bal + amount);
         env.storage().instance().set(&key, &balances);

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1079,11 +1079,31 @@ pub struct CollateralRecordedEvt {
     pub prior_amount: i128,
 }
 
+/// Emitted when the SME clears the stored metadata-only collateral commitment.
+///
+/// This event is the removal-side counterpart to [`CollateralRecordedEvt`]. It
+/// copies the stored commitment fields before deletion so off-chain indexers can
+/// reconstruct which SME-reported asset record was retired without polling
+/// storage after the mutation.
+///
+/// # Fields
+/// - `name`: Hardcoded `coll_clr` symbol.
+/// - `invoice_id`: Symbol representation of the invoice.
+/// - `asset`: Cleared SME-reported off-chain asset symbol.
+/// - `amount`: Cleared SME-reported amount.
+/// - `recorded_at`: Ledger timestamp from the original commitment record.
 #[contractevent]
 pub struct CollateralClearedEvt {
     #[topic]
+    pub name: Symbol,
+    #[topic]
     pub invoice_id: Symbol,
+    /// SME-reported off-chain asset symbol that was cleared from storage.
+    pub asset: Symbol,
+    /// SME-reported amount that was cleared from storage.
     pub amount: i128,
+    /// Ledger timestamp from the original recorded commitment.
+    pub recorded_at: u64,
 }
 
 #[contractevent]
@@ -2306,8 +2326,11 @@ impl LiquifactEscrow {
             .remove(&DataKey::SmeCollateralPledge);
 
         CollateralClearedEvt {
+            name: symbol_short!("coll_clr"),
             invoice_id: escrow.invoice_id.clone(),
+            asset: commitment.asset.clone(),
             amount: commitment.amount,
+            recorded_at: commitment.recorded_at,
         }
         .publish(&env);
     }

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -2082,7 +2082,10 @@ fn test_registry_ref_does_not_affect_settlement_or_funding() {
         registry: None,
     }
     .to_xdr(&env, &contract_id);
-    assert_eq!(last, expected_clear, "last event must be reg_rebind with None");
+    assert_eq!(
+        last, expected_clear,
+        "last event must be reg_rebind with None"
+    );
 }
 
 fn test_error_code_uniqueness() {

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -4495,14 +4495,29 @@ fn test_event_collateral_cleared_struct() {
     );
 
     let asset = Symbol::new(&env, "USDC");
-    client.record_sme_collateral_commitment(&asset, &5000);
+    let commitment = client.record_sme_collateral_commitment(&asset, &5000);
     client.clear_sme_collateral_commitment();
 
-    // CollateralClearedEvt has no name topic ÔÇö only invoice_id as #[topic].
-    // Verify the event exists by checking topic[0].
+    let expected = CollateralClearedEvt {
+        name: symbol_short!("coll_clr"),
+        invoice_id: client.get_escrow().invoice_id,
+        asset,
+        amount: 5000,
+        recorded_at: commitment.recorded_at,
+    };
+    assert_eq!(
+        last_event_name_symbol(&env),
+        Some(symbol_short!("coll_clr")),
+        "CollateralClearedEvt must emit symbol 'coll_clr'"
+    );
     let events = env.events().all();
     let all_events = events.events();
-    assert!(!all_events.is_empty(), "must emit at least one event");
+    let last = all_events.last().unwrap().clone();
+    assert_eq!(
+        last,
+        expected.to_xdr(&env, &contract_id),
+        "CollateralClearedEvt struct must match"
+    );
 }
 
 // ÔöÇÔöÇ SmeWithdrew ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
@@ -5332,20 +5347,20 @@ fn test_all_event_symbols_are_unique_across_struct_types() {
         "escrow_ii", "inv_cap", "raise_cap", "floor_lo", "funded", "ben_rot",
         "part_set", "escrow_sd", "maturity", "admin", "adm_acc", "adm_prop",
         "adm_can", "depr_xfer", "fund_tgt", "legalhld", "lh_req", "coll_rec",
-        "sme_wd", "inv_claim", "fund_can", "refunded", "reg_rebind", "dust_sw",
-        "att_bind", "att_app", "att_rev", "att_unrev", "mtry_max", "al_ena",
-        "al_set", "lh_cancel", "upgrade",
+        "coll_clr", "sme_wd", "inv_claim", "fund_can", "refunded", "reg_rebind",
+        "dust_sw", "att_bind", "att_app", "att_rev", "att_unrev", "mtry_max",
+        "al_ena", "al_set", "lh_cancel", "upgrade",
     ]
     .iter()
     .cloned()
     .collect();
 
-    // 33 unique symbols across 36 defined event structs.
-    // CollateralClearedEvt has no name field, LegalHoldClearDelayUpdated has no hardcoded symbol,
-    // and inv_cap is shared by MaxUniqueInvestorsCapLowered and MaxPerInvestorCapRaised.
+    // 34 unique symbols across 36 defined event structs.
+    // LegalHoldClearDelayUpdated has no hardcoded symbol, and inv_cap is shared
+    // by MaxUniqueInvestorsCapLowered and MaxPerInvestorCapRaised.
     assert_eq!(
         symbols.len(),
-        33,
+        34,
         "each event struct must have a unique name symbol"
     );
 }

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -4617,11 +4617,7 @@ fn test_get_yield_tiers_is_pure_read_no_state_change() {
 
 /// Helper: initialise an escrow with three tiers (30s / 60s / 90s) and a base
 /// yield of 500 bps.  Returns the client ready for use; all auth is mocked.
-fn setup_three_tier_escrow(
-    env: &Env,
-    invoice_id: &str,
-    target: i128,
-) -> LiquifactEscrowClient {
+fn setup_three_tier_escrow(env: &Env, invoice_id: &str, target: i128) -> LiquifactEscrowClient {
     let admin = Address::generate(env);
     let sme = Address::generate(env);
     let (tok, tre) = free_addresses(env);

--- a/escrow/src/tests/integration_status_guards.rs
+++ b/escrow/src/tests/integration_status_guards.rs
@@ -16,7 +16,15 @@ fn make_env() -> Env {
     env
 }
 
-fn setup_open(env: &Env) -> (LiquifactEscrowClient<'_>, Address, Address, Address, Address) {
+fn setup_open(
+    env: &Env,
+) -> (
+    LiquifactEscrowClient<'_>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     let client = LiquifactEscrowClient::new(env, &env.register(LiquifactEscrow, ()));
     let admin = Address::generate(env);
     let sme = Address::generate(env);

--- a/escrow/src/tests/properties.rs
+++ b/escrow/src/tests/properties.rs
@@ -2088,10 +2088,7 @@ fn snapshot_denominator_consistent_across_all_payout_reads() {
 ///
 /// When a cap is present: `count + remaining == cap` and `remaining >= 0`.
 /// When no cap: `get_remaining_investor_slots` returns `None`.
-fn assert_slots_invariant(
-    client: &super::LiquifactEscrowClient<'_>,
-    label: &str,
-) {
+fn assert_slots_invariant(client: &super::LiquifactEscrowClient<'_>, label: &str) {
     match client.get_remaining_investor_slots() {
         None => {
             // No cap — correct; nothing more to assert.
@@ -2139,7 +2136,7 @@ fn slots_no_cap_is_none_after_multiple_funds() {
         &Address::generate(&env),
         &None,
         &None,
-        &None,  // no max_unique_investors
+        &None, // no max_unique_investors
         &None,
         &None,
         &None,
@@ -2394,7 +2391,10 @@ fn slots_lower_cap_mid_sequence_invariant() {
 
     assert_eq!(cap_after_lower, 3);
     assert_eq!(count_after_lower, 3);
-    assert_eq!(remaining_after_lower, 0, "remaining must be 0 when cap == count");
+    assert_eq!(
+        remaining_after_lower, 0,
+        "remaining must be 0 when cap == count"
+    );
 
     // Further lower to mid-range (cap = 5, count stays 3).
     // First reset cap to 6, then lower to 5.
@@ -2723,15 +2723,16 @@ fn slots_cap_exactly_hit_remaining_is_zero() {
         &None,
     );
 
-    let investors: Vec<Address> = (0..cap as usize)
-        .map(|_| Address::generate(&env))
-        .collect();
+    let investors: Vec<Address> = (0..cap as usize).map(|_| Address::generate(&env)).collect();
 
     for (i, inv) in investors.iter().enumerate() {
         client.fund(inv, &100_000i128);
         let remaining = client.get_remaining_investor_slots().unwrap();
         let count = client.get_unique_funder_count();
-        assert!(remaining >= 0, "remaining must not underflow after investor {i}");
+        assert!(
+            remaining >= 0,
+            "remaining must not underflow after investor {i}"
+        );
         assert_eq!(
             count + remaining,
             cap,
@@ -2741,6 +2742,9 @@ fn slots_cap_exactly_hit_remaining_is_zero() {
 
     // After all cap slots consumed: remaining must be 0.
     let final_remaining = client.get_remaining_investor_slots().unwrap();
-    assert_eq!(final_remaining, 0, "remaining must be exactly 0 when cap is fully consumed");
+    assert_eq!(
+        final_remaining, 0,
+        "remaining must be exactly 0 when cap is fully consumed"
+    );
     assert_slots_invariant(&client, "cap exactly hit");
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -2097,14 +2097,20 @@ fn test_settlement_readiness_funded_but_held_blocks_ready() {
     let r = client.get_settlement_readiness();
     assert!(r.legal_hold_active);
     assert!(r.maturity_reached);
-    assert!(!r.is_settleable, "a legal hold makes the escrow not settleable");
+    assert!(
+        !r.is_settleable,
+        "a legal hold makes the escrow not settleable"
+    );
     assert!(!r.ready_now, "ready_now must be false under an active hold");
 
     // Parity: ready_now == false ⇒ settle fails.
     let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.settle();
     }));
-    assert!(res.is_err(), "settle must fail while a legal hold is active");
+    assert!(
+        res.is_err(),
+        "settle must fail while a legal hold is active"
+    );
 }
 
 /// Funded with a future maturity: pre-maturity `maturity_reached` is false and


### PR DESCRIPTION
## Summary
- Add a `coll_clr` name topic to `CollateralClearedEvt` so indexers can route clear events by a unique short symbol.
- Copy the cleared commitment metadata (`asset`, `amount`, `recorded_at`) into the clear event before removing storage.
- Tighten the collateral clear event coverage test and update the event schema, indexer docs, audit handoff table, README, and SME collateral guide.

## Security notes
- Additive event metadata only; no auth, storage-key, token-transfer, or state-machine behavior changes.
- Existing SME auth gate and `NoCollateralToClear` behavior are preserved.
- The event remains metadata-only and does not imply custody, lien, token movement, or enforceable collateral.

## Validation
- `git diff --check` passes.
- `cargo fmt -p liquifact_escrow -- --check` passes after the separate rustfmt commit.
- GitHub CI now advances to `cargo clippy -p liquifact_escrow -- -D warnings`, where it is blocked on upstream `main` compile errors unrelated to this PR: duplicate `guard_status_eq` / `guard_status_in`, duplicate `EscrowError` discriminant `201`, and missing `PausedBlocks*` variants.
- `$HOME/.cargo/bin/cargo check -p liquifact_escrow --lib` is blocked locally on the same upstream compile errors.
- `$HOME/.cargo/bin/cargo test test_event_collateral_cleared_struct` is also blocked before the focused test can run because the same upstream compile errors and pre-existing test compile errors are hit first.

Closes #554