### PR TITLE
docs(escrow): document the shared start/limit pagination contract

### DIFF
--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -72,6 +72,9 @@ re-implementing storage reads to guarantee identical semantics.
 - [get_distributed_principal](#get_distributed_principal--i128)
 - [get_reconciliation](#get_reconciliation--reconciliationview)
 
+**Paginated Enumeration:**
+- [Paginated Enumeration](#paginated-enumeration)
+
 ---
 
 ## Core Escrow State
@@ -799,3 +802,43 @@ Returns the yield-tier ladder configured at `init`, or an empty `Vec` when no ti
 |-------|------|-------------|
 | `min_lock_secs` | `u64` | Minimum `committed_lock_secs` an investor must pass to qualify for this tier |
 | `yield_bps` | `i64` | Effective annualized yield in basis points for qualifying investors |
+
+---
+
+## Paginated Enumeration
+
+`get_investors`, `get_allowlisted_investors`, and `get_revoked_attestation_digests` share one `(start, limit)` contract. Both args are `u32`; `start` is a zero-based index position and `limit` is clamped (never rejected) to a per-view maximum. See docs/escrow-indexer.md for how indexers poll these.
+
+All three apply the same guard first:
+
+```text
+len = length of backing index/log   // absent key => 0
+if start >= len || limit == 0 { return empty Vec }
+```
+
+So `start >= len` or `limit == 0` returns an empty `Vec` (never panics), and an absent backing key behaves as `len == 0`. All three are pure reads (no auth, no writes, no TTL bump). Every backing collection is append-only, so a given `start` keeps addressing the same position as new entries are appended at the tail; already-read pages stay stable.
+
+| View | Backing key | Max limit | Page shape |
+|------|-------------|-----------|------------|
+| `get_investors` | `InvestorIndex` | `MAX_INVESTOR_READ_BATCH` = 50 | Unfiltered half-open slice |
+| `get_allowlisted_investors` | `AllowlistIndex` | 50 | Half-open slice, then filtered |
+| `get_revoked_attestation_digests` | `AttestationAppendLog` | `MAX_ATTESTATION_READ_PAGE` = 20 | Forward scan for matches |
+
+**get_investors** returns `index[start .. min(start + min(limit,50), len)]` in first-funded order, one address per position. Detect the last page when the returned length is below your page size; otherwise call again with `start += page_size`.
+
+**get_allowlisted_investors** walks the same window over `AllowlistIndex` but drops addresses whose live `InvestorAllowlisted(addr)` flag is no longer true (revoked entries stay in the index and are skipped at read time). A page may be shorter than the window, so a short or empty page is NOT end-of-list. Advance `start` by the page size each call and stop once `start >= len`. Note `get_allowlisted_investors_count` returns only the live count, not the index length.
+
+**get_revoked_attestation_digests** scans forward from `start` collecting up to `min(limit,20)` revoked entries, skipping non-revoked ones; it stops on match count, not positions scanned, and does not report where it stopped. The log is capped at 32 entries, so `start = 0` then `start = 20` covers any instance. Read the log length from `get_attestation_log_stats` or `get_escrow_summary().attestation_log_length`; do not derive the next `start` from the returned length.
+
+Worked loop (full investor enumeration, 50 at a time):
+
+```text
+start = 0
+page_size = 50
+loop {
+    page = get_investors(start, page_size)
+    process(page)
+    if page.len() < page_size { break }   // last page
+    start += page_size
+}
+```


### PR DESCRIPTION
What
Adds a Paginated Enumeration section to docs/escrow-read-api.md (plus an Index entry) documenting the shared (start, limit) contract used by get_investors, get_allowlisted_investors, and get_revoked_attestation_digests.
Why
The three read views share identical window math and edge cases that are easy to get wrong when reimplemented off-chain. Specifying the contract once keeps indexers consistent.
Covers
The shared guard (start >= len || limit == 0 → empty Vec; absent key behaves as len == 0), that limit is clamped (never rejected), and that all three are pure, append-only, stable reads.
Per-view caps: get_investors 50 (MAX_INVESTOR_READ_BATCH), get_allowlisted_investors 50, get_revoked_attestation_digests 20 (MAX_ATTESTATION_READ_PAGE).
Per-view paging caveats — the allowlist filter means a short/empty page is not end-of-list, and the attestation view stops on match count (use get_attestation_log_stats / get_escrow_summary().attestation_log_length for length).
A worked enumeration loop.
Docs-only; no code or behavior changes.
Closes #665