### PR TITLE
refactor(escrow): centralize paginated view window clamping

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -730,6 +730,27 @@ pub(crate) fn validate_maturity_bounds(env: &Env, maturity: u64, max_horizon: u6
     );
 }
 
+/// Resolves the (start, end) window for a collection of `len` items.
+///
+/// Returns `Some((start, end))` when the requested window is non-empty,
+/// or `None` when `start >= len` or `limit == 0`.
+///
+/// The effective page size is capped at `max_batch`, and saturating
+/// arithmetic protects against overflow:
+///
+/// ```ignore
+/// let actual = min(limit, max_batch);
+/// let end    = min(start + actual, len);  // saturating add
+/// ```
+fn paginate(len: u32, start: u32, limit: u32, max_batch: u32) -> Option<(u32, u32)> {
+    if start >= len || limit == 0 {
+        return None;
+    }
+    let actual = limit.min(max_batch);
+    let end = start.saturating_add(actual).min(len);
+    Some((start, end))
+}
+
 // --- Storage keys ---
 
 #[contracttype]
@@ -2601,13 +2622,10 @@ impl LiquifactEscrow {
             .get(&DataKey::InvestorIndex)
             .unwrap_or_else(|| Vec::new(&env));
 
-        let len = index.len();
-        if start >= len || limit == 0 {
-            return Vec::new(&env);
-        }
-
-        let actual_limit = limit.min(MAX_INVESTOR_READ_BATCH);
-        let end = (start + actual_limit).min(len);
+        let (start, end) = match paginate(index.len(), start, limit, MAX_INVESTOR_READ_BATCH) {
+            Some(w) => w,
+            None => return Vec::new(&env),
+        };
 
         let mut result = Vec::new(&env);
         for i in start..end {
@@ -2859,15 +2877,14 @@ impl LiquifactEscrow {
         limit: u32,
     ) -> Vec<AttestationDigestInfo> {
         let log = Self::get_attestation_append_log(env.clone());
-        let len = log.len();
-        if start >= len || limit == 0 {
-            return Vec::new(&env);
-        }
+        let (start, end) = match paginate(log.len(), start, limit, MAX_ATTESTATION_READ_PAGE) {
+            Some(w) => w,
+            None => return Vec::new(&env),
+        };
 
-        let actual_limit = limit.min(MAX_ATTESTATION_READ_PAGE);
         let mut result = Vec::new(&env);
         let mut i = start;
-        while i < len && result.len() < actual_limit {
+        while i < end && result.len() < (end - start) {
             if Self::is_attestation_revoked(env.clone(), i) {
                 let digest = log.get(i).unwrap();
                 result.push_back(AttestationDigestInfo {
@@ -3321,18 +3338,14 @@ impl LiquifactEscrow {
             .get(&DataKey::AllowlistIndex)
             .unwrap_or_else(|| Vec::new(&env));
 
-        let len = index.len();
-        if start >= len || limit == 0 {
-            return Vec::new(&env);
-        }
-
-        let actual_limit = limit.min(50);
-        let end = (start + actual_limit).min(len);
+        let (start, end) = match paginate(index.len(), start, limit, MAX_INVESTOR_READ_BATCH) {
+            Some(w) => w,
+            None => return Vec::new(&env),
+        };
 
         let mut result = Vec::new(&env);
         for i in start..end {
             let addr = index.get(i).unwrap();
-            // Only include addresses that are still allowlisted
             let is_al: bool = env
                 .storage()
                 .persistent()

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -1,6 +1,6 @@
 use super::{
     AllowlistEnabledChanged, DataKey, EscrowError, InvestorAllowlistChanged, LiquifactEscrow,
-    LiquifactEscrowClient,
+    LiquifactEscrowClient, MAX_INVESTOR_READ_BATCH,
 };
 use soroban_sdk::Vec as SorobanVec;
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Error, Event, InvokeError};
@@ -918,4 +918,125 @@ fn gate_batch_revoke_blocks_all_revoked_members() {
     // Contributions remain at the pre-revocation values.
     assert_eq!(client.get_contribution(&a), 1_000i128);
     assert_eq!(client.get_contribution(&b), 1_000i128);
+}
+
+// ── get_allowlisted_investors pagination ──────────────────────────────────
+
+fn add_allowlisted(_env: &Env, client: &LiquifactEscrowClient<'_>, inv: Address) {
+    client.set_investor_allowlisted(&inv, &true);
+}
+
+fn add_allowlisted_n(
+    env: &Env,
+    client: &LiquifactEscrowClient<'_>,
+    n: u32,
+) -> std::vec::Vec<Address> {
+    let mut invs = std::vec::Vec::new();
+    for _ in 0..n {
+        let inv = Address::generate(env);
+        add_allowlisted(env, client, inv.clone());
+        invs.push(inv);
+    }
+    invs
+}
+
+#[test]
+fn test_get_allowlisted_investors_basic_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    client.set_allowlist_active(&true);
+
+    let invs = add_allowlisted_n(&env, &client, 5);
+
+    let page = client.get_allowlisted_investors(&0, &3);
+    assert_eq!(page.len(), 3);
+    assert_eq!(page.get(0).unwrap(), invs[0]);
+    assert_eq!(page.get(1).unwrap(), invs[1]);
+    assert_eq!(page.get(2).unwrap(), invs[2]);
+
+    let page2 = client.get_allowlisted_investors(&3, &3);
+    assert_eq!(page2.len(), 2);
+    assert_eq!(page2.get(0).unwrap(), invs[3]);
+    assert_eq!(page2.get(1).unwrap(), invs[4]);
+}
+
+#[test]
+fn test_get_allowlisted_investors_start_past_end() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    client.set_allowlist_active(&true);
+    add_allowlisted(&env, &client, Address::generate(&env));
+
+    let page = client.get_allowlisted_investors(&5, &10);
+    assert_eq!(page.len(), 0);
+}
+
+#[test]
+fn test_get_allowlisted_investors_zero_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    client.set_allowlist_active(&true);
+    add_allowlisted(&env, &client, Address::generate(&env));
+
+    let page = client.get_allowlisted_investors(&0, &0);
+    assert_eq!(page.len(), 0);
+}
+
+#[test]
+fn test_get_allowlisted_investors_limit_exceeds_remaining() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    client.set_allowlist_active(&true);
+
+    let invs = add_allowlisted_n(&env, &client, 3);
+
+    let page = client.get_allowlisted_investors(&2, &100);
+    assert_eq!(page.len(), 1);
+    assert_eq!(page.get(0).unwrap(), invs[2]);
+}
+
+#[test]
+fn test_get_allowlisted_investors_filters_unallowlisted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    client.set_allowlist_active(&true);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    add_allowlisted(&env, &client, a.clone());
+    add_allowlisted(&env, &client, b.clone());
+    add_allowlisted(&env, &client, c.clone());
+
+    // Revoke b from allowlist.
+    client.set_investor_allowlisted(&b, &false);
+
+    let page = client.get_allowlisted_investors(&0, &5);
+    assert_eq!(page.len(), 2);
+    assert_eq!(page.get(0).unwrap(), a);
+    assert_eq!(page.get(1).unwrap(), c);
+}
+
+#[test]
+fn test_get_allowlisted_investors_caps_at_max_batch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    client.set_allowlist_active(&true);
+
+    add_allowlisted_n(&env, &client, MAX_INVESTOR_READ_BATCH + 5);
+
+    let page = client.get_allowlisted_investors(&0, &u32::MAX);
+    assert_eq!(page.len(), MAX_INVESTOR_READ_BATCH);
 }

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -770,6 +770,17 @@ fn test_revoked_digests_view_pagination_and_empty_past_end() {
 }
 
 #[test]
+fn test_revoked_digests_view_zero_limit() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0xAA));
+    client.revoke_attestation_digest(&0);
+
+    let page = client.get_revoked_attestation_digests(&0, &0);
+    assert_eq!(page.len(), 0);
+}
+
+#[test]
 #[ignore = "branch-specific latent failure"]
 fn test_revoked_digests_view_caps_limit() {
     let env = Env::default();

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -5600,6 +5600,29 @@ fn test_get_investors_legacy_compatibility() {
     assert_eq!(investors.len(), 0);
 }
 
+#[test]
+fn test_get_investors_pagination_edge_cases() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    for _ in 0..3 {
+        client.fund(&Address::generate(&env), &1_000i128);
+    }
+
+    // Start past the end
+    let past = client.get_investors(&5, &10);
+    assert_eq!(past.len(), 0);
+
+    // Zero limit
+    let zero = client.get_investors(&0, &0);
+    assert_eq!(zero.len(), 0);
+
+    // Limit exceeding remaining items (start=2 with 3 total → 1 remaining)
+    let overflow = client.get_investors(&2, &100);
+    assert_eq!(overflow.len(), 1);
+}
+
 // ---------------------------------------------------------------------------
 
 // update_funding_target: rejection bounds and mid-update funded promotion


### PR DESCRIPTION
closes #659 

## Refactor: Centralize paginated view window clamping

### Motivation

`get_investors`, `get_allowlisted_investors`, and `get_revoked_attestation_digests` each re-implement the same start/limit window clamping against a backing collection length. The duplicated arithmetic is the kind of code where one path silently drifts into an off-by-one or an underflow.

### Changes

**`escrow/src/lib.rs`** — Added a private `paginate` free function with saturating arithmetic:

```rust
fn paginate(len: u32, start: u32, limit: u32, max_batch: u32) -> Option<(u32, u32)>
```

Returns `Some((start, end))` when the window is non-empty, `None` when `start >= len` or `limit == 0`. The effective limit is capped at `max_batch`, and `end = saturating_add(start, actual_limit).min(len)`.

All three paginated views now call `paginate` instead of inlining the bounds logic:

| Function | Before | After |
|---|---|---|
| `get_investors` | Inline `start >= len`, `limit.min(MAX_INVESTOR_READ_BATCH)`, `(start + actual).min(len)` | `paginate(index.len(), start, limit, MAX_INVESTOR_READ_BATCH)` |
| `get_allowlisted_investors` | Inline same pattern with hardcoded `50` | `paginate(index.len(), start, limit, MAX_INVESTOR_READ_BATCH)` (uses constant) |
| `get_revoked_attestation_digests` | Inline early-return and `limit.min(MAX_ATTESTATION_READ_PAGE)` | `paginate(log.len(), start, limit, MAX_ATTESTATION_READ_PAGE)`, scan bound changed from `len` to `end` |

The `get_allowlisted_investors` hardcoded cap of `50` was replaced with the existing `MAX_INVESTOR_READ_BATCH` constant (also `50`), making the intent explicit.

`get_revoked_attestation_digests` now stops its scan at the computed page end rather than scanning through the entire tail to fill sparse pages. This makes pagination behavior consistent across all three views.

**Public signatures and return types are unchanged.**

### Tests

| Test file | New tests | Coverage |
|---|---|---|
| `tests/funding.rs` | `test_get_investors_pagination_edge_cases` | Start past end, zero limit, limit exceeding remaining |
| `tests/attestations.rs` | `test_revoked_digests_view_zero_limit` | Zero limit |
| `test_allowlist_tests.rs` | 6 new tests | Basic pagination, start past end, zero limit, limit exceeding remaining, filtering un-allowlisted, max-batch cap |

All **848 unit tests pass** (0 failures, 54 pre-existing ignores).

### Verification

- `cargo fmt -p liquifact_escrow -- --check` — passed
- `cargo build` — passed
- `cargo test -p liquifact_escrow --lib` — passed (848 passed, 0 failed)
