### PR TITLE
test(admin): assert rotate_beneficiary requires dual SME+admin auth (#477)

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -476,7 +476,12 @@ pub(crate) fn ensure(env: &Env, condition: bool, error: EscrowError) {
 /// specific named status check (e.g. [`require_funding_open`]) delegate here so the
 /// exact error code is preserved at every call site.
 #[inline(always)]
-pub(crate) fn guard_status_eq(env: &Env, actual_status: u32, expected_status: u32, error: EscrowError) {
+pub(crate) fn guard_status_eq(
+    env: &Env,
+    actual_status: u32,
+    expected_status: u32,
+    error: EscrowError,
+) {
     ensure(env, actual_status == expected_status, error);
 }
 
@@ -2525,8 +2530,7 @@ impl LiquifactEscrow {
     pub fn get_settlement_readiness(env: Env) -> SettlementReadiness {
         let legal_hold_active = Self::legal_hold_active(&env);
         let escrow = Self::get_escrow(env.clone());
-        let maturity_reached =
-            escrow.maturity == 0 || env.ledger().timestamp() >= escrow.maturity;
+        let maturity_reached = escrow.maturity == 0 || env.ledger().timestamp() >= escrow.maturity;
 
         // Reuse the single-source-of-truth gate so this view cannot drift from `settle`.
         let is_settleable = Self::settleable_now(&env);
@@ -4763,7 +4767,9 @@ impl DefaultMockToken {
         let from_bal = balances
             .get(from.clone())
             .unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
-        let to_bal = balances.get(to.clone()).unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
+        let to_bal = balances
+            .get(to.clone())
+            .unwrap_or(MOCK_TOKEN_DEFAULT_BALANCE);
         balances.set(from.clone(), from_bal - amount);
         balances.set(to.clone(), to_bal + amount);
         env.storage().instance().set(&key, &balances);

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -361,6 +361,51 @@ fn test_rotate_beneficiary_wrong_state() {
     client.rotate_beneficiary(&Address::generate(&env));
 }
 
+/// #477: `rotate_beneficiary` requires BOTH the outgoing SME and the admin
+/// to authorize (dual authorization). Authorizing only the SME must still
+/// fail, because the admin's `require_auth` is never satisfied.
+#[test]
+#[should_panic]
+fn test_rotate_beneficiary_missing_admin_auth_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    let new_sme = Address::generate(&env);
+    // Authorize ONLY the SME for this call; admin stays unauthorized.
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &sme,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "rotate_beneficiary",
+            args: soroban_sdk::Vec::<soroban_sdk::Val>::new(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.rotate_beneficiary(&new_sme);
+}
+
+/// #477: Authorizing only the admin must also fail, because the outgoing
+/// SME's `require_auth` (checked first) is never satisfied.
+#[test]
+#[should_panic]
+fn test_rotate_beneficiary_missing_sme_auth_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    let new_sme = Address::generate(&env);
+    // Authorize ONLY the admin for this call; SME stays unauthorized.
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "rotate_beneficiary",
+            args: soroban_sdk::Vec::<soroban_sdk::Val>::new(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.rotate_beneficiary(&new_sme);
+}
+
 #[test]
 #[should_panic]
 fn test_transfer_admin_uninitialized_panics() {

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -2127,7 +2127,10 @@ fn test_registry_ref_does_not_affect_settlement_or_funding() {
         registry: None,
     }
     .to_xdr(&env, &contract_id);
-    assert_eq!(last, expected_clear, "last event must be reg_rebind with None");
+    assert_eq!(
+        last, expected_clear,
+        "last event must be reg_rebind with None"
+    );
 }
 
 fn test_error_code_uniqueness() {

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -4617,11 +4617,7 @@ fn test_get_yield_tiers_is_pure_read_no_state_change() {
 
 /// Helper: initialise an escrow with three tiers (30s / 60s / 90s) and a base
 /// yield of 500 bps.  Returns the client ready for use; all auth is mocked.
-fn setup_three_tier_escrow(
-    env: &Env,
-    invoice_id: &str,
-    target: i128,
-) -> LiquifactEscrowClient {
+fn setup_three_tier_escrow(env: &Env, invoice_id: &str, target: i128) -> LiquifactEscrowClient {
     let admin = Address::generate(env);
     let sme = Address::generate(env);
     let (tok, tre) = free_addresses(env);

--- a/escrow/src/tests/integration_status_guards.rs
+++ b/escrow/src/tests/integration_status_guards.rs
@@ -16,7 +16,15 @@ fn make_env() -> Env {
     env
 }
 
-fn setup_open(env: &Env) -> (LiquifactEscrowClient<'_>, Address, Address, Address, Address) {
+fn setup_open(
+    env: &Env,
+) -> (
+    LiquifactEscrowClient<'_>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     let client = LiquifactEscrowClient::new(env, &env.register(LiquifactEscrow, ()));
     let admin = Address::generate(env);
     let sme = Address::generate(env);

--- a/escrow/src/tests/properties.rs
+++ b/escrow/src/tests/properties.rs
@@ -2088,10 +2088,7 @@ fn snapshot_denominator_consistent_across_all_payout_reads() {
 ///
 /// When a cap is present: `count + remaining == cap` and `remaining >= 0`.
 /// When no cap: `get_remaining_investor_slots` returns `None`.
-fn assert_slots_invariant(
-    client: &super::LiquifactEscrowClient<'_>,
-    label: &str,
-) {
+fn assert_slots_invariant(client: &super::LiquifactEscrowClient<'_>, label: &str) {
     match client.get_remaining_investor_slots() {
         None => {
             // No cap — correct; nothing more to assert.
@@ -2139,7 +2136,7 @@ fn slots_no_cap_is_none_after_multiple_funds() {
         &Address::generate(&env),
         &None,
         &None,
-        &None,  // no max_unique_investors
+        &None, // no max_unique_investors
         &None,
         &None,
         &None,
@@ -2394,7 +2391,10 @@ fn slots_lower_cap_mid_sequence_invariant() {
 
     assert_eq!(cap_after_lower, 3);
     assert_eq!(count_after_lower, 3);
-    assert_eq!(remaining_after_lower, 0, "remaining must be 0 when cap == count");
+    assert_eq!(
+        remaining_after_lower, 0,
+        "remaining must be 0 when cap == count"
+    );
 
     // Further lower to mid-range (cap = 5, count stays 3).
     // First reset cap to 6, then lower to 5.
@@ -2723,15 +2723,16 @@ fn slots_cap_exactly_hit_remaining_is_zero() {
         &None,
     );
 
-    let investors: Vec<Address> = (0..cap as usize)
-        .map(|_| Address::generate(&env))
-        .collect();
+    let investors: Vec<Address> = (0..cap as usize).map(|_| Address::generate(&env)).collect();
 
     for (i, inv) in investors.iter().enumerate() {
         client.fund(inv, &100_000i128);
         let remaining = client.get_remaining_investor_slots().unwrap();
         let count = client.get_unique_funder_count();
-        assert!(remaining >= 0, "remaining must not underflow after investor {i}");
+        assert!(
+            remaining >= 0,
+            "remaining must not underflow after investor {i}"
+        );
         assert_eq!(
             count + remaining,
             cap,
@@ -2741,6 +2742,9 @@ fn slots_cap_exactly_hit_remaining_is_zero() {
 
     // After all cap slots consumed: remaining must be 0.
     let final_remaining = client.get_remaining_investor_slots().unwrap();
-    assert_eq!(final_remaining, 0, "remaining must be exactly 0 when cap is fully consumed");
+    assert_eq!(
+        final_remaining, 0,
+        "remaining must be exactly 0 when cap is fully consumed"
+    );
     assert_slots_invariant(&client, "cap exactly hit");
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -2097,14 +2097,20 @@ fn test_settlement_readiness_funded_but_held_blocks_ready() {
     let r = client.get_settlement_readiness();
     assert!(r.legal_hold_active);
     assert!(r.maturity_reached);
-    assert!(!r.is_settleable, "a legal hold makes the escrow not settleable");
+    assert!(
+        !r.is_settleable,
+        "a legal hold makes the escrow not settleable"
+    );
     assert!(!r.ready_now, "ready_now must be false under an active hold");
 
     // Parity: ready_now == false ⇒ settle fails.
     let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.settle();
     }));
-    assert!(res.is_err(), "settle must fail while a legal hold is active");
+    assert!(
+        res.is_err(),
+        "settle must fail while a legal hold is active"
+    );
 }
 
 /// Funded with a future maturity: pre-maturity `maturity_reached` is false and


### PR DESCRIPTION
## Summary
Adds two `#[should_panic]` tests that close the dual-authorization gap called out in #477.

The existing `rotate_beneficiary` tests (`test_rotate_beneficiary_success`, `_same_address_panics`, `_wrong_state`) all run under `mock_all_auths()` / the default test auth, so they never exercise the per-signatory gate. `rotate_beneficiary` (escrow/src/lib.rs) in fact requires BOTH `sme_address.require_auth()` and `admin.require_auth()`.

- `test_rotate_beneficiary_missing_admin_auth_panics` - only the SME is authorized -> `admin.require_auth()` fails.
- `test_rotate_beneficiary_missing_sme_auth_panics` - only the admin is authorized -> `sme_address.require_auth()` (checked first) fails.

Both must panic, confirming neither signatory alone can rotate the beneficiary.

## Test plan
- `cargo test` (Liquifact-contracts escrow crate) - the two new `#[should_panic]` tests pass; existing suite unaffected.
- References #477.
