### PR TITLE
feat/test: implement #615, #619, #631 — capacity view, collateral tes…

### DIFF
--- a/docs/escrow-attestations.md
+++ b/docs/escrow-attestations.md
@@ -159,6 +159,29 @@ fat-finger revocation before indexers process the erroneous tombstone.
 storage mutation. This means range and state errors are surfaced even to unauthenticated
 callers, consistent with the existing revoke path.
 
+### `get_revoked_attestation_indices() → Vec<u32>`
+
+| Property | Value |
+|---|---|
+| Auth | None — pure read |
+| Storage keys | `DataKey::AttestationAppendLog`, `DataKey::AttestationRevoked(u32)` |
+| Mutation | None |
+| Bounded by | `MAX_ATTESTATION_APPEND_ENTRIES` (32) iterations |
+
+Returns the ordered set of indices in the append-log that have been revoked. Scans
+`0..get_attestation_append_log().len()` and collects every index `i` where
+`DataKey::AttestationRevoked(i)` is set. The result is ascending (0-based).
+
+**Use case:** auditors and indexers no longer need to probe all 32 slots individually via
+`is_attestation_revoked(i)` — this view returns the complete revoked-index set in a single
+host invocation.
+
+**Alignment:** index `i` in the result corresponds to `get_attestation_append_log().get(i)` —
+indices share the same 0-based ordering.
+
+**Legacy instances:** instances where no revocations have been recorded return an empty `Vec`
+(additive-key backward compatibility, ADR-007).
+
 The append log entry and its digest are unaffected. After a successful unrevoke,
 `is_attestation_revoked(index)` returns `false` and the entry is once again treated as
 active by indexers.
@@ -472,3 +495,31 @@ Attestation behavior is covered in [`escrow/src/tests/attestations.rs`](../escro
 | `test_batch_revoke_preserves_log_entries` | Append log contents unchanged after batch revocation |
 | `test_batch_revoke_emits_events` | Exactly one `att_rev` event per revoked index |
 | `test_batch_revoke_atomic_rollback` | Mid-batch failure rolls back all prior revocations |
+
+### Revoked-index enumeration (`get_revoked_attestation_indices`)
+
+| Test | What it proves |
+|---|---|
+| `test_get_revoked_attestation_indices_empty_log` | Empty log returns empty Vec |
+| `test_get_revoked_attestation_indices_none_revoked` | Non-empty log with no revocations returns empty Vec |
+| `test_get_revoked_attestation_indices_single_revoked` | Single revocation returns Vec with exactly that index |
+| `test_get_revoked_attestation_indices_some_revoked_ascending_order` | Partial revocations returned in ascending order |
+| `test_get_revoked_attestation_indices_all_revoked` | Full revocation: result length equals log length |
+| `test_get_revoked_attestation_indices_excludes_unrevoked` | Unrevoked index no longer appears after `unrevoke_attestation_digest` |
+| `test_get_revoked_attestation_indices_align_with_log_order` | Index `i` in result aligns with `get_attestation_append_log().get(i)` |
+| `test_get_revoked_attestation_indices_bounded_by_max_entries` | Full log with alternating revocations — result bounded and correct |
+| `test_get_revoked_attestation_indices_no_auth_required` | Pure read — succeeds with no auth mocks |
+
+### Revoked-index enumeration (`get_revoked_attestation_indices`)
+
+| Test | What it proves |
+|---|---|
+| `test_get_revoked_attestation_indices_empty_log` | Empty log returns empty Vec |
+| `test_get_revoked_attestation_indices_none_revoked` | Non-empty log with no revocations returns empty Vec |
+| `test_get_revoked_attestation_indices_single_revoked` | Single revocation returns Vec with exactly that index |
+| `test_get_revoked_attestation_indices_some_revoked_ascending_order` | Partial revocations returned in ascending order |
+| `test_get_revoked_attestation_indices_all_revoked` | Full revocation: result length equals log length |
+| `test_get_revoked_attestation_indices_excludes_unrevoked` | Unrevoked index no longer appears after `unrevoke_attestation_digest` |
+| `test_get_revoked_attestation_indices_align_with_log_order` | Index `i` in result aligns with `get_attestation_append_log().get(i)` |
+| `test_get_revoked_attestation_indices_bounded_by_max_entries` | Full log with alternating revocations — result bounded and correct |
+| `test_get_revoked_attestation_indices_no_auth_required` | Pure read — succeeds with no auth mocks |

--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -60,6 +60,7 @@ re-implementing storage reads to guarantee identical semantics.
 - [get_attestation_append_log](#get_attestation_append_log--vecbytesn32)
 - [get_attestation_log_stats](#get_attestation_log_stats--u32-u32)
 - [is_attestation_revoked](#is_attestation_revokedindex-u32--bool)
+- [get_revoked_attestation_indices](#get_revoked_attestation_indices--vecu32)
 
 **Collateral Metadata:**
 - [get_sme_collateral_commitment](#get_sme_collateral_commitment--optionsmecollateralcommitment)
@@ -243,17 +244,36 @@ Returns the pending-admin proposal's remaining validity window computed against 
 
 ## `get_remaining_funding_capacity() → i128`
 
-**Storage key:** `DataKey::Escrow`
+**Storage key:** `DataKey::Escrow`  
+**Signature:** `pub fn get_remaining_funding_capacity(env: Env) -> i128`
 
-Returns the remaining funding capacity before the funding target is reached.
+Returns `max(0, funding_target − funded_amount)` — the headroom remaining before the funding
+target is reached. Saturating arithmetic ensures the result is **always non-negative**, even
+when the escrow has been over-funded past the target.
 
-- **Calculation**: `funding_target.saturating_sub(funded_amount)` clamped at `0` (via `.max(0)`) so it never goes negative when over-funded.
-- **Informational only**: This view is for frontend guidance. The `fund` method may still accept deposits that over-fund past the target while the escrow status is `0` (Open).
-- **No authorization**: Pure read; no auth or signature required.
-- **Complexity**:
-  - Time Complexity: $O(1)$ read from storage.
-  - Space Complexity: $O(1)$ in-memory calculation.
-- Panics with `"Escrow not initialized"` before `init`.
+**Informational only:** Front-ends should use this view to size deposit suggestions. The `fund`
+entrypoint does **not** use this value as a gate — it accepts deposits that push `funded_amount`
+past `funding_target` while `status == 0` (open). A return value of `0` means the target has
+already been met or exceeded; it does not mean further deposits are rejected.
+
+**Requires initialization:** Yes — emits [`EscrowError::EscrowNotInitialized`] (code 20) if
+called before `init`.
+
+**No authorization required.** Pure read; no state mutation.
+
+| Escrow state | Return value |
+|---|---|
+| No deposits yet | `funding_target` |
+| Partially funded | `funding_target − funded_amount` |
+| Exactly at target | `0` |
+| Over-funded | `0` (clamped, never negative) |
+
+**Complexity:** O(1) — single instance-storage read.
+
+**Security notes:**
+- The `.max(0)` clamp is redundant given `saturating_sub` but is retained explicitly for
+  auditor clarity.
+- Reads `DataKey::Escrow` directly; no side effects.
 
 ---
 
@@ -799,3 +819,50 @@ Returns the yield-tier ladder configured at `init`, or an empty `Vec` when no ti
 |-------|------|-------------|
 | `min_lock_secs` | `u64` | Minimum `committed_lock_secs` an investor must pass to qualify for this tier |
 | `yield_bps` | `i64` | Effective annualized yield in basis points for qualifying investors |
+
+---
+
+## `get_revoked_attestation_indices() → Vec<u32>`
+
+**Storage keys:** `DataKey::AttestationAppendLog`, `DataKey::AttestationRevoked(u32)`  
+**Signature:** `pub fn get_revoked_attestation_indices(env: Env) -> Vec<u32>`
+
+Returns the ordered set of indices in the attestation append-log that have been revoked.
+Scans `0..get_attestation_append_log().len()` and collects every index `i` where
+`DataKey::AttestationRevoked(i)` is set. The result is ascending (0-based) and its length
+is bounded by the log length, which is itself capped at `MAX_ATTESTATION_APPEND_ENTRIES` (32).
+
+**Requires initialization:** No  
+**No authorization required.** Pure read; no state mutation.
+
+**Relation to other attestation views:**
+
+| View | What it returns |
+|---|---|
+| `get_attestation_append_log()` | All digests (revoked and active) in insertion order |
+| `is_attestation_revoked(index)` | Revocation flag for a single index |
+| `get_revoked_attestation_indices()` | Ordered set of all revoked indices |
+
+**Alignment guarantee:** index `i` in the returned `Vec` corresponds to
+`get_attestation_append_log().get(i)` — the same ordering. Integrators can join
+the two views by position without secondary key lookups.
+
+**Legacy instances:** instances where no revocations have ever been recorded return an
+empty `Vec`. This is backward-compatible under the additive-key policy (ADR-007).
+
+| Log / revocation state | Return value |
+|---|---|
+| Empty log | `[]` |
+| Log with no revocations | `[]` |
+| Some indices revoked | Ascending list of revoked indices, e.g. `[0, 2, 4]` |
+| All indices revoked | `[0, 1, 2, …, log.len()-1]` |
+| After `unrevoke_attestation_digest(i)` | Index `i` no longer appears |
+
+**Complexity:** O(N) where N = `get_attestation_append_log().len()` ≤ 32. The scan and
+storage reads are bounded by `MAX_ATTESTATION_APPEND_ENTRIES`.
+
+**Security notes:**
+- Pure read — no authorization required, no state mutation.
+- Bounded scan — loops at most 32 times regardless of call context.
+- Reads `DataKey::AttestationAppendLog` once for log length, then probes
+  `DataKey::AttestationRevoked(i)` per slot; no writes occur.

--- a/docs/escrow-sme-collateral.md
+++ b/docs/escrow-sme-collateral.md
@@ -47,13 +47,13 @@ The scenarios below are covered by the focused collateral suite in
 | `test_collateral_first_record_returns_correct_fields_and_prior_amount_is_zero` | First record returns the correct asset/amount/timestamp; `get_sme_collateral_commitment` reflects it. |
 | `test_collateral_first_record_event_prior_amount_is_zero` | `CollateralRecordedEvt` emitted by the first record has `prior_amount = 0`. |
 | `test_collateral_replacement_overwrites_stored_value_and_emits_prior_amount` | Replacement overwrites storage; event carries the previous record's amount as `prior_amount`. |
-| `test_collateral_backwards_timestamp_rejected` | Replacing with a ledger timestamp earlier than `recorded_at` is rejected with `CollateralTimestampBackwards`; original record is preserved. |
+| `test_collateral_backwards_timestamp_rejected` | Replacing with a ledger timestamp earlier than `recorded_at` is rejected with `CollateralTimestampBackwards` (62); original record is preserved. |
 | `test_collateral_same_timestamp_replacement_is_allowed` | Equal timestamps (`now >= prior.recorded_at`) are accepted (monotonic, not strictly increasing). |
-| `test_collateral_zero_amount_rejected` | Zero amount is rejected with `CollateralAmountNotPositive`. |
-| `test_collateral_negative_amount_rejected` | Negative amount is rejected with `CollateralAmountNotPositive`. |
-| `test_collateral_empty_asset_rejected` | Empty asset symbol is rejected with `CollateralAssetEmpty`. |
-| `test_collateral_non_sme_caller_rejected` | A caller that is not the SME address is rejected (auth failure). |
-| `test_collateral_record_does_not_change_token_balances` | No token balances change on the escrow contract, SME, or admin after recording. |
+| `test_collateral_zero_amount_rejected` | Zero amount is rejected with `CollateralAmountNotPositive` (60). |
+| `test_collateral_negative_amount_rejected` | Negative amount is rejected with `CollateralAmountNotPositive` (60). |
+| `test_collateral_empty_asset_rejected_with_typed_error` | Empty asset symbol is rejected with `CollateralAssetEmpty` (61). |
+| `test_collateral_non_sme_caller_rejected` | A caller that is not the SME address is rejected (auth failure); stored record unchanged. |
+| `test_collateral_record_does_not_change_token_balances` | No token balances change on the escrow contract or SME after recording (metadata-only invariant). |
 
 Additional collateral scenarios (happy-path and validation) are also exercised in:
 - [`escrow/src/tests/admin.rs`](../escrow/src/tests/admin.rs) — collateral record in admin-flow baselines.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1963,7 +1963,38 @@ impl LiquifactEscrow {
 
     /// Returns the remaining funding capacity before the funding target is reached.
     ///
-    /// Clamped to `0` via `saturating_sub` if the escrow is over-funded.
+    /// Computes `max(0, funding_target − funded_amount)` using saturating arithmetic
+    /// so the result is **always non-negative**, even when the escrow has been
+    /// over-funded past the target.
+    ///
+    /// # Informational only
+    ///
+    /// This view is a convenience for front-ends sizing a deposit. It does **not**
+    /// gate `fund` — the `fund` entrypoint accepts deposits that push
+    /// `funded_amount` past `funding_target` while `status == 0` (open). A value
+    /// of `0` here means the target has already been met or exceeded; it does not
+    /// mean further deposits are rejected.
+    ///
+    /// # Returns
+    ///
+    /// | Escrow state | Return value |
+    /// |---|---|
+    /// | No deposits yet | `funding_target` |
+    /// | Partially funded | `funding_target − funded_amount` |
+    /// | Exactly at target | `0` |
+    /// | Over-funded | `0` (clamped, never negative) |
+    ///
+    /// # Errors
+    ///
+    /// Panics with [`EscrowError::EscrowNotInitialized`] (code 20) if called
+    /// before [`LiquifactEscrow::init`].
+    ///
+    /// # Security notes
+    ///
+    /// - **Pure read** — no authorization required, no state mutation.
+    /// - **Non-negative invariant** — the `.max(0)` clamp is redundant given
+    ///   `saturating_sub`, but retained for explicitness in audits.
+    /// - Reads [`DataKey::Escrow`] directly; no side effects.
     pub fn get_remaining_funding_capacity(env: Env) -> i128 {
         let escrow = Self::get_escrow(env);
         escrow
@@ -2851,6 +2882,59 @@ impl LiquifactEscrow {
             .instance()
             .get(&DataKey::AttestationRevoked(index))
             .unwrap_or(false)
+    }
+
+    /// Returns the indices in the attestation append-log that have been revoked.
+    ///
+    /// Scans `0..get_attestation_append_log().len()` and collects every index `i`
+    /// where [`DataKey::AttestationRevoked(i)`] is set. The returned [`Vec`] is
+    /// ordered ascending (0-based) and its length is bounded by the append-log
+    /// length, which is itself bounded by [`MAX_ATTESTATION_APPEND_ENTRIES`] (32).
+    ///
+    /// # Relation to other views
+    ///
+    /// | View | What it returns |
+    /// |---|---|
+    /// | [`LiquifactEscrow::get_attestation_append_log`] | All digests (revoked and active) in order |
+    /// | [`LiquifactEscrow::is_attestation_revoked`] | Revocation flag for a single index |
+    /// | **`get_revoked_attestation_indices`** | Ordered set of all revoked indices |
+    ///
+    /// Indices align with the ordering of
+    /// [`LiquifactEscrow::get_attestation_append_log`] — index `i` in the result
+    /// corresponds to `get_attestation_append_log().get(i)`.
+    ///
+    /// # Legacy instances
+    ///
+    /// Instances where no revocations have ever been recorded return an empty [`Vec`].
+    /// This is the same default as [`LiquifactEscrow::get_attestation_append_log`]
+    /// returning an empty log (additive-key policy, ADR-007).
+    ///
+    /// # Security notes
+    ///
+    /// - **Pure read** — no authorization required, no state mutation.
+    /// - **Bounded scan** — the loop runs at most [`MAX_ATTESTATION_APPEND_ENTRIES`]
+    ///   (32) iterations; the storage and CPU cost is constant.
+    /// - Reads [`DataKey::AttestationAppendLog`] once for the log length, then
+    ///   probes [`DataKey::AttestationRevoked(i)`] for each slot; no writes occur.
+    pub fn get_revoked_attestation_indices(env: Env) -> Vec<u32> {
+        let log: Vec<BytesN<32>> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AttestationAppendLog)
+            .unwrap_or_else(|| Vec::new(&env));
+        let len = log.len();
+        let mut result = Vec::new(&env);
+        for i in 0..len {
+            if env
+                .storage()
+                .instance()
+                .get(&DataKey::AttestationRevoked(i))
+                .unwrap_or(false)
+            {
+                result.push_back(i);
+            }
+        }
+        result
     }
 
     pub fn get_revoked_attestation_digests(

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -781,3 +781,180 @@ fn test_revoked_digests_view_caps_limit() {
     let page = client.get_revoked_attestation_digests(&0, &100);
     assert_eq!(page.len(), crate::MAX_ATTESTATION_READ_PAGE);
 }
+
+// ── Issue #631: get_revoked_attestation_indices ───────────────────────────────
+
+/// Empty log → empty result (no revocations, no log entries).
+#[test]
+fn test_get_revoked_attestation_indices_empty_log() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let indices = client.get_revoked_attestation_indices();
+    assert_eq!(indices.len(), 0);
+}
+
+/// Log with no revocations → empty result even though entries exist.
+#[test]
+fn test_get_revoked_attestation_indices_none_revoked() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..4 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    let indices = client.get_revoked_attestation_indices();
+    assert_eq!(indices.len(), 0);
+}
+
+/// Single revocation: only the revoked index is returned.
+#[test]
+fn test_get_revoked_attestation_indices_single_revoked() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    client.append_attestation_digest(&digest(&env, 0x02));
+    client.append_attestation_digest(&digest(&env, 0x03));
+
+    client.revoke_attestation_digest(&1);
+
+    let indices = client.get_revoked_attestation_indices();
+    assert_eq!(indices.len(), 1);
+    assert_eq!(indices.get(0).unwrap(), 1u32);
+}
+
+/// Some revoked: only the revoked indices appear, in ascending order.
+#[test]
+fn test_get_revoked_attestation_indices_some_revoked_ascending_order() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..5 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+
+    client.revoke_attestation_digest(&0);
+    client.revoke_attestation_digest(&2);
+    client.revoke_attestation_digest(&4);
+
+    let indices = client.get_revoked_attestation_indices();
+    assert_eq!(indices.len(), 3);
+    assert_eq!(indices.get(0).unwrap(), 0u32);
+    assert_eq!(indices.get(1).unwrap(), 2u32);
+    assert_eq!(indices.get(2).unwrap(), 4u32);
+}
+
+/// All entries revoked: result length equals log length.
+#[test]
+fn test_get_revoked_attestation_indices_all_revoked() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let count = 6u8;
+    for i in 0u8..count {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    for i in 0u32..(count as u32) {
+        client.revoke_attestation_digest(&i);
+    }
+
+    let indices = client.get_revoked_attestation_indices();
+    assert_eq!(indices.len(), count as u32);
+    for i in 0u32..(count as u32) {
+        assert_eq!(indices.get(i).unwrap(), i);
+    }
+}
+
+/// After an unrevoke, the unrevoked index must no longer appear in the result.
+#[test]
+fn test_get_revoked_attestation_indices_excludes_unrevoked() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0xAA));
+    client.append_attestation_digest(&digest(&env, 0xBB));
+    client.append_attestation_digest(&digest(&env, 0xCC));
+
+    client.revoke_attestation_digest(&0);
+    client.revoke_attestation_digest(&1);
+    client.revoke_attestation_digest(&2);
+
+    // Unrevoke index 1.
+    client.unrevoke_attestation_digest(&1);
+
+    let indices = client.get_revoked_attestation_indices();
+    assert_eq!(indices.len(), 2);
+    assert_eq!(indices.get(0).unwrap(), 0u32);
+    assert_eq!(indices.get(1).unwrap(), 2u32);
+}
+
+/// Indices align with the ordering of `get_attestation_append_log`: index i
+/// in the result corresponds to `get_attestation_append_log().get(i)`.
+#[test]
+fn test_get_revoked_attestation_indices_align_with_log_order() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+
+    let d0 = digest(&env, 0x10);
+    let d1 = digest(&env, 0x20);
+    let d2 = digest(&env, 0x30);
+    let d3 = digest(&env, 0x40);
+
+    client.append_attestation_digest(&d0); // index 0
+    client.append_attestation_digest(&d1); // index 1
+    client.append_attestation_digest(&d2); // index 2
+    client.append_attestation_digest(&d3); // index 3
+
+    client.revoke_attestation_digest(&1);
+    client.revoke_attestation_digest(&3);
+
+    let revoked_indices = client.get_revoked_attestation_indices();
+    let log = client.get_attestation_append_log();
+
+    assert_eq!(revoked_indices.len(), 2);
+
+    // Verify alignment: index in result maps to same digest in log.
+    let idx0 = revoked_indices.get(0).unwrap();
+    let idx1 = revoked_indices.get(1).unwrap();
+    assert_eq!(idx0, 1u32);
+    assert_eq!(idx1, 3u32);
+    assert_eq!(log.get(idx0).unwrap(), d1);
+    assert_eq!(log.get(idx1).unwrap(), d3);
+}
+
+/// Full log (MAX_ATTESTATION_APPEND_ENTRIES) with alternating revocations:
+/// the result is bounded and correct.
+#[test]
+fn test_get_revoked_attestation_indices_bounded_by_max_entries() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+
+    // Fill log to capacity.
+    for i in 0u8..(MAX_ATTESTATION_APPEND_ENTRIES as u8) {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+
+    // Revoke every even index.
+    let mut expected_revoked: Vec<u32> = Vec::new();
+    for i in (0u32..MAX_ATTESTATION_APPEND_ENTRIES).step_by(2) {
+        client.revoke_attestation_digest(&i);
+        expected_revoked.push(i);
+    }
+
+    let indices = client.get_revoked_attestation_indices();
+    assert_eq!(indices.len() as usize, expected_revoked.len());
+    for (pos, &expected_idx) in expected_revoked.iter().enumerate() {
+        assert_eq!(indices.get(pos as u32).unwrap(), expected_idx);
+    }
+}
+
+/// Pure read: no auth required (calling without any mock auths must succeed).
+#[test]
+fn test_get_revoked_attestation_indices_no_auth_required() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    client.revoke_attestation_digest(&0);
+
+    // Drop all auth mocks — the view must still succeed.
+    env.mock_auths(&[]);
+    let indices = client.get_revoked_attestation_indices();
+    assert_eq!(indices.len(), 1);
+    assert_eq!(indices.get(0).unwrap(), 0u32);
+}

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -1976,6 +1976,318 @@ fn test_sme_collateral_replacement_preserves_prior_amount() {
     assert_eq!(stored.amount, 7000);
 }
 
+// ─── Comprehensive SME collateral commitment tests (issue #619) ──────────────
+
+/// Helper: initialise a bare escrow without a real token (metadata-only tests).
+fn init_collateral_escrow<'a>(
+    env: &'a Env,
+    client: &LiquifactEscrowClient<'a>,
+    admin: &Address,
+    sme: &Address,
+) {
+    let (token, treasury) = free_addresses(env);
+    client.init(
+        admin,
+        &soroban_sdk::String::from_str(env, "COLTEST"),
+        sme,
+        &100_000,
+        &500i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+}
+
+/// Happy path: first `record_sme_collateral_commitment` returns correct
+/// asset / amount / timestamp and `get_sme_collateral_commitment` reflects
+/// the stored record.
+#[test]
+fn test_collateral_first_record_returns_correct_fields_and_prior_amount_is_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    init_collateral_escrow(&env, &client, &admin, &sme);
+
+    let asset = soroban_sdk::Symbol::new(&env, "USDC");
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let result = client.record_sme_collateral_commitment(&asset, &5_000);
+    assert_eq!(result.amount, 5_000);
+    assert_eq!(result.asset, asset);
+    assert_eq!(result.recorded_at, 1000);
+
+    let stored = client.get_sme_collateral_commitment().unwrap();
+    assert_eq!(stored.amount, 5_000);
+    assert_eq!(stored.asset, asset);
+    assert_eq!(stored.recorded_at, 1000);
+}
+
+/// The `CollateralRecordedEvt` emitted on the **first** record must carry
+/// `prior_amount = 0` (no previous commitment).
+#[test]
+fn test_collateral_first_record_event_prior_amount_is_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    init_collateral_escrow(&env, &client, &admin, &sme);
+
+    let asset = soroban_sdk::Symbol::new(&env, "GOLD");
+    env.ledger().with_mut(|li| li.timestamp = 500);
+    client.record_sme_collateral_commitment(&asset, &8_000);
+
+    // Find the CollateralRecordedEvt in the event log.
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+    // The last event should be CollateralRecordedEvt.
+    let found = events_list.iter().any(|ev| {
+        // CollateralRecordedEvt has topic name "coll_rec"; verify prior_amount field.
+        let contract_id = client.address.clone();
+        let expected = CollateralRecordedEvt {
+            name: symbol_short!("coll_rec"),
+            invoice_id: client.get_escrow().invoice_id,
+            amount: 8_000,
+            prior_amount: 0,
+        }
+        .to_xdr(&env, &contract_id);
+        ev == expected
+    });
+    assert!(found, "CollateralRecordedEvt with prior_amount=0 must be emitted on first record");
+}
+
+/// Replacement: a second `record_sme_collateral_commitment` overwrites storage
+/// and the emitted event carries the **prior** amount.
+#[test]
+fn test_collateral_replacement_overwrites_stored_value_and_emits_prior_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    init_collateral_escrow(&env, &client, &admin, &sme);
+
+    let asset = soroban_sdk::Symbol::new(&env, "ETH");
+
+    // First record.
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.record_sme_collateral_commitment(&asset, &3_000);
+
+    // Advance ledger — replacement timestamp must be >= recorded_at.
+    env.ledger().with_mut(|li| li.timestamp = 2000);
+    client.record_sme_collateral_commitment(&asset, &9_000);
+
+    // Storage must reflect the replacement.
+    let stored = client.get_sme_collateral_commitment().unwrap();
+    assert_eq!(stored.amount, 9_000);
+    assert_eq!(stored.recorded_at, 2000);
+
+    // Verify prior_amount in the replacement event.
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+    let replacement_event_found = events_list.iter().any(|ev| {
+        ev == CollateralRecordedEvt {
+            name: symbol_short!("coll_rec"),
+            invoice_id: invoice_id.clone(),
+            amount: 9_000,
+            prior_amount: 3_000,
+        }
+        .to_xdr(&env, &contract_id)
+    });
+    assert!(
+        replacement_event_found,
+        "replacement CollateralRecordedEvt must carry prior_amount = 3_000"
+    );
+}
+
+/// Backwards timestamp: replacing with a ledger timestamp **earlier** than
+/// `recorded_at` must be rejected with `CollateralTimestampBackwards` (62).
+/// The stored record must be preserved.
+#[test]
+fn test_collateral_backwards_timestamp_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    init_collateral_escrow(&env, &client, &admin, &sme);
+
+    let asset = soroban_sdk::Symbol::new(&env, "GOLD");
+
+    // Record at timestamp 5000.
+    env.ledger().with_mut(|li| li.timestamp = 5000);
+    client.record_sme_collateral_commitment(&asset, &5_000);
+
+    // Attempt replacement with earlier timestamp.
+    env.ledger().with_mut(|li| li.timestamp = 100);
+    let res = client.try_record_sme_collateral_commitment(&asset, &7_000);
+    assert_contract_error(res, EscrowError::CollateralTimestampBackwards);
+
+    // Original record must still be intact.
+    let stored = client.get_sme_collateral_commitment().unwrap();
+    assert_eq!(stored.amount, 5_000);
+    assert_eq!(stored.recorded_at, 5000);
+}
+
+/// Same-timestamp replacement: `now == prior.recorded_at` is allowed (monotonic, not
+/// strictly increasing).
+#[test]
+fn test_collateral_same_timestamp_replacement_is_allowed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    init_collateral_escrow(&env, &client, &admin, &sme);
+
+    let asset = soroban_sdk::Symbol::new(&env, "USDC");
+
+    env.ledger().with_mut(|li| li.timestamp = 3000);
+    client.record_sme_collateral_commitment(&asset, &1_000);
+
+    // Same timestamp: should succeed (>= semantics).
+    env.ledger().with_mut(|li| li.timestamp = 3000);
+    client.record_sme_collateral_commitment(&asset, &2_000);
+
+    let stored = client.get_sme_collateral_commitment().unwrap();
+    assert_eq!(stored.amount, 2_000);
+    assert_eq!(stored.recorded_at, 3000);
+}
+
+/// Zero amount must be rejected with `CollateralAmountNotPositive` (60).
+#[test]
+fn test_collateral_zero_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    init_collateral_escrow(&env, &client, &admin, &sme);
+
+    let asset = soroban_sdk::Symbol::new(&env, "USDC");
+    let res = client.try_record_sme_collateral_commitment(&asset, &0);
+    assert_contract_error(res, EscrowError::CollateralAmountNotPositive);
+    assert_eq!(client.get_sme_collateral_commitment(), None);
+}
+
+/// Negative amount must be rejected with `CollateralAmountNotPositive` (60).
+#[test]
+fn test_collateral_negative_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    init_collateral_escrow(&env, &client, &admin, &sme);
+
+    let asset = soroban_sdk::Symbol::new(&env, "USDC");
+    let res = client.try_record_sme_collateral_commitment(&asset, &(-1_000i128));
+    assert_contract_error(res, EscrowError::CollateralAmountNotPositive);
+    assert_eq!(client.get_sme_collateral_commitment(), None);
+}
+
+/// Empty asset symbol must be rejected with `CollateralAssetEmpty` (61).
+#[test]
+fn test_collateral_empty_asset_rejected_with_typed_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    init_collateral_escrow(&env, &client, &admin, &sme);
+
+    let empty_asset = soroban_sdk::Symbol::new(&env, "");
+    let res = client.try_record_sme_collateral_commitment(&empty_asset, &5_000);
+    assert_contract_error(res, EscrowError::CollateralAssetEmpty);
+    assert_eq!(client.get_sme_collateral_commitment(), None);
+}
+
+/// A caller that is **not** the SME address must be rejected (auth failure).
+/// The stored commitment (if any) must be unchanged.
+#[test]
+fn test_collateral_non_sme_caller_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    init_collateral_escrow(&env, &client, &admin, &sme);
+
+    let asset = soroban_sdk::Symbol::new(&env, "USDC");
+
+    // First, record as SME to establish a baseline.
+    client.record_sme_collateral_commitment(&asset, &5_000);
+
+    // Now attempt with no auth at all — should fail.
+    env.mock_auths(&[]);
+    let non_sme = Address::generate(&env);
+    let _ = non_sme; // unused but documents intent
+    let res = client.try_record_sme_collateral_commitment(&asset, &9_999);
+    assert!(res.is_err(), "non-SME caller must be rejected");
+
+    // Original record must be unchanged.
+    let stored = client.get_sme_collateral_commitment().unwrap();
+    assert_eq!(stored.amount, 5_000);
+}
+
+/// Metadata-only invariant: no token balance on the escrow contract changes after
+/// `record_sme_collateral_commitment`. Uses a real SAC token so we can query balances.
+#[test]
+fn test_collateral_record_does_not_change_token_balances() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Deploy a real SAC token so we can check balances.
+    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_id = sac.address();
+    let sac_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    let token_client = soroban_sdk::token::TokenClient::new(&env, &token_id);
+
+    let (client, admin, sme) = setup(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "COLBAL"),
+        &sme,
+        &100_000,
+        &500i64,
+        &0u64,
+        &token_id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let escrow_id = client.address.clone();
+
+    // Mint some tokens into the escrow to have a non-zero baseline.
+    sac_admin.mint(&escrow_id, &10_000);
+    let balance_before = token_client.balance(&escrow_id);
+    let sme_balance_before = token_client.balance(&sme);
+
+    let asset = soroban_sdk::Symbol::new(&env, "COLLAT");
+    client.record_sme_collateral_commitment(&asset, &50_000);
+
+    let balance_after = token_client.balance(&escrow_id);
+    let sme_balance_after = token_client.balance(&sme);
+
+    assert_eq!(
+        balance_before, balance_after,
+        "escrow token balance must not change after recording collateral"
+    );
+    assert_eq!(
+        sme_balance_before, sme_balance_after,
+        "SME token balance must not change after recording collateral"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 #[test]
 fn test_clear_legal_hold_convenience() {
     let env = Env::default();


### PR DESCRIPTION
…ts, revoked-index view

=== Issue #615 — get_remaining_funding_capacity read view ===

WHAT WAS DONE:
The existing get_remaining_funding_capacity function in escrow/src/lib.rs had only a two-line NatSpec comment that did not document the informational-only guarantee, the non-negative invariant, the error code on uninitialised escrow, or the security notes required by the issue specification.

HOW IT WAS DONE:
- Enhanced the /// NatSpec block on get_remaining_funding_capacity in escrow/src/lib.rs to document: the full formula (max(0, funding_target - funded_amount)), the four possible return states (zero deposits / partial / exact / over-funded), the EscrowError::EscrowNotInitialized (code 20) panic path, and security notes explaining why the .max(0) clamp is retained for auditor clarity even though saturating_sub already prevents negatives. Pure-read / no-auth guarantee is explicitly stated.
- Updated docs/escrow-read-api.md: replaced the terse existing entry with a complete reference section including a return-value table, complexity note, and security notes. Added get_revoked_attestation_indices to the Attestations index block.
- Tests already existed comprehensively in escrow/src/tests/funding.rs (13 tests covering zero state, single deposit, multiple deposits, exact target, over-funded clamping, target raised/lowered, batch funding, minimal/large targets, tiered yield).

CLOSES #615

=== Issue #619 — SME collateral commitment record and replace tests ===

WHAT WAS DONE:
record_sme_collateral_commitment had only 4 partial tests in coverage.rs. Missing coverage: prior_amount in CollateralRecordedEvt on first record (must be 0), prior_amount on replacement, backwards-timestamp rejection with typed error and record preservation, same-timestamp acceptance (monotonic >= semantics), zero amount typed error, negative amount typed error, non-SME auth rejection with record preservation, and the metadata-only invariant (no token balance changes).

HOW IT WAS DONE:
- Added 10 new test functions to escrow/src/tests/coverage.rs inside a clearly labelled section (issue #619):
    * test_collateral_first_record_returns_correct_fields_and_prior_amount_is_zero Asserts the happy path: correct asset/amount/timestamp returned and stored.
    * test_collateral_first_record_event_prior_amount_is_zero Scans the event log for CollateralRecordedEvt and asserts prior_amount == 0.
    * test_collateral_replacement_overwrites_stored_value_and_emits_prior_amount Advances ledger, records twice, asserts storage updated and event carries prior_amount == first amount.
    * test_collateral_backwards_timestamp_rejected Sets ledger to 5000, records, resets to 100, asserts CollateralTimestampBackwards (code 62) via try_ and confirms original record unchanged.
    * test_collateral_same_timestamp_replacement_is_allowed Sets ledger to 3000 for both calls; confirms >= semantics accepted.
    * test_collateral_zero_amount_rejected Asserts CollateralAmountNotPositive (code 60); commitment remains None.
    * test_collateral_negative_amount_rejected Same typed error for -1000 amount.
    * test_collateral_empty_asset_rejected_with_typed_error Asserts CollateralAssetEmpty (code 61); commitment remains None.
    * test_collateral_non_sme_caller_rejected Records as SME first, then clears auths and asserts any error is returned; original record preserved.
    * test_collateral_record_does_not_change_token_balances Uses real SAC token, mints baseline into escrow, records collateral, asserts escrow and SME balances unchanged — confirms metadata-only invariant.
- Updated docs/escrow-sme-collateral.md: updated the test coverage table with the actual implemented test names and correct typed-error codes.

CLOSES #619

=== Issue #631 — get_revoked_attestation_indices read view ===

WHAT WAS DONE:
Attestation revocation was stored per-index under DataKey::AttestationRevoked(u32) and only queryable one slot at a time via is_attestation_revoked(index). Auditors and indexers had to probe all 32 slots individually. No single on-chain view returned the set of revoked indices.

HOW IT WAS DONE:
- Implemented get_revoked_attestation_indices(env) -> Vec<u32> in escrow/src/lib.rs, inserted after is_attestation_revoked. The function reads DataKey::AttestationAppendLog once for the log length, then scans 0..len probing DataKey::AttestationRevoked(i) with unwrap_or(false). Revoked indices are pushed to a result Vec in ascending order. The scan is bounded by MAX_ATTESTATION_APPEND_ENTRIES (32). No auth, no mutation. Full NatSpec /// block documents: relation to other views, alignment guarantee, legacy-instance empty-Vec behaviour, security notes (pure read, bounded scan).
- Added 9 test functions to escrow/src/tests/attestations.rs:
    * test_get_revoked_attestation_indices_empty_log — empty log returns []
    * test_get_revoked_attestation_indices_none_revoked — log entries but no revocations
    * test_get_revoked_attestation_indices_single_revoked — only revoked index returned
    * test_get_revoked_attestation_indices_some_revoked_ascending_order — partial revocations in ascending order, non-revoked indices absent
    * test_get_revoked_attestation_indices_all_revoked — result length == log length
    * test_get_revoked_attestation_indices_excludes_unrevoked — after unrevoke, index no longer in result
    * test_get_revoked_attestation_indices_align_with_log_order — cross-validates index positions against get_attestation_append_log() to prove alignment
    * test_get_revoked_attestation_indices_bounded_by_max_entries — fills log to 32, revokes all even indices, asserts correct subset
    * test_get_revoked_attestation_indices_no_auth_required — drops all auth mocks after setup, asserts view succeeds as pure read
- Updated docs/escrow-read-api.md: added get_revoked_attestation_indices to the Attestations index and added a full reference section with return-value table, relation-to-other-views table, alignment guarantee, legacy-instance note, complexity note, and security notes.
- Updated docs/escrow-attestations.md: added get_revoked_attestation_indices entrypoint section (auth, storage keys, mutation, bounded-by, use-case, alignment, legacy note) and added a new Revoked-index enumeration test table with all 9 tests.

CLOSES #631
CLOSES #619
CLOSES #615