### PR TITLE
refactor(escrow): remove duplicate coll_clr event emission

### DIFF
--- a/docs/escrow-sme-collateral.md
+++ b/docs/escrow-sme-collateral.md
@@ -93,17 +93,9 @@ pub struct CollateralClearedEvt {
     pub invoice_id: Symbol,
     pub asset: Symbol,    // carried from the pledge at the time of removal
     pub amount: i128,   // carried from the pledge at the time of removal
-    pub recorded_at: u64, // original pledge ledger timestamp
-}
-
-pub struct CollateralCommitmentCleared {
-    pub name: Symbol,   // coll_clr
-    pub invoice_id: Symbol,
-    pub asset: Symbol,
-    pub amount: i128,
-    pub recorded_at: u64,
-}
-```
+            pub recorded_at: u64, // original pledge ledger timestamp
+        }
+        ```
 
 ---
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1350,23 +1350,6 @@ pub struct CollateralClearedEvt {
     pub recorded_at: u64,
 }
 
-/// Emitted after [`LiquifactEscrow::clear_sme_collateral_commitment`] removes
-/// the SME-reported collateral metadata.
-///
-/// This supplements [`CollateralClearedEvt`] with a short event name and the
-/// full cleared commitment identity so indexers can reconstruct the
-/// record-to-clear lifecycle without a storage read after removal.
-#[contractevent]
-pub struct CollateralCommitmentCleared {
-    #[topic]
-    pub name: Symbol,
-    #[topic]
-    pub invoice_id: Symbol,
-    pub asset: Symbol,
-    pub amount: i128,
-    pub recorded_at: u64,
-}
-
 #[contractevent]
 pub struct SmeWithdrew {
     #[topic]
@@ -2718,15 +2701,6 @@ impl LiquifactEscrow {
             .remove(&DataKey::SmeCollateralPledge);
 
         CollateralClearedEvt {
-            name: symbol_short!("coll_clr"),
-            invoice_id: escrow.invoice_id.clone(),
-            asset: commitment.asset.clone(),
-            amount: commitment.amount,
-            recorded_at: commitment.recorded_at,
-        }
-        .publish(&env);
-
-        CollateralCommitmentCleared {
             name: symbol_short!("coll_clr"),
             invoice_id: escrow.invoice_id.clone(),
             asset: commitment.asset.clone(),

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -12,7 +12,7 @@ use crate::{
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events as _, Ledger},
-    Address, BytesN, Env, Error, InvokeError, Vec as SorobanVec,
+    Address, BytesN, Env, Error, Event, InvokeError, Vec as SorobanVec,
 };
 
 const AMOUNT: i128 = 100_000_000_000;
@@ -1092,7 +1092,44 @@ fn test_overwrite_then_clear() {
     assert!(client.get_sme_collateral_commitment().is_none());
 }
 
-// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+#[test]
+fn test_clear_emits_exactly_one_coll_clr_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+
+    let asset = symbol_short!("USDC");
+    client.record_sme_collateral_commitment(&asset, &PLEDGE);
+
+    // Clear the event buffer so we only measure the clear operation
+    let _ = env.events().all();
+    client.clear_sme_collateral_commitment();
+
+    let contract_events = env.events().all().filter_by_contract(&contract_id);
+    let events = contract_events.events();
+    assert_eq!(
+        events.len(),
+        1,
+        "clear_sme_collateral_commitment must emit exactly one event"
+    );
+
+    let invoice_id = client.get_escrow().invoice_id;
+    assert_eq!(
+        events.last().unwrap().clone(),
+        CollateralClearedEvt {
+            name: symbol_short!("coll_clr"),
+            invoice_id,
+            asset,
+            amount: PLEDGE,
+            recorded_at: env.ledger().timestamp(),
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // Anchoring tests: read-view default/absent return values (docs/escrow-read-api.md)
 //
 // Each test asserts the default or absent-key return value documented in the


### PR DESCRIPTION
closes #658 
## Description

`clear_sme_collateral_commitment()` emitted two separate `#[contractevent]` structs — `CollateralClearedEvt` and `CollateralCommitmentCleared` — both carrying the identical topic symbol `symbol_short!("coll_clr")` and the same field payload (`invoice_id`, `asset`, `amount`, `recorded_at`). Downstream indexers filtering on `coll_clr` observed two logically equivalent events per call and could not distinguish which was authoritative.

## Changes

| File | Change |
|------|--------|
| `escrow/src/lib.rs` | Removed `CollateralCommitmentCleared` struct definition (dead code) |
| `escrow/src/lib.rs` | Removed the duplicate `CollateralCommitmentCleared.publish()` block from `clear_sme_collateral_commitment` |
| `docs/escrow-sme-collateral.md` | Removed `CollateralCommitmentCleared` struct documentation |
| `escrow/src/tests/coverage.rs` | Added `test_clear_emits_exactly_one_coll_clr_event` asserting exactly one event per successful clear with payload verification |

## Rationale

- `CollateralClearedEvt` is the authoritative event — all existing documentation (README, audit handoff, event schema, escrow events doc) references it as the emitted event.
- `CollateralCommitmentCleared` was added later as a "supplement" but the original emission was never removed, creating the duplicate.
- Every field observable to indexers is preserved — `CollateralClearedEvt` carries the identical field set under the same `coll_clr` symbol.
- The change is additive from a consumer's point of view: one event instead of two, same shape.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo build` — clean
- `cargo test` — 841 passed, 0 failed, 54 ignored
