### PR TITLE
feat(escrow): add unfund(investor, amount) entrypoint

### DIFF
--- a/docs/escrow-lifecycle.md
+++ b/docs/escrow-lifecycle.md
@@ -20,11 +20,15 @@ forbidden regressions, and interaction rules between `withdraw` vs `settle` path
 ## State diagram
 
 ```text
+  unfund(investor, amount) [investor]
+  (partial or full; status stays 0)
+         │
+         ▼
                 ┌─────────────┐
                 │   (init)    │
-                │  status = 0 │
-                │    open      │
-                └──────┬──────┘
+                │  status = 0 │◄────┐
+                │    open      │     │
+                └──────┬──────┘─────┘
                        │
          ┌─────────────┼──────────────────────┐
          │             │                      │
@@ -140,6 +144,7 @@ let result = fund_batch(entries); // All three processed; status = 1
 |------|----|---------|--------------|
 | `0` (open) | `1` (funded) | `fund()`, `fund_with_commitment()`, or `fund_batch()` when `funded_amount >= funding_target` | Investor auth (per-investor for batch) |
 | `0` (open) | `4` (cancelled) | `cancel_funding()` | Admin auth; legal hold must be inactive |
+| `0` (open) | `0` (open) | `unfund(investor, amount)` | Investor auth; legal hold must be inactive | Partial unfund: `funded_amount` decreases, status stays 0. Full unfund (contribution → 0): `UniqueFunderCount` decrements, status stays 0 |
 | `1` (funded) | `2` (settled) | `settle()` | SME auth; legal hold must be inactive; if `maturity > 0`, ledger timestamp must be >= maturity |
 | `1` (funded) | `3` (withdrawn) | `withdraw()` | SME auth; legal hold must be inactive |
 
@@ -206,6 +211,38 @@ their principal:
 
 ---
 
+## Investor unfund path (status 0 — open)
+
+While an escrow is open, investors may reduce or fully exit their principal position
+without requiring admin cancellation:
+
+1. Investor calls `unfund(investor, amount)` — decrements `DataKey::InvestorContribution`
+   and `InvoiceEscrow::funded_amount` by `amount`.
+2. If contribution reaches zero: `DataKey::InvestorContribution` entry is zeroed,
+   `DataKey::UniqueFunderCount` is decremented (floor: 0).
+3. Status remains 0 (open) in all cases — `unfund` never transitions status.
+4. Tokens are returned to the investor via `external_calls::transfer_funding_token_with_balance_checks`
+   (SEP-41 balance-delta invariants enforced).
+5. `EscrowUnfunded` is emitted with the investor, amount, remaining contribution,
+   new `funded_amount`, and ledger timestamp.
+
+### Invariants
+
+- Investor can only unfund their own contribution; no third-party unfunding.
+- `unfund` is blocked while a legal hold is active (`UnfundLegalHoldActive`, code 222).
+- `unfund` is blocked in any state other than open (0) (`UnfundEscrowNotOpen`, code 220).
+- `amount` must be ≤ `DataKey::InvestorContribution[investor]` (`OverWithdrawal`, code 221).
+- `funded_amount` never goes negative (checked arithmetic).
+- `UniqueFunderCount` never goes negative (saturating_sub).
+
+### Events emitted
+
+| Event | When |
+|-------|------|
+| `EscrowUnfunded` | `unfund()` succeeds |
+
+---
+
 ## SME auth vs admin role
 
 | Function | Role |
@@ -230,12 +267,13 @@ Legal hold blocks all risk-bearing operations regardless of status:
 
 | Function | Blocked by legal hold |
 |----------|----------------------|
+| `cancel_funding()` | Yes |
+| `claim_investor_payout()` | Yes |
 | `fund()` | Yes |
 | `settle()` | Yes |
-| `withdraw()` | Yes |
-| `claim_investor_payout()` | Yes |
-| `cancel_funding()` | Yes |
 | `sweep_terminal_dust()` | Yes |
+| `unfund()` | Yes |
+| `withdraw()` | Yes |
 
 Once legal hold is cleared, normal state transitions resume.
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -564,6 +564,18 @@ pub enum EscrowError {
     WithdrawNetArithmeticUnderflow = 217,
     /// [`LiquifactEscrow::init`] rejected a `funding_deadline` at or after maturity.
     FundingDeadlineAtOrAfterMaturity = 218,
+
+    /// [`LiquifactEscrow::unfund`] called when [`InvoiceEscrow::status`] is not 0 (open).
+    /// Unfunding is only valid while the escrow is still accepting contributions.
+    UnfundEscrowNotOpen = 220,
+
+    /// [`LiquifactEscrow::unfund`] requested amount exceeds the investor's recorded contribution.
+    /// Never withdraw more than was contributed; checked via [`i128::checked_sub`].
+    OverWithdrawal = 221,
+
+    /// [`LiquifactEscrow::unfund`] blocked because a compliance/legal hold is active.
+    /// No fund movement is permitted until the hold is cleared by the admin.
+    UnfundLegalHoldActive = 222,
 }
 
 #[inline(always)]
@@ -597,6 +609,7 @@ pub(crate) fn guard_status_eq(
 ///
 /// Used for terminal-state checks where multiple valid statuses apply (e.g. sweep dust
 /// is allowed in settled/withdrawn/cancelled).
+#[allow(dead_code)]
 #[inline(always)]
 pub(crate) fn guard_status_in(env: &Env, actual_status: u32, allowed: &[u32], error: EscrowError) {
     ensure(env, allowed.contains(&actual_status), error);
@@ -676,7 +689,7 @@ pub(crate) fn guard_not_legal_hold(env: &Env, error: EscrowError) {
 /// `guard_status_in` keep the call-site `ensure` self-documenting at entrypoints.
 #[inline(always)]
 pub(crate) fn is_terminal_status(status: u32) -> bool {
-    matches!(status, 2 | 3 | 4)
+    matches!(status, 2..=4)
 }
 
 /// Predicate: `true` when `status` is one of the **pre-settlement** escrow states
@@ -1390,6 +1403,29 @@ pub struct InvestorRefundedEvt {
     #[topic]
     pub invoice_id: Symbol,
     pub amount: i128,
+}
+
+/// Emitted after a successful [`LiquifactEscrow::unfund`] call.
+///
+/// The investor partially or fully exits their principal position while the escrow
+/// remains open (status 0). Carries the withdrawal amount, the investor's remaining
+/// contribution, the escrow's updated `funded_amount`, and the ledger timestamp.
+#[contractevent]
+pub struct EscrowUnfunded {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    #[topic]
+    pub investor: Address,
+    /// Amount withdrawn in this call.
+    pub amount: i128,
+    /// Investor's remaining contribution after this withdrawal.
+    pub remaining_contribution: i128,
+    /// Escrow's total funded_amount after this withdrawal.
+    pub new_funded_amount: i128,
+    /// Ledger timestamp at which the withdrawal occurred.
+    pub timestamp: u64,
 }
 
 #[contractevent]
@@ -4049,17 +4085,14 @@ impl LiquifactEscrow {
                 (escrow.yield_bps, 0u64)
             } else {
                 // Returning investor: yield was set on first deposit; read it for the event.
+                // If prev > 0, preserve existing effective yield and claim lock.
+                // Read stored yield for the event (falls back to escrow default for new investors).
                 (
                     Self::get_persistent_investor_effective_yield(&env, investor.clone())
                         .unwrap_or(escrow.yield_bps),
                     0u64,
                 )
             }
-            // If prev > 0, preserve existing effective yield and claim lock.
-            // Read stored yield for the event (falls back to escrow default for new investors).
-            let eff = Self::get_persistent_investor_effective_yield(&env, investor.clone())
-                .unwrap_or(escrow.yield_bps);
-            (eff, 0u64)
         } else {
             ensure(&env, prev == 0, EscrowError::TieredSecondDeposit);
             let (eff, lock) =
@@ -5318,6 +5351,109 @@ impl LiquifactEscrow {
             // Apply identical per-investor gates as single refund().
             Self::refund(env.clone(), investor);
         }
+    }
+
+    /// Allow an investor to partially or fully withdraw their principal while the escrow
+    /// remains open (status 0).
+    ///
+    /// An investor may call `unfund` any number of times before the escrow transitions out
+    /// of the open state. Each call decrements the investor's recorded contribution and the
+    /// escrow's `funded_amount` by `amount`, then transfers `amount` tokens back to the
+    /// investor via the SEP-41 balance-delta wrapper.
+    ///
+    /// When the investor's contribution reaches zero the `DataKey::UniqueFunderCount` is
+    /// decremented by one (floor: 0, via saturating arithmetic). Status always remains 0;
+    /// `unfund` never triggers a state transition in either direction.
+    ///
+    /// # Parameters
+    /// - `investor`: The address whose contribution is being reduced. Must match `require_auth`.
+    /// - `amount`: The positive amount to withdraw (must be ≤ recorded contribution).
+    ///
+    /// # Errors
+    /// - [`EscrowError::UnfundEscrowNotOpen`] if `status != 0`.
+    /// - [`EscrowError::UnfundLegalHoldActive`] if a compliance hold is currently active.
+    /// - [`EscrowError::OverWithdrawal`] if `amount` exceeds the investor's contribution.
+    ///
+    /// # Events
+    /// Emits [`EscrowUnfunded`] on success.
+    pub fn unfund(env: Env, investor: Address, amount: i128) -> InvoiceEscrow {
+        // 1. Status guard (read-only; checked before auth to fail fast).
+        let mut escrow = Self::get_escrow(env.clone());
+        ensure(&env, escrow.status == 0, EscrowError::UnfundEscrowNotOpen);
+
+        // 2. Legal-hold guard (read-only; checked before auth to fail fast).
+        ensure(
+            &env,
+            !Self::legal_hold_active(&env),
+            EscrowError::UnfundLegalHoldActive,
+        );
+
+        // 3. Investor auth.
+        investor.require_auth();
+
+        // 4. Over-withdrawal guard: contribution - amount must not underflow.
+        let contribution: i128 = Self::get_persistent_investor_contribution(&env, investor.clone());
+        let remaining_contribution = contribution
+            .checked_sub(amount)
+            .unwrap_or_else(|| fail(&env, EscrowError::OverWithdrawal));
+
+        // Guard: amount must be > 0 (a zero amount would pass checked_sub but is nonsensical).
+        // checked_sub on a negative amount would yield a value > contribution — still caught
+        // above — but a zero withdrawal is explicitly rejected here for clarity.
+        if amount <= 0 {
+            fail(&env, EscrowError::OverWithdrawal);
+        }
+
+        // 5. funded_amount decrement.
+        let new_funded_amount = escrow
+            .funded_amount
+            .checked_sub(amount)
+            .unwrap_or_else(|| fail(&env, EscrowError::OverWithdrawal));
+
+        // 6. Effects — update contribution (checks-effects-interactions).
+        Self::set_persistent_investor_contribution(&env, investor.clone(), remaining_contribution);
+
+        // 7. Decrement UniqueFunderCount when contribution reaches zero.
+        if remaining_contribution == 0 {
+            let cur: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::UniqueFunderCount)
+                .unwrap_or(0);
+            env.storage()
+                .instance()
+                .set(&DataKey::UniqueFunderCount, &cur.saturating_sub(1));
+        }
+
+        // 8. Persist updated escrow.
+        escrow.funded_amount = new_funded_amount;
+        env.storage().instance().set(&DataKey::Escrow, &escrow);
+
+        // 9. Token transfer (interactions last — checks-effects-interactions pattern).
+        let token_addr = Self::funding_token_or_fail(&env);
+        let this = env.current_contract_address();
+        external_calls::transfer_funding_token_with_balance_checks(
+            &env,
+            &token_addr,
+            &this,
+            &investor,
+            amount,
+        );
+
+        // 10. Event emission.
+        let timestamp = env.ledger().timestamp();
+        EscrowUnfunded {
+            name: symbol_short!("unfunded"),
+            invoice_id: escrow.invoice_id.clone(),
+            investor: investor.clone(),
+            amount,
+            remaining_contribution,
+            new_funded_amount,
+            timestamp,
+        }
+        .publish(&env);
+
+        escrow
     }
 
     /// Whether an investor has already received a refund in a cancelled escrow.

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -10,8 +10,8 @@
 use super::{
     AttestationDigestAppended, AttestationDigestRevoked, AttestationDigestUnrevoked,
     CollateralRecordedEvt, ContractUpgraded, DataKey, DeprecatedTransferAdminUsed, EscrowError,
-    EscrowFunded, EscrowInitialized, FundingCancelled, FundingTargetUpdated, InvestorRefundedEvt,
-    LiquifactEscrow, LiquifactEscrowClient, MaturityMaxHorizonUpdated,
+    EscrowFunded, EscrowInitialized, EscrowUnfunded, FundingCancelled, FundingTargetUpdated,
+    InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient, MaturityMaxHorizonUpdated,
     MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept,
     YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH,
     SCHEMA_VERSION,

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -7217,3 +7217,595 @@ fn test_fund_batch_duplicate_leaves_no_partial_state() {
         "inv_b contribution must be zero after duplicate rejection"
     );
 }
+
+// ── unfund entrypoint tests ───────────────────────────────────────────────────
+
+/// Helper: init with a real SAC token and return (client, contract_id, sac_admin, token_id, investor).
+/// The escrow is open (status 0); the investor is funded with `amount` but the escrow
+/// target is `TARGET` so status stays 0.  Tokens are minted to the investor and pulled
+/// by `fund`.  The escrow contract address is also seeded with `amount` so that `unfund`
+/// can push them back.
+fn init_open_with_real_token<'a>(
+    env: &'a Env,
+    amount: i128,
+) -> (
+    LiquifactEscrowClient<'a>,
+    Address, // contract_id
+    crate::tests::StellarTestToken<'a>,
+    Address, // investor
+) {
+    use soroban_sdk::token::StellarAssetClient;
+    let token = install_stellar_asset_token(env);
+    let escrow_id = env.register(LiquifactEscrow, ());
+    let client = LiquifactEscrowClient::new(env, &escrow_id);
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.init(
+        &admin,
+        &String::from_str(env, "UNFUND01"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    let investor = Address::generate(env);
+    // Mint tokens to the investor so fund() can pull them.
+    token.stellar.mint(&investor, &amount);
+    client.fund(&investor, &amount);
+    // Also ensure the escrow contract has enough balance to return the tokens on unfund.
+    // (fund already pulled `amount` into the contract, so the balance is already there.)
+    (client, escrow_id, token, investor)
+}
+
+#[test]
+fn test_unfund_partial() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF001"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&investor, &(TARGET / 4));
+    assert_eq!(client.get_escrow().status, 0);
+
+    let result = client.unfund(&investor, &(TARGET / 8));
+
+    assert_eq!(client.get_contribution(&investor), TARGET / 8);
+    assert_eq!(result.funded_amount, TARGET / 8);
+    assert_eq!(client.get_unique_funder_count(), 1);
+    assert_eq!(result.status, 0);
+}
+
+#[test]
+fn test_unfund_full() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF002"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&investor, &(TARGET / 4));
+    let result = client.unfund(&investor, &(TARGET / 4));
+
+    assert_eq!(client.get_contribution(&investor), 0);
+    assert_eq!(result.funded_amount, 0);
+    assert_eq!(client.get_unique_funder_count(), 0);
+    assert_eq!(result.status, 0);
+}
+
+#[test]
+fn test_unfund_funder_count_floor() {
+    // Inject UniqueFunderCount=0 manually and verify saturating_sub does not underflow.
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let contract_id = client.address.clone();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF003"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&investor, &1i128);
+
+    // Force UniqueFunderCount to 0 (simulating corruption / undercount).
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::UniqueFunderCount, &0u32);
+    });
+
+    // Unfund full contribution — saturating_sub must keep it at 0, not wrap.
+    client.unfund(&investor, &1i128);
+
+    assert_eq!(client.get_unique_funder_count(), 0);
+}
+
+#[test]
+fn test_unfund_over_withdrawal() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF004"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&investor, &1_000i128);
+
+    assert_contract_error(
+        client.try_unfund(&investor, &1_001i128),
+        EscrowError::OverWithdrawal,
+    );
+}
+
+#[test]
+fn test_unfund_wrong_status_funded() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF005"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    // Fund to TARGET — transitions to status 1.
+    client.fund(&investor, &TARGET);
+    assert_eq!(client.get_escrow().status, 1);
+
+    assert_contract_error(
+        client.try_unfund(&investor, &1i128),
+        EscrowError::UnfundEscrowNotOpen,
+    );
+}
+
+#[test]
+fn test_unfund_wrong_status_settled() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF006"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&investor, &TARGET); // status = 1
+    client.settle(); // status = 2
+
+    assert_contract_error(
+        client.try_unfund(&investor, &1i128),
+        EscrowError::UnfundEscrowNotOpen,
+    );
+}
+
+#[test]
+fn test_unfund_wrong_status_withdrawn() {
+    // Uses a real token so withdraw() can actually transfer.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _escrow_id, sme) = init_and_fund_with_real_token(&env, TARGET, "UF007");
+
+    client.settle();
+    client.withdraw(); // status = 3
+
+    assert_contract_error(
+        client.try_unfund(&Address::generate(&env), &1i128),
+        EscrowError::UnfundEscrowNotOpen,
+    );
+}
+
+#[test]
+fn test_unfund_wrong_status_cancelled() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF008"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&investor, &(TARGET / 2));
+    client.cancel_funding(); // status = 4
+
+    assert_contract_error(
+        client.try_unfund(&investor, &1i128),
+        EscrowError::UnfundEscrowNotOpen,
+    );
+}
+
+#[test]
+fn test_unfund_legal_hold_blocked() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF009"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&investor, &(TARGET / 4));
+    client.set_legal_hold(&true);
+
+    assert_contract_error(
+        client.try_unfund(&investor, &1i128),
+        EscrowError::UnfundLegalHoldActive,
+    );
+}
+
+#[test]
+fn test_unfund_requires_investor_auth() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF010"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&investor, &(TARGET / 4));
+    client.unfund(&investor, &(TARGET / 8));
+
+    // Verify that investor auth was required.
+    let auths = env.auths();
+    let investor_authed = auths.iter().any(|(addr, _)| *addr == investor);
+    assert!(investor_authed, "investor auth was not recorded for unfund");
+}
+
+#[test]
+fn test_unfund_no_underflow() {
+    // Exact-boundary: unfund the precise contribution amount — must succeed cleanly.
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF011"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&investor, &1_000i128);
+    client.unfund(&investor, &1_000i128);
+
+    assert_eq!(client.get_contribution(&investor), 0);
+}
+
+#[test]
+fn test_unfund_multiple_investors_isolation() {
+    // Unfunding one investor must not affect another investor's contribution.
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let inv_a = Address::generate(&env);
+    let inv_b = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF012"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&inv_a, &30_000i128);
+    client.fund(&inv_b, &50_000i128);
+
+    // Partially unfund inv_a.
+    let result = client.unfund(&inv_a, &10_000i128);
+
+    assert_eq!(
+        client.get_contribution(&inv_a),
+        20_000i128,
+        "inv_a contribution wrong"
+    );
+    assert_eq!(
+        client.get_contribution(&inv_b),
+        50_000i128,
+        "inv_b contribution must be unchanged"
+    );
+    assert_eq!(result.funded_amount, 70_000i128, "funded_amount wrong");
+}
+
+#[test]
+fn test_unfund_then_fund_again() {
+    // After partially unfunding, the investor can fund again.
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF013"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund(&investor, &20_000i128);
+    client.unfund(&investor, &10_000i128);
+    client.fund(&investor, &5_000i128);
+
+    assert_eq!(client.get_contribution(&investor), 15_000i128);
+    assert_eq!(client.get_escrow().funded_amount, 15_000i128);
+}
+
+#[test]
+fn test_unfund_event_emitted() {
+    // Deploy and fund with a real SAC so `unfund` can actually transfer tokens.
+    // Verify that EscrowUnfunded is emitted with correct fields.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, client) = deploy_with_id(&env);
+
+    let token = install_stellar_asset_token(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let investor = Address::generate(&env);
+
+    let invoice_id = soroban_sdk::Symbol::new(&env, "UF014");
+    let fund_amount = 20_000i128;
+    let unfund_amount = 8_000i128;
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "UF014"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    token.stellar.mint(&investor, &fund_amount);
+    client.fund(&investor, &fund_amount);
+
+    // Clear events from init/fund so we can isolate the unfund event.
+    let _ = env.events().all();
+
+    client.unfund(&investor, &unfund_amount);
+
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+
+    // The last event must be our EscrowUnfunded.
+    let last = events_list
+        .last()
+        .expect("expected at least one event after unfund");
+
+    let expected = EscrowUnfunded {
+        name: symbol_short!("unfunded"),
+        invoice_id,
+        investor: investor.clone(),
+        amount: unfund_amount,
+        remaining_contribution: fund_amount - unfund_amount,
+        new_funded_amount: fund_amount - unfund_amount,
+        timestamp: env.ledger().timestamp(),
+    };
+
+    assert_eq!(*last, expected.to_xdr(&env, &contract_id));
+}


### PR DESCRIPTION
## Summary

Implements the `unfund(investor, amount)` entrypoint, allowing investors to partially or fully exit their principal while the escrow remains open (status 0), without requiring admin cancellation.

## Changes

### `escrow/src/lib.rs`
- **3 new `EscrowError` variants** (append-only, codes 220–222):
  - `UnfundEscrowNotOpen = 220` — called when status ≠ 0
  - `OverWithdrawal = 221` — amount exceeds recorded contribution
  - `UnfundLegalHoldActive = 222` — blocked by compliance hold
- **`EscrowUnfunded` event struct** — emitted on successful unfund
- **`pub fn unfund(env, investor, amount)`** — checks-effects-interactions, SEP-41 token transfer

### `escrow/src/tests/funding.rs`
- 14 new tests covering all specified cases

### `docs/escrow-lifecycle.md`
- State diagram self-loop, valid transitions row, legal hold table, new unfund path section

## Security notes
- Status and legal hold guards before `require_auth()`
- `checked_sub` on contribution and `funded_amount`; `saturating_sub` on `UniqueFunderCount`
- Checks-effects-interactions: storage before token transfer
- SEP-41 conservation via `transfer_funding_token_with_balance_checks`

## Verification
- `cargo fmt --all -- --check` ✅
- `cargo build -p liquifact_escrow` ✅  closes #630