### PR TITLE
fix(escrow): bound bump_ttl batch length with a typed error

### DIFF
--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -42,6 +42,7 @@ Codes are grouped by domain so SDKs can map coarse categories without parsing va
 | Legal-hold clear (two-phase) | 150–152 | Delayed compliance-hold lift workflow | 150, 152 |
 | Beneficiary rotation | 160–162 | Governed SME address rotation | 160, 162 |
 | Funding deadline / balance | 163–164 | Post-deadline funding and contract balance sufficiency | 163, 164 |
+| TTL batch | 223–224 | `bump_ttl` batch bounds for permissionless TTL extension | 223, 224 |
 
 See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 [`docs/ESCROW_BENEFICIARY_ROTATION.md`](ESCROW_BENEFICIARY_ROTATION.md), and
@@ -152,6 +153,8 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 203 | `FundingDeadlineNotExtended` | `extend_funding_deadline` | `new_deadline <= current` | Pass a strictly later deadline | typed |
 | 204 | `FundingDeadlineBeyondMaturity` | `init`, `extend_funding_deadline` | deadline at or beyond maturity | Keep deadline before maturity | typed |
 | 205 | `FundingDeadlineNotSet` | `extend_funding_deadline` | no deadline configured | Set deadline at init first | typed |
+| 223 | `BumpTtlBatchEmpty` | `bump_ttl` | `allowlisted.len() == 0` | Pass at least one address | typed |
+| 224 | `BumpTtlBatchTooLarge` | `bump_ttl` | `allowlisted.len() > MAX_BUMP_TTL_BATCH` | Split into smaller batches | typed |
 
 ### Legacy panic strings (migration aid)
 
@@ -247,6 +250,8 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 162 | `New SME address must differ from current beneficiary` |
 | 163 | `Funding deadline has passed` |
 | 164 | `Contract balance below funded amount` |
+| 223 | `bump_ttl allowlisted vector must be non-empty` |
+| 224 | `bump_ttl allowlisted vector length exceeds MAX_BUMP_TTL_BATCH` |
 
 ## Client Guidance
 
@@ -270,6 +275,7 @@ Recommended SDK category mappings:
 | 140–143 | Cancellation or refund failure |
 | 150–152 | Legal-hold clear workflow failure |
 | 160–162 | Beneficiary rotation failure |
+| 223–224 | TTL batch bounds failure |
 
 ## Security Notes
 

--- a/docs/escrow-gas-storage-notes.md
+++ b/docs/escrow-gas-storage-notes.md
@@ -82,6 +82,9 @@ Key properties (invariant):
 
 - **Extension never shortens** an existing TTL.
 - **No state mutation beyond TTL extension**: `bump_ttl` only calls `extend_ttl(...)`.
+- **Batch size bounded**: `allowlisted` is capped at [`MAX_BUMP_TTL_BATCH`](../escrow/src/lib.rs) (32) to
+  limit per-call storage work. An empty vector is rejected with [`EscrowError::BumpTtlBatchEmpty`]
+  (223) and an oversized vector with [`EscrowError::BumpTtlBatchTooLarge`] (224).
 
 ### Thresholds
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -237,6 +237,12 @@ pub const MAX_REFUND_BATCH: u32 = 50;
 /// Upper bound on [`LiquifactEscrow::set_investors_allowlisted`] batch size.
 pub const MAX_INVESTOR_ALLOWLIST_BATCH: u32 = 32;
 
+/// Upper bound on [`LiquifactEscrow::bump_ttl`] allowlisted addresses to cap per-call storage work.
+///
+/// This entrypoint is permissionless; the length cap is the sole mitigation against
+/// unbounded iteration. Must be non-empty to invoke.
+pub const MAX_BUMP_TTL_BATCH: u32 = 32;
+
 /// Upper bound on [`LiquifactEscrow::get_contributions`] / investor read batch size.
 pub const MAX_INVESTOR_READ_BATCH: u32 = 50;
 
@@ -576,6 +582,11 @@ pub enum EscrowError {
     /// [`LiquifactEscrow::unfund`] blocked because a compliance/legal hold is active.
     /// No fund movement is permitted until the hold is cleared by the admin.
     UnfundLegalHoldActive = 222,
+
+    /// [`LiquifactEscrow::bump_ttl`] received an empty allowlisted vector.
+    BumpTtlBatchEmpty = 223,
+    /// [`LiquifactEscrow::bump_ttl`] exceeded [`MAX_BUMP_TTL_BATCH`].
+    BumpTtlBatchTooLarge = 224,
 }
 
 #[inline(always)]
@@ -4962,6 +4973,15 @@ impl LiquifactEscrow {
         // Documentation references:
         // - ADR-007: storage key evolution policy (additive changes / key semantics).
         // - docs/escrow-ledger-time.md: all gating uses `Env::ledger().timestamp()` with `>=`.
+
+        // Reject empty or oversized batches to cap per-call storage work.
+        let n = allowlisted.len();
+        ensure(&env, n > 0, EscrowError::BumpTtlBatchEmpty);
+        ensure(
+            &env,
+            n <= MAX_BUMP_TTL_BATCH,
+            EscrowError::BumpTtlBatchTooLarge,
+        );
 
         // Extend persistent TTL for allowlisted investor entries.
         for addr in allowlisted.iter() {

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -23,8 +23,8 @@ use super::{
     EscrowFunded, EscrowInitialized, EscrowUnfunded, FundingCancelled, FundingTargetUpdated,
     InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient, MaturityMaxHorizonUpdated,
     MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept,
-    YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH,
-    SCHEMA_VERSION,
+    YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_BUMP_TTL_BATCH, MAX_DUST_SWEEP_AMOUNT,
+    MAX_FUND_BATCH, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -7,7 +7,7 @@ use crate::{
     CollateralRecordedEvt, DataKey, EscrowCloseSnapshot, EscrowError, FundingCancelled,
     InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient, PrimaryAttestationBound,
     RegistryRefRebound, TreasuryDustSwept, YieldTier, DEFAULT_MATURITY_MAX_HORIZON_SECS,
-    MAX_ATTESTATION_APPEND_ENTRIES, SCHEMA_VERSION,
+    MAX_ATTESTATION_APPEND_ENTRIES, MAX_BUMP_TTL_BATCH, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,
@@ -231,8 +231,10 @@ fn escrow_error_discriminants_match_canonical_table() {
         (EscrowError::FloorLowerNotOpen, 173),
         (EscrowError::NewFloorNotLower, 174),
         (EscrowError::NewFloorNotPositive, 175),
+        (EscrowError::BumpTtlBatchEmpty, 223),
+        (EscrowError::BumpTtlBatchTooLarge, 224),
     ];
-    assert_eq!(TABLE.len(), 89);
+    assert_eq!(TABLE.len(), 91);
     for (variant, code) in TABLE {
         assert_eq!(*variant as u32, *code, "discriminant drift for code {code}");
     }
@@ -1618,6 +1620,105 @@ fn test_bump_ttl_covers_persistent_investor_keys() {
     // assert!(ttl_allow > 0, "Allowlist TTL should be extended");
     //     let ttl_contrib = env.storage().persistent().get_ttl(&DataKey::InvestorContribution(investor.clone()));
     // assert!(ttl_contrib > 0, "Contribution TTL should be extended");
+}
+
+#[test]
+fn test_bump_ttl_empty_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TTL002"),
+        &sme,
+        &100,
+        &10,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    let empty_vec = SorobanVec::new(&env);
+    let result = client.try_bump_ttl(&empty_vec);
+    assert_contract_error(result, EscrowError::BumpTtlBatchEmpty);
+}
+
+#[test]
+fn test_bump_ttl_oversized_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TTL003"),
+        &sme,
+        &100,
+        &10,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    let mut investors = SorobanVec::new(&env);
+    for _ in 0..=(MAX_BUMP_TTL_BATCH as usize) {
+        investors.push_back(Address::generate(&env));
+    }
+    let result = client.try_bump_ttl(&investors);
+    assert_contract_error(result, EscrowError::BumpTtlBatchTooLarge);
+}
+
+#[test]
+fn test_bump_ttl_max_batch_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TTL004"),
+        &sme,
+        &100,
+        &10,
+        &0,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    let mut investors = SorobanVec::new(&env);
+    for _ in 0..MAX_BUMP_TTL_BATCH {
+        investors.push_back(Address::generate(&env));
+    }
+    client.bump_ttl(&investors);
+    // Succeeds without panic.
 }
 
 #[test]


### PR DESCRIPTION
closes #656 
## Description

`bump_ttl(env, allowlisted: Vec<Address>)` is a permissionless entrypoint that iterates the caller-supplied vector to extend per-investor persistent storage TTLs. The vector length was unbounded, allowing a caller to pass an arbitrarily large list and drive instruction/storage-access budget to the ledger limit on every invocation.

This PR introduces a `MAX_BUMP_TTL_BATCH` constant and rejects empty or oversized inputs with typed `EscrowError` variants, consistent with `MAX_INVESTOR_ALLOWLIST_BATCH` and `MAX_ATTESTATION_REVOKE_BATCH`.

## Changes

### `escrow/src/lib.rs`
- Added `MAX_BUMP_TTL_BATCH = 32` constant
- Added `BumpTtlBatchEmpty = 223` and `BumpTtlBatchTooLarge = 224` to `EscrowError`
- Added length guards at the top of `bump_ttl`: rejects empty vectors and vectors exceeding `MAX_BUMP_TTL_BATCH`

### `escrow/src/tests/coverage.rs`
- `test_bump_ttl_empty_rejected` — empty vector → `BumpTtlBatchEmpty`
- `test_bump_ttl_oversized_rejected` — `MAX_BUMP_TTL_BATCH + 1` entries → `BumpTtlBatchTooLarge`
- `test_bump_ttl_max_batch_succeeds` — exactly `MAX_BUMP_TTL_BATCH` entries → succeeds
- Updated discriminant table with new variants

### `escrow/src/tests.rs`
- Added `MAX_BUMP_TTL_BATCH` to test imports

### Documentation
- `docs/escrow-error-messages.md`: canonical table entries, legacy panic strings, and client guidance for codes 223–224
- `docs/escrow-gas-storage-notes.md`: batch cap note in the `bump_ttl` section

## Security

- **Permissionless preserved**: the cap is the sole mitigation, not an auth gate
- **Value = 32**: matches `MAX_INVESTOR_ALLOWLIST_BATCH` and `MAX_ATTESTATION_REVOKE_BATCH`
- **Typed errors**: enable SDK-level error handling without string matching

## Testing

- `cargo fmt --all -- --check` — passes
- `cargo build` — passes
- `cargo test` — blocked by pre-existing `dlltool.exe` absence on Windows GNU toolchain (environment limitation, not related to changes)

## Commit

```
fix(escrow): bound bump_ttl batch length with a typed error
```
