### PR TITLE
fix: reject duplicate investor addresses in fund_batch (closes #643)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ liquifact-contracts/
 | `init` | Admin (implicit) | Create an invoice escrow (invoice id, SME, amount, yield bps, maturity). |
 | `fund` | Investor | Record investor principal and atomically pull the funding token from the investor; marks escrow funded when target is met. |
 | `fund_with_commitment` | Investor | First deposit with optional lock period (atomically pulling the funding token); selects tiered yield. |
+| `fund_batch` | Investor | Batch up to `MAX_FUND_BATCH` (50) `(investor, amount)` entries in a single call. Each entry is processed identically to a single `fund` call. Batches containing a **duplicate investor address** are rejected atomically with `FundingBatchDuplicateInvestor` (error 84) before any state mutation — repeat deposits for one investor must use separate `fund` calls. |
 | `settle` | SME | Mark a funded escrow as settled (SME auth required; maturity enforced). |
 | `partial_settle` | SME | SME marks a portion of the escrow as settled before full settlement. |
 | `withdraw` | SME | SME pulls funded liquidity (accounting record). |

--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -36,7 +36,7 @@ Codes are grouped by domain so SDKs can map coarse categories without parsing va
 | Admin validation | 70–81 | Allowlist batch, funding target, investor cap, maturity, admin handover | 70, 81 |
 | Schema migration | 90–92 | `migrate` version checks | 90, 92 |
 | Funding | 100–111 | Investor deposits, batch funding, and contribution limits | 100, 111 |
-| Funding batch | 82–83 | [`fund_batch`] entry count bounds | 82, 83 |
+| Funding batch | 82–84 | [`fund_batch`] entry count bounds and duplicate address rejection | 82, 84 |
 | Settlement / payout | 120–129 | Settle, withdraw, investor claims, payout math | 120, 129 |
 | Cancel / refund | 140–143 | Cancel funding and investor refunds | 140, 143 |
 | Legal-hold clear (two-phase) | 150–152 | Delayed compliance-hold lift workflow | 150, 152 |
@@ -105,6 +105,7 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 81 | `MaturityUnchanged` | `update_maturity` | `new_maturity == old_maturity` | Use a different maturity | typed |
 | 82 | `FundingBatchEmpty` | `fund_batch` | `entries.len() == 0` | Pass at least one `(investor, amount)` pair | typed |
 | 83 | `FundingBatchTooLarge` | `fund_batch` | `entries.len() > MAX_FUND_BATCH` | Split into smaller batches | typed |
+| 84 | `FundingBatchDuplicateInvestor` | `fund_batch` | batch contains a repeated investor address | Each address must appear at most once per batch; use separate `fund` calls for repeat deposits | typed |
 | 90 | `MigrationVersionMismatch` | `migrate` | stored version `!= from_version` | Pass matching `from_version` | typed |
 | 91 | `AlreadyCurrentSchemaVersion` | `migrate` | `from_version >= SCHEMA_VERSION` | No migration needed | typed |
 | 92 | `NoMigrationPath` | `migrate` | `from_version < SCHEMA_VERSION` and no transform implemented | Redeploy or extend `migrate` | typed |
@@ -210,6 +211,7 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 81 | `New maturity must differ from current maturity` |
 | 82 | `fund_batch entries vector must be non-empty` |
 | 83 | `fund_batch entries vector length exceeds MAX_FUND_BATCH` |
+| 84 | `fund_batch batch contains duplicate investor address` |
 | 90 | `from_version does not match stored version` |
 | 91 | `Already at current schema version` |
 | 92 | `No migration path from version 0 - extend migrate or redeploy` |
@@ -262,7 +264,7 @@ Recommended SDK category mappings:
 | 30–42 | Dust sweep or token integration failure |
 | 50–56 | Attestation failure |
 | 60–62 | Collateral metadata failure |
-| 70–83 | Administrative validation or batch-funding bounds failure |
+| 70–84 | Administrative validation or batch-funding bounds failure |
 | 90–92 | Migration failure |
 | 100–111 | Funding failure |
 | 163–164 | Funding deadline or contract balance failure |

--- a/docs/escrow-lifecycle.md
+++ b/docs/escrow-lifecycle.md
@@ -71,11 +71,17 @@ reducing transaction overhead for primary issuance workflows.
 - One `EscrowFunded` event is emitted per entry
 - If any entry fails its invariants, the call returns an error **without corrupting prior entries**
   (Soroban's transaction atomicity ensures consistent state)
+- **Duplicate addresses are rejected:** each investor address must appear at most once per batch.
+  Duplicate detection is performed before any state mutation so the entire batch is rejected
+  atomically (`FundingBatchDuplicateInvestor`, error code 84). Repeat deposits for one investor
+  must be submitted as separate single [`fund()`] calls, matching the tiered second-deposit
+  discipline enforced by `fund_with_commitment`.
 
 **Capacity:**
 - Batch size must be `> 0` and `<= MAX_FUND_BATCH` (50 entries)
 - Empty batch panics with `EscrowError::FundingBatchEmpty`
 - Oversized batch panics with `EscrowError::FundingBatchTooLarge`
+- Duplicate address panics with `EscrowError::FundingBatchDuplicateInvestor`
 
 **Funded-target snapshot:**
 - If any entry causes the escrow to transition to **funded** (status `0 → 1`),
@@ -122,6 +128,14 @@ let result = fund_batch(entries); // All three processed; status = 1
 | Over-funding across two entries; snapshot correct | `test_fund_batch_overfunding_across_two_entries_snapshot_correct` |
 | Per-investor `require_auth` recorded for each entry | `test_fund_batch_investor_auth_recorded_for_each_entry` |
 | Event count == entry count | `test_fund_batch_event_count_matches_entry_count` |
+| Adjacent duplicate → `FundingBatchDuplicateInvestor` (#84) | `test_fund_batch_duplicate_adjacent_rejected` |
+| Non-adjacent duplicate → `FundingBatchDuplicateInvestor` (#84) | `test_fund_batch_duplicate_non_adjacent_rejected` |
+| Duplicate at last position → `FundingBatchDuplicateInvestor` (#84) | `test_fund_batch_duplicate_last_position_rejected` |
+| Rejected duplicate batch leaves zero state (no partial mutation) | `test_fund_batch_duplicate_no_partial_state` |
+| All-unique batch succeeds normally | `test_fund_batch_all_unique_succeeds` |
+| Single-entry batch is trivially unique | `test_fund_batch_single_entry_unique_by_definition` |
+| Rejected duplicate batch; subsequent valid batch succeeds | `test_fund_batch_duplicate_then_valid_batch_succeeds` |
+| Duplicate check fires before amount check | `test_fund_batch_duplicate_check_before_amount_check` |
 
 ---
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -344,6 +344,13 @@ pub enum EscrowError {
     FundingBatchEmpty = 82,
     /// [`LiquifactEscrow::fund_batch`] exceeded [`MAX_FUND_BATCH`].
     FundingBatchTooLarge = 83,
+    /// [`LiquifactEscrow::fund_batch`] received a batch containing a duplicate investor address.
+    ///
+    /// Each address may appear **at most once** per batch call. Repeat deposits for the same
+    /// investor must be submitted as separate single [`LiquifactEscrow::fund`] calls, consistent
+    /// with the tiered second-deposit discipline enforced by [`LiquifactEscrow::fund_with_commitment`].
+    /// Duplicate detection is performed before any state mutation so the batch is rejected atomically.
+    FundingBatchDuplicateInvestor = 84,
     /// [`LiquifactEscrow::get_contributions`] exceeded [`MAX_INVESTOR_READ_BATCH`].
     ContributionReadBatchTooLarge = 203,
     /// [`LiquifactEscrow::update_funding_target`] received a non-positive target.
@@ -3792,6 +3799,10 @@ impl LiquifactEscrow {
     /// # Errors
     /// - [`EscrowError::FundingBatchEmpty`] if entries is empty
     /// - [`EscrowError::FundingBatchTooLarge`] if entries.len() > [`MAX_FUND_BATCH`]
+    /// - [`EscrowError::FundingBatchDuplicateInvestor`] if any investor address appears more than
+    ///   once in the batch. Duplicate detection is performed before any state mutation so the
+    ///   entire batch is rejected atomically. Repeat deposits for the same investor must be
+    ///   submitted as separate single [`LiquifactEscrow::fund`] calls.
     /// - Per-entry: all errors from [`LiquifactEscrow::fund`] for that investor/amount pair
     ///
     /// # Events
@@ -3819,6 +3830,28 @@ impl LiquifactEscrow {
         //
         // Stateful per-entry guards (per-investor cap, unique-investor cap, overflow)
         // remain enforced inside `fund_impl` against the running accumulated state.
+
+        // ── Duplicate investor guard (issue #643) ─────────────────────────────
+        // Reject any batch where the same investor address appears more than once.
+        // Checked here — before any state mutation — so the batch is either fully
+        // accepted or fully rejected. Repeat deposits for one investor must be
+        // submitted as separate single `fund` calls, matching the tiered
+        // second-deposit discipline enforced by `fund_with_commitment`.
+        //
+        // Scan is O(n²) over at most MAX_FUND_BATCH = 50 entries, so the worst-case
+        // work is bounded at (50 * 49) / 2 = 1225 address comparisons per call.
+        for i in 0..n {
+            let (addr_i, _) = entries.get(i).unwrap();
+            for j in (i + 1)..n {
+                let (addr_j, _) = entries.get(j).unwrap();
+                ensure(
+                    &env,
+                    addr_i != addr_j,
+                    EscrowError::FundingBatchDuplicateInvestor,
+                );
+            }
+        }
+
         let floor: i128 = env
             .storage()
             .instance()
@@ -3841,8 +3874,8 @@ impl LiquifactEscrow {
         for i in 0..n {
             let (investor, amount) = entries.get(i).unwrap();
 
-            // Each entry is now known to satisfy positivity and the floor; remaining
-            // per-entry invariants (auth, caps, overflow) are enforced inside fund_impl.
+            // Each entry is now known to satisfy positivity, the floor, and uniqueness;
+            // remaining per-entry invariants (auth, caps, overflow) are enforced inside fund_impl.
             escrow = Self::fund_impl(env.clone(), investor, amount, true, 0);
         }
 

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -4307,65 +4307,7 @@ fn test_fund_batch_mid_batch_funded_transition() {
     assert_eq!(snap.unwrap().total_principal, 105_000i128);
 }
 
-#[test]
-#[should_panic(expected = "HostError: Error(Contract, #106)")]
-#[ignore = "upstream latent: escrow API/test drift"]
-fn test_fund_batch_duplicate_addresses() {
-    let env = Env::default();
-
-    env.mock_all_auths();
-
-    let client = deploy(&env);
-
-    let admin = Address::generate(&env);
-
-    let sme = Address::generate(&env);
-
-    let inv = Address::generate(&env);
-
-    let (tok, tre) = free_addresses(&env);
-
-    let target = 100_000i128;
-
-    let per_investor_cap = 50_000i128;
-
-    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let sac_id = sac.address();
-    let sac_admin = StellarAssetClient::new(&env, &sac_id);
-    sac_admin.mint(&inv1, &20_000i128);
-    sac_admin.mint(&inv2, &15_000i128);
-
-    client.init(
-        &admin,
-        &soroban_sdk::String::from_str(&env, "DUP001"),
-        &sme,
-        &target,
-        &800i64,
-        &0u64,
-        &sac_id,
-        &None,
-        &Address::generate(&env),
-        &None,
-        &None,
-        &None,
-        &Some(per_investor_cap),
-        &None,
-        &None,
-        &None,
-        &None,
-    );
-
-    let mut entries = SorobanVec::new(&env);
-
-    entries.push_back((inv.clone(), 30_000i128)); // First entry: 30k
-
-    entries.push_back((inv.clone(), 25_000i128)); // Second entry: 30k + 25k = 55k > cap
-
-    let result = client.fund_batch(&entries);
-    assert_eq!(client.get_contribution(&inv1), 20_000i128);
-    assert_eq!(client.get_contribution(&inv2), 15_000i128);
-    assert_eq!(result.funded_amount, 35_000i128);
-}
+// Replaced by test_fund_batch_duplicate_adjacent and friends below (issue #643).
 
 #[test]
 #[should_panic]
@@ -4550,7 +4492,176 @@ fn test_fund_batch_preserves_event_semantics() {
     // (Detailed event field verification depends on EscrowFunded structure)
 }
 
-// ─── get_remaining_funding_capacity tests (issue tracking funding capacity) ─────
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for fund_batch duplicate investor address rejection (Issue #643)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Adjacent duplicate (positions 0 and 1): the batch must be rejected with
+/// `FundingBatchDuplicateInvestor` (error #84) and leave no partial state.
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #84)")]
+fn test_fund_batch_duplicate_adjacent_rejected() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let inv = Address::generate(&env);
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((inv.clone(), 10_000i128));
+    entries.push_back((inv.clone(), 10_000i128)); // same address immediately after
+
+    client.fund_batch(&entries);
+}
+
+/// Non-adjacent duplicate (positions 0 and 2 in a 3-entry batch): the batch must be
+/// rejected with `FundingBatchDuplicateInvestor` (error #84).
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #84)")]
+fn test_fund_batch_duplicate_non_adjacent_rejected() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((inv_a.clone(), 10_000i128));
+    entries.push_back((inv_b.clone(), 10_000i128)); // unique in the middle
+    entries.push_back((inv_a.clone(), 10_000i128)); // duplicate of position 0
+
+    client.fund_batch(&entries);
+}
+
+/// Duplicate at the last position (positions 0 and MAX_FUND_BATCH-1): ensures the
+/// scan reaches the end of a maximum-length batch.
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #84)")]
+fn test_fund_batch_duplicate_last_position_rejected() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let dup_inv = Address::generate(&env);
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((dup_inv.clone(), 1_000i128)); // will be duplicated at the end
+
+    // Fill positions 1 .. MAX_FUND_BATCH-1 with unique addresses
+    for _ in 1..(MAX_FUND_BATCH as usize - 1) {
+        entries.push_back((Address::generate(&env), 1_000i128));
+    }
+
+    // Duplicate at the final position
+    entries.push_back((dup_inv.clone(), 1_000i128));
+
+    client.fund_batch(&entries);
+}
+
+/// Verify that a duplicate-containing batch leaves zero state: after the rejected
+/// call, `funded_amount` must still be 0 and no contribution must be recorded.
+#[test]
+fn test_fund_batch_duplicate_no_partial_state() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let inv = Address::generate(&env);
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((inv.clone(), 20_000i128));
+    entries.push_back((inv.clone(), 20_000i128));
+
+    let result = client.try_fund_batch(&entries);
+    assert_contract_error(result, EscrowError::FundingBatchDuplicateInvestor);
+
+    // No state must have been mutated
+    let escrow = client.get_escrow();
+    assert_eq!(escrow.funded_amount, 0, "funded_amount must be 0 after rejected duplicate batch");
+    assert_eq!(
+        client.get_contribution(&inv),
+        0,
+        "investor contribution must be 0 after rejected duplicate batch"
+    );
+}
+
+/// A fully unique batch of two investors must succeed normally.
+#[test]
+fn test_fund_batch_all_unique_succeeds() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((inv_a.clone(), 30_000i128));
+    entries.push_back((inv_b.clone(), 40_000i128));
+
+    let result = client.fund_batch(&entries);
+    assert_eq!(result.funded_amount, 70_000i128);
+    assert_eq!(client.get_contribution(&inv_a), 30_000i128);
+    assert_eq!(client.get_contribution(&inv_b), 40_000i128);
+}
+
+/// A single-element batch is trivially unique and must succeed.
+#[test]
+fn test_fund_batch_single_entry_unique_by_definition() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let inv = Address::generate(&env);
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((inv.clone(), 25_000i128));
+
+    let result = client.fund_batch(&entries);
+    assert_eq!(result.funded_amount, 25_000i128);
+    assert_eq!(client.get_contribution(&inv), 25_000i128);
+}
+
+/// After a rejected duplicate batch the escrow remains open (status == 0),
+/// so a subsequent correctly-formed batch must succeed.
+#[test]
+fn test_fund_batch_duplicate_then_valid_batch_succeeds() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let inv = Address::generate(&env);
+
+    // First call: duplicate batch — rejected
+    let mut dup_entries = SorobanVec::new(&env);
+    dup_entries.push_back((inv.clone(), 10_000i128));
+    dup_entries.push_back((inv.clone(), 10_000i128));
+    let dup_result = client.try_fund_batch(&dup_entries);
+    assert_contract_error(dup_result, EscrowError::FundingBatchDuplicateInvestor);
+
+    // Second call: valid batch with the same investor appearing only once
+    let inv2 = Address::generate(&env);
+    let mut ok_entries = SorobanVec::new(&env);
+    ok_entries.push_back((inv.clone(), 10_000i128));
+    ok_entries.push_back((inv2.clone(), 15_000i128));
+    let result = client.fund_batch(&ok_entries);
+    assert_eq!(result.funded_amount, 25_000i128);
+}
+
+/// Duplicate detection fires before the positivity and floor checks: a batch with
+/// both a duplicate address and a zero amount must be rejected with
+/// `FundingBatchDuplicateInvestor`, not `FundingAmountNotPositive`.
+#[test]
+fn test_fund_batch_duplicate_check_before_amount_check() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let inv = Address::generate(&env);
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((inv.clone(), 0i128));   // also invalid amount
+    entries.push_back((inv.clone(), 10_000i128)); // duplicate
+
+    let result = client.try_fund_batch(&entries);
+    assert_contract_error(result, EscrowError::FundingBatchDuplicateInvestor);
+}
+
+
 
 /// Verify that `get_remaining_funding_capacity` returns the full funding target
 


### PR DESCRIPTION
## Summary

Closes #643

Guard `fund_batch` against intra-batch duplicate investor addresses by rejecting any batch where the same address appears more than once, with a new append-only typed error `FundingBatchDuplicateInvestor` (code 84). Detection runs **before any state mutation** so the batch is rejected atomically.

---

## Changes

### `escrow/src/lib.rs`
- Add `FundingBatchDuplicateInvestor = 84` to `EscrowError` (append-only, stable for SDK branching on `ContractError(84)`)
- Add O(n²) duplicate-address guard in `fund_batch` placed before positivity/floor checks and before any `fund_impl` storage write
- Worst-case: 1225 address comparisons bounded by `MAX_FUND_BATCH = 50`
- Updated `fund_batch` doc comment to list the new error and document that repeat deposits must use separate `fund()` calls

### `escrow/src/tests/funding.rs`
- Removed stale `#[ignore]` placeholder test (was expecting wrong error code #106)
- Added 8 new tests:

| Test | Scenario |
|------|----------|
| `test_fund_batch_duplicate_adjacent_rejected` | Adjacent dup → error #84 |
| `test_fund_batch_duplicate_non_adjacent_rejected` | Non-adjacent dup (positions 0 and 2) → error #84 |
| `test_fund_batch_duplicate_last_position_rejected` | Dup at last slot of 50-entry batch |
| `test_fund_batch_duplicate_no_partial_state` | `funded_amount == 0`, `contribution == 0` after rejection |
| `test_fund_batch_all_unique_succeeds` | Regression: unique batch still processes normally |
| `test_fund_batch_single_entry_unique_by_definition` | Single-entry trivially unique |
| `test_fund_batch_duplicate_then_valid_batch_succeeds` | Escrow stays open; subsequent valid batch works |
| `test_fund_batch_duplicate_check_before_amount_check` | Duplicate guard fires before positivity/floor guards |

### `docs/escrow-error-messages.md`
- Error 84 added to canonical table, legacy strings, range-group table (82–84), and client category mapping (70–84)

### `docs/escrow-lifecycle.md`
- Duplicate-rejection documented in `fund_batch` semantics and capacity sections
- 8 new test rows added to the coverage table

### `README.md`
- Added missing `fund_batch` row to entrypoint table with duplicate-rejection guarantee

---

## Security notes

- **Atomic rejection:** duplicate scan runs entirely before any `fund_impl` call — no partial state possible
- **Bounded scan:** O(n²) over ≤ 50 entries; worst-case 1225 comparisons per call
- **Consistent with tiered discipline:** callers must use separate `fund()` calls for repeat deposits, matching `fund_with_commitment` second-deposit semantics
- **Append-only error code:** 84 is a new discriminant, no existing code renumbered or reused

---

## What was tested

- All 8 new tests pass locally
- Existing `fund_batch` tests (`#82`, `#83`, per-investor cap, mid-batch transition, event semantics) unaffected