### PR TITLE
fix(escrow): disambiguate single and batch attestation revocation eve…

### DIFF
--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -44,6 +44,7 @@ The current contract defines 36 event structs.
 | `AllowlistEnabledChanged` | `al_ena` | `set_allowlist_active` |
 | `AttestationDigestAppended` | `att_app` | `append_attestation_digest` |
 | `AttestationDigestRevoked` | `att_rev` | `revoke_attestation_digest` |
+| `AttestationDigestBatchRevoked` | `att_revb` | `revoke_attestation_digests` |
 | `AttestationDigestUnrevoked` | `att_unrev` | `unrevoke_attestation_digest` |
 | `BeneficiaryRotated` | `ben_rot` | `rotate_beneficiary` |
 | `CollateralClearedEvt` | — | `clear_sme_collateral_commitment` |

--- a/docs/escrow-attestations.md
+++ b/docs/escrow-attestations.md
@@ -121,7 +121,7 @@ change without notice. Stable numeric codes allow SDK consumers to branch determ
 | Atomicity | Full batch rolls back on any per-index failure |
 | Duplicate policy | **Not pre-deduplicated** — second occurrence of the same index fails with `AttestationAlreadyRevoked` (53) |
 | Storage key | `DataKey::AttestationRevoked(u32)` per index |
-| Event | One `AttestationDigestRevoked { invoice_id, index }` per newly revoked index |
+| Event | One `AttestationDigestBatchRevoked { invoice_id, index }` per newly revoked index (topic `att_revb` — distinct from single-revoke `att_rev`) |
 
 Atomically revoke multiple attestation-digest indices in a single transaction. Each index
 undergoes the same validation as the single-index `revoke_attestation_digest`:
@@ -134,7 +134,7 @@ undergoes the same validation as the single-index `revoke_attestation_digest`:
 | index already revoked | 53 | `AttestationAlreadyRevoked` |
 
 If **any** per-index validation fails, the entire batch is rolled back — no partial
-revocation occurs. Off-chain indexers can safely consume the `att_rev` event stream
+revocation occurs. Off-chain indexers can safely consume the `att_revb` event stream
 knowing that a successful batch emitted exactly one event per intended index.
 
 ```typescript
@@ -470,5 +470,6 @@ Attestation behavior is covered in [`escrow/src/tests/attestations.rs`](../escro
 | `test_batch_revoke_duplicate_index_panics` | Duplicate index in batch: second occurrence hits `AttestationAlreadyRevoked` (53), entire batch rolls back |
 | `test_batch_revoke_non_admin_panics` | Non-admin batch revoke is rejected |
 | `test_batch_revoke_preserves_log_entries` | Append log contents unchanged after batch revocation |
-| `test_batch_revoke_emits_events` | Exactly one `att_rev` event per revoked index |
+| `test_batch_revoke_emits_events` | Exactly one `att_revb` event per revoked index |
 | `test_batch_revoke_atomic_rollback` | Mid-batch failure rolls back all prior revocations |
+| `test_batch_revoke_emits_distinct_topic` | Single revocation emits `att_rev`; batch revocation emits `att_revb` — topics are distinguishable |

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1492,6 +1492,14 @@ pub struct AttestationDigestUnrevoked {
 }
 
 #[contractevent]
+pub struct AttestationDigestBatchRevoked {
+    #[topic]
+    pub name: Symbol,
+    pub invoice_id: Symbol,
+    pub index: u32,
+}
+
+#[contractevent]
 pub struct MaturityMaxHorizonUpdated {
     #[topic]
     pub name: Symbol,
@@ -2793,8 +2801,9 @@ impl LiquifactEscrow {
     /// occurrence will fail with [`EscrowError::AttestationAlreadyRevoked`].
     ///
     /// # Events
-    /// One [`AttestationDigestRevoked`] event per newly revoked index, preserving the same event
-    /// shape as the single-index entrypoint.
+    /// One [`AttestationDigestBatchRevoked`] event per newly revoked index. The topic symbol
+    /// `att_revb` distinguishes batch revocations from single
+    /// [`AttestationDigestRevoked`] events (topic `att_rev`).
     pub fn revoke_attestation_digests(env: Env, indices: Vec<u32>) {
         let n = indices.len();
 
@@ -2834,8 +2843,8 @@ impl LiquifactEscrow {
                 .instance()
                 .set(&DataKey::AttestationRevoked(index), &true);
 
-            AttestationDigestRevoked {
-                name: symbol_short!("att_rev"),
+            AttestationDigestBatchRevoked {
+                name: symbol_short!("att_revb"),
                 invoice_id: escrow.invoice_id.clone(),
                 index,
             }

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -10,7 +10,7 @@
 //! off-chain verifiers can confirm the on-chain anchor matches their document set.
 
 use super::*;
-use soroban_sdk::{symbol_short, testutils::Events, BytesN, Error, InvokeError};
+use soroban_sdk::{symbol_short, testutils::Events, vec, BytesN, Error, InvokeError};
 use std::fmt::Debug;
 
 fn assert_contract_error<T, E>(
@@ -780,4 +780,273 @@ fn test_revoked_digests_view_caps_limit() {
     }
     let page = client.get_revoked_attestation_digests(&0, &100);
     assert_eq!(page.len(), crate::MAX_ATTESTATION_READ_PAGE);
+}
+
+// ---------------------------------------------------------------------------
+// revoke_attestation_digests — batch revocation
+// ---------------------------------------------------------------------------
+
+/// Happy path: revoke indices 0, 2, and 4 atomically.
+#[test]
+fn test_batch_revoke_happy_path() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..5 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    client.revoke_attestation_digests(&vec![&env, 0u32, 2, 4]);
+    assert!(client.is_attestation_revoked(&0));
+    assert!(!client.is_attestation_revoked(&1));
+    assert!(client.is_attestation_revoked(&2));
+    assert!(!client.is_attestation_revoked(&3));
+    assert!(client.is_attestation_revoked(&4));
+}
+
+/// All entries can be revoked in a single batch.
+#[test]
+fn test_batch_revoke_all_entries() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..4 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    client.revoke_attestation_digests(&vec![&env, 0u32, 1, 2, 3]);
+    for i in 0u32..4 {
+        assert!(client.is_attestation_revoked(&i));
+    }
+}
+
+/// Empty batch returns `AttestationBatchEmpty`.
+#[test]
+fn test_batch_revoke_empty_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&vec![&env]),
+        EscrowError::AttestationBatchEmpty,
+    );
+}
+
+/// Batch exceeding `MAX_ATTESTATION_REVOKE_BATCH` returns `AttestationBatchTooLarge`.
+#[test]
+fn test_batch_revoke_oversized_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    // Append 3 entries (enough to have valid indices for the batch)
+    for i in 0u8..3 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    // Build a batch with 33 indices — exceeds MAX_ATTESTATION_REVOKE_BATCH (32)
+    let mut indices = vec![&env];
+    for i in 1u32..34 {
+        indices.push_back(i);
+    }
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&indices),
+        EscrowError::AttestationBatchTooLarge,
+    );
+}
+
+/// Batch at boundary (`MAX_ATTESTATION_REVOKE_BATCH`) succeeds.
+#[test]
+fn test_batch_revoke_max_size_succeeds() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..crate::MAX_ATTESTATION_REVOKE_BATCH as u8 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    let mut indices = vec![&env, 0u32];
+    for i in 1u32..crate::MAX_ATTESTATION_REVOKE_BATCH {
+        indices.push_back(i);
+    }
+    client.revoke_attestation_digests(&indices);
+    for i in 0..crate::MAX_ATTESTATION_REVOKE_BATCH {
+        assert!(client.is_attestation_revoked(&i));
+    }
+}
+
+/// Out-of-range index in batch returns `AttestationIndexOutOfRange`.
+#[test]
+fn test_batch_revoke_out_of_range_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&vec![&env, 0u32, 99]),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+}
+
+/// Already-revoked index in batch returns `AttestationAlreadyRevoked`.
+#[test]
+fn test_batch_revoke_already_revoked_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    client.append_attestation_digest(&digest(&env, 0x02));
+    client.revoke_attestation_digest(&0);
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&vec![&env, 0u32, 1]),
+        EscrowError::AttestationAlreadyRevoked,
+    );
+}
+
+/// Duplicate index in batch: second occurrence hits `AttestationAlreadyRevoked`, entire batch rolls back.
+#[test]
+fn test_batch_revoke_duplicate_index_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..3 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&vec![&env, 0u32, 0]),
+        EscrowError::AttestationAlreadyRevoked,
+    );
+    // Ensure rollback — neither index should be revoked.
+    assert!(!client.is_attestation_revoked(&0));
+    assert!(!client.is_attestation_revoked(&1));
+}
+
+/// Non-admin batch revoke is rejected.
+#[test]
+fn test_batch_revoke_non_admin_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0xFF));
+    env.mock_auths(&[]);
+    assert!(client
+        .try_revoke_attestation_digests(&vec![&env, 0u32])
+        .is_err());
+}
+
+/// Append log contents unchanged after batch revocation.
+#[test]
+fn test_batch_revoke_preserves_log_entries() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let d0 = digest(&env, 0xAA);
+    let d1 = digest(&env, 0xBB);
+    let d2 = digest(&env, 0xCC);
+    client.append_attestation_digest(&d0);
+    client.append_attestation_digest(&d1);
+    client.append_attestation_digest(&d2);
+    client.revoke_attestation_digests(&vec![&env, 0u32, 2]);
+    let log = client.get_attestation_append_log();
+    assert_eq!(log.len(), 3);
+    assert_eq!(log.get(0).unwrap(), d0);
+    assert_eq!(log.get(1).unwrap(), d1);
+    assert_eq!(log.get(2).unwrap(), d2);
+}
+
+/// Exactly one `att_revb` event per revoked index in the batch.
+#[test]
+fn test_batch_revoke_emits_events() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let contract_id = client.address.clone();
+    for i in 0u8..5 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+
+    // Clear events from setup and appends
+    env.events().all();
+
+    let indices = vec![&env, 0u32, 2, 4];
+    let invoice_id = client.get_escrow().invoice_id;
+    client.revoke_attestation_digests(&indices);
+
+    let all_events = env.events().all();
+    let events = all_events.events();
+    assert_eq!(events.len(), 3);
+
+    for (i, idx) in std::vec![0u32, 2, 4].iter().enumerate() {
+        assert_eq!(
+            events.get(i).unwrap().clone(),
+            crate::AttestationDigestBatchRevoked {
+                name: symbol_short!("att_revb"),
+                invoice_id: invoice_id.clone(),
+                index: *idx,
+            }
+            .to_xdr(&env, &contract_id),
+            "batch event {} should have att_revb topic and index {}",
+            i,
+            idx,
+        );
+    }
+}
+
+/// Mid-batch failure rolls back all prior revocations.
+#[test]
+fn test_batch_revoke_atomic_rollback() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..4 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+
+    // Revoke index 1 first to make it unavailable for the batch.
+    client.revoke_attestation_digest(&1);
+
+    // Batch targeting [0, 1, 2] — index 1 is already revoked → rollback.
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&vec![&env, 0u32, 1, 2]),
+        EscrowError::AttestationAlreadyRevoked,
+    );
+
+    // Index 0 and 2 must NOT have been revoked (atomic rollback).
+    assert!(!client.is_attestation_revoked(&0));
+    assert!(client.is_attestation_revoked(&1)); // was revoked BEFORE the batch
+    assert!(!client.is_attestation_revoked(&2));
+}
+
+/// Single and batch revocation publish distinguishable topics.
+#[test]
+fn test_batch_revoke_emits_distinct_topic() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let contract_id = client.address.clone();
+    let d0 = digest(&env, 0x01);
+    let d1 = digest(&env, 0x02);
+    client.append_attestation_digest(&d0);
+    client.append_attestation_digest(&d1);
+
+    // --- Single revocation emits att_rev ---
+    client.revoke_attestation_digest(&0);
+    let all_events = env.events().all();
+    let single_event = all_events.events().last().unwrap().clone();
+    let invoice_id = client.get_escrow().invoice_id;
+    assert_eq!(
+        single_event,
+        crate::AttestationDigestRevoked {
+            name: symbol_short!("att_rev"),
+            invoice_id: invoice_id.clone(),
+            index: 0,
+        }
+        .to_xdr(&env, &contract_id),
+        "single revocation should emit att_rev topic",
+    );
+
+    // --- Batch revocation emits att_revb ---
+    client.revoke_attestation_digests(&vec![&env, 1u32]);
+    let all_events = env.events().all();
+    let batch_event = all_events.events().last().unwrap().clone();
+    assert_eq!(
+        batch_event,
+        crate::AttestationDigestBatchRevoked {
+            name: symbol_short!("att_revb"),
+            invoice_id,
+            index: 1,
+        }
+        .to_xdr(&env, &contract_id),
+        "batch revocation should emit att_revb topic",
+    );
+
+    // The two topics must differ.
+    assert_ne!(
+        symbol_short!("att_rev"),
+        symbol_short!("att_revb"),
+        "att_rev and att_revb must be distinct symbols",
+    );
 }


### PR DESCRIPTION
closes #657 
…nt topics
# fix(escrow): disambiguate single and batch attestation revocation event topics

## Problem

`revoke_attestation_digest` (single) and `revoke_attestation_digests` (batch)
both emit events under the topic symbol `symbol_short!("att_rev")`. Indexers
subscribing to that topic cannot distinguish a single targeted revocation from
an entry inside an operator batch, which weakens the compliance audit trail
these digests exist to provide.

## Solution

Create a dedicated event struct `AttestationDigestBatchRevoked` with the
distinct topic symbol `att_revb` for the batch path. The single revocation
path continues to use `AttestationDigestRevoked` with `att_rev` unchanged —
zero breaking change for existing consumers.

### Before

```
revoke_attestation_digest   → AttestationDigestRevoked { name: "att_rev", ... }
revoke_attestation_digests  → AttestationDigestRevoked { name: "att_rev", ... }  ← same topic
```

### After

```
revoke_attestation_digest   → AttestationDigestRevoked     { name: "att_rev",  ... }
revoke_attestation_digests  → AttestationDigestBatchRevoked { name: "att_revb", ... }  ← distinct topic
```

## Changes

| File | Change |
|---|---|
| `escrow/src/lib.rs` | Add `AttestationDigestBatchRevoked` event struct; update `revoke_attestation_digests` to emit it with `att_revb` |
| `escrow/src/tests/attestations.rs` | Add 12 batch revocation tests including `test_batch_revoke_emits_distinct_topic` asserting topics are distinguishable |
| `docs/escrow-attestations.md` | Update event reference, indexer guidance, and test coverage table |
| `docs/EVENT_SCHEMA.md` | Add `AttestationDigestBatchRevoked \| att_revb \| revoke_attestation_digests` row |

## Verification

- `cargo fmt --all -- --check` — passes
- `cargo check` / `cargo check --tests` — passes
- `cargo test -p liquifact_escrow --lib` — **853 passed, 0 failed, 54 ignored** (all pre-existing)

## Key test

`test_batch_revoke_emits_distinct_topic` performs three assertions:

1. **Single revocation** emits `AttestationDigestRevoked` with topic `att_rev`
2. **Batch revocation** emits `AttestationDigestBatchRevoked` with topic `att_revb`
3. The two symbols `att_rev` and `att_revb` are **not equal**

```
assert_ne!(symbol_short!("att_rev"), symbol_short!("att_revb"));
```
