### PR TITLE
test: add comprehensive cancel_pending_admin entrypoint tests

### DIFF
--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -2066,8 +2066,123 @@ fn test_rotate_beneficiary_then_withdraw_goes_to_new_sme() {
 
 // ── cancel_pending_admin ──────────────────────────────────────────────────────
 
-/// Happy path: propose then cancel — `get_pending_admin` returns `None` and current
-/// admin is unchanged.
+/// Happy path: propose then cancel — `get_pending_admin` returns `None` and the
+/// cancelled address is returned to the caller.
+#[test]
+fn test_cancel_pending_admin_propose_then_cancel_clears_pending() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let new_admin = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    client.propose_admin(&new_admin, &None);
+    let cancelled = client.cancel_pending_admin();
+
+    assert_eq!(cancelled, new_admin);
+    assert_eq!(client.get_pending_admin(), None);
+    assert_eq!(client.get_pending_admin_remaining_secs(), None);
+    // Current admin is unchanged after cancel
+    assert_eq!(client.get_escrow().admin, admin);
+}
+
+/// accept_admin after cancel_pending_admin must fail with NoPendingAdmin.
+#[test]
+fn test_cancel_pending_admin_accept_after_cancel_fails() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let new_admin = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    client.propose_admin(&new_admin, &None);
+    client.cancel_pending_admin();
+
+    assert_contract_error(client.try_accept_admin(), EscrowError::NoPendingAdmin);
+}
+
+/// Calling cancel_pending_admin without a prior proposal must fail with NoPendingAdmin.
+#[test]
+fn test_cancel_pending_admin_without_proposal_rejected() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    assert_contract_error(
+        client.try_cancel_pending_admin(),
+        EscrowError::NoPendingAdmin,
+    );
+}
+
+/// A non-admin caller cannot cancel a pending admin proposal.
+#[test]
+#[should_panic]
+fn test_cancel_pending_admin_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let new_admin = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    client.propose_admin(&new_admin, &None);
+    env.mock_auths(&[]);
+    client.cancel_pending_admin();
+}
+
+/// Cancel then re-propose a different admin — the new proposal is accepted.
+#[test]
+fn test_cancel_pending_admin_cancel_then_repropose_succeeds() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let first = Address::generate(&env);
+    let second = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    // Propose first, then cancel
+    client.propose_admin(&first, &None);
+    client.cancel_pending_admin();
+    assert_eq!(client.get_pending_admin(), None);
+
+    // Propose second, then accept
+    client.propose_admin(&second, &None);
+    let updated = client.accept_admin();
+    assert_eq!(updated.admin, second);
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+/// Cancel on an uninitialized escrow must panic (no escrow to load).
+#[test]
+#[should_panic]
+fn test_cancel_pending_admin_uninitialized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    client.cancel_pending_admin();
+}
+
+/// Verify that cancel_pending_admin emits AdminProposalCancelled event.
+#[test]
+fn test_cancel_pending_admin_emits_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    let new_admin = Address::generate(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    client.propose_admin(&new_admin, &None);
+    client.cancel_pending_admin();
+
+    let all_events = env.events().all();
+    assert_eq!(
+        all_events.events().last().unwrap().clone(),
+        AdminProposalCancelled {
+            name: symbol_short!("adm_can"),
+            invoice_id: client.get_escrow().invoice_id,
+            cancelled_pending: new_admin,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
 #[test]
 fn test_rebind_registry_ref_sets_and_clears() {
     use soroban_sdk::testutils::Events as _;


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for the `cancel_pending_admin` entrypoint. The production implementation (`cancel_pending_admin`, `AdminProposalCancelled` event, `NoPendingAdmin` error code 172) was already in place — this fills the missing test gap with 7 test functions covering the full lifecycle of admin proposal cancellation.

Closes #633

---

## Background

The two-step admin handover writes `DataKey::PendingAdmin` in `propose_admin` and only clears it when the successor calls `accept_admin`. Without `cancel_pending_admin`, there was no way for the current admin to retract a proposal once made — if the wrong successor was proposed, or the handover was abandoned, the pending key would linger and the proposed address could accept at any later time, representing a standing key-rotation risk.

The `cancel_pending_admin` entrypoint (already implemented in `escrow/src/lib.rs` at line 5071) allows the current admin to withdraw an unaccepted proposal.

---

## Files Changed

| File | Change | +/- |
|------|--------|-----|
| `escrow/src/tests/admin.rs` | Added 7 test functions under `cancel_pending_admin` section | +117 / -2 |

---

## Implementation (existing in `escrow/src/lib.rs`)

```rust
pub fn cancel_pending_admin(env: Env) -> Address {
    let escrow = Self::load_escrow_require_admin(&env);

    let pending: Option<Address> = env.storage().instance().get(&DataKey::PendingAdmin);
    ensure(&env, pending.is_some(), EscrowError::NoPendingAdmin);
    let cancelled = pending.unwrap();

    env.storage().instance().remove(&DataKey::PendingAdmin);
    env.storage().instance().remove(&DataKey::PendingAdminExpiry);

    AdminProposalCancelled {
        name: symbol_short!("adm_can"),
        invoice_id: escrow.invoice_id.clone(),
        cancelled_pending: cancelled.clone(),
    }
    .publish(&env);

    cancelled
}
```

**Flow:**
1. Admin auth gate via `load_escrow_require_admin`
2. `NoPendingAdmin` (code 172) if no proposal exists
3. Removes `DataKey::PendingAdmin` and `DataKey::PendingAdminExpiry`
4. Emits `AdminProposalCancelled` (topic: `adm_can`)
5. Returns the cancelled address

---

## Test Coverage (7 new tests)

| # | Test | Scenario | Key Assertions |
|---|------|----------|----------------|
| 1 | `test_cancel_pending_admin_propose_then_cancel_clears_pending` | Happy path | `get_pending_admin()` → `None`, `remaining_secs()` → `None`, returned address matches, `admin` unchanged |
| 2 | `test_cancel_pending_admin_accept_after_cancel_fails` | Accept blocked after cancel | `try_accept_admin()` → `NoPendingAdmin` |
| 3 | `test_cancel_pending_admin_without_proposal_rejected` | Cancel with no proposal | `try_cancel_pending_admin()` → `NoPendingAdmin` |
| 4 | `test_cancel_pending_admin_non_admin_rejected` | Non-admin caller | `#[should_panic]` auth failure |
| 5 | `test_cancel_pending_admin_cancel_then_repropose_succeeds` | Cancel → re-propose → accept | Second proposal accepted, admin promoted |
| 6 | `test_cancel_pending_admin_uninitialized_panics` | Uninitialized escrow | `#[should_panic]` |
| 7 | `test_cancel_pending_admin_emits_event` | Event emission | `adm_can` event with correct fields |

---

## Security Notes

- **Admin-only**: Gated via `load_escrow_require_admin` — only the current `InvoiceEscrow::admin` may cancel
- **No timing attack surface**: Single `is_some()` check, no looping, no external calls, constant gas cost
- **No re-entrancy risk**: No token transfers, no cross-contract calls — only two instance storage `remove` operations
- **Invariant preserved**: `cancel_pending_admin` does not modify `InvoiceEscrow::admin` — current admin retains control
- **Orthogonal to legal hold**: Like `propose_admin` and `accept_admin`, `cancel_pending_admin` is not gated by the legal hold flag, preserving the admin rotation recovery path under all compliance states (see `OPERATOR_RUNBOOK.md` §8)

---

## How to Test

```bash
cargo test -p liquifact_escrow -- cancel_pending_admin
cargo fmt --all -- --check
cargo clippy -p liquifact_escrow -- -D warnings
cargo llvm-cov --features testutils --fail-under-lines 95 --summary-only -p liquifact_escrow
```
