### PR TITLE
feat(funding): emit FundingReached state-change event (#692)

### DIFF
--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -50,7 +50,8 @@ The current contract defines 36 event structs.
 | `CollateralRecordedEvt` | `coll_rec` | `record_sme_collateral_commitment` |
 | `ContractUpgraded` | `upgrade` | `upgrade` |
 | `DeprecatedTransferAdminUsed` | `depr_xfer` | `transfer_admin` |
-| `EscrowFunded` | `funded` | `fund`, `fund_with_commitment` |
+| `EscrowFunded` | `funded` | `fund`, `fund_with_commitment`, `fund_batch` |
+| `FundingReached` | `fund_rchd` | `fund`, `fund_with_commitment`, `fund_batch`, `update_funding_target` |
 | `EscrowInitialized` | `escrow_ii` | `init` |
 | `EscrowPartialSettle` | `part_set` | `partial_settle` |
 | `EscrowSettled` | `escrow_sd` | `settle` |
@@ -120,7 +121,7 @@ Data:
 
 ### `EscrowFunded`
 
-Emitted after successful `fund` or `fund_with_commitment`.
+Emitted after successful `fund`, `fund_with_commitment`, or `fund_batch` (once per entry).
 
 Topics:
 
@@ -139,6 +140,36 @@ Data:
 | `funded_amount` | `i128` |
 | `status` | `u32` |
 | `investor_effective_yield_bps` | `i64` |
+
+### `FundingReached`
+
+Emitted exactly **once** when the escrow transitions from **open** (status 0) to **funded**
+(status 1). This event fires:
+
+1. Inside `fund` / `fund_with_commitment` / `fund_batch` when a deposit crosses the
+   funding threshold — always **after** the corresponding `EscrowFunded` event.
+2. Inside `update_funding_target` when a target lowering promotes an already-credited
+   principal — always **after** the `FundingTargetUpdated` event.
+
+Indexers can subscribe to `fund_rchd` to react to the funding threshold crossing without
+inspecting the `status` field of every per-deposit `EscrowFunded` event.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `funding_reached` |
+| 1 | `name` | `Symbol` | `fund_rchd` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type | Description |
+|---|---|---|
+| `funded_amount` | `i128` | Total principal credited at the moment of the 0→1 transition (may exceed `funding_target` on over-funded escrows). |
+| `funding_target` | `i128` | The effective target that was satisfied. |
+| `ledger_timestamp` | `u64` | `env.ledger().timestamp()` at promotion time. |
+| `ledger_sequence` | `u32` | `env.ledger().sequence()` at promotion time. |
 
 ### `EscrowSettled`
 

--- a/docs/escrow-events.md
+++ b/docs/escrow-events.md
@@ -82,6 +82,42 @@ Emitted when an investor deposits principal.
 }
 ```
 
+### `FundingReached`
+Emitted exactly once when the escrow transitions from **open** (status 0) to **funded** (status 1).
+
+This event is the dedicated state-change signal for the 0→1 transition. Indexers can
+subscribe to `fund_rchd` to react to the funding threshold crossing without inspecting
+the `status` field of every per-deposit `EscrowFunded` event.
+
+The event fires in two situations:
+1. During `fund` / `fund_with_commitment` / `fund_batch` when a deposit crosses the
+   threshold — emitted immediately **after** the per-deposit `EscrowFunded` event.
+2. During `update_funding_target` when a target lowering promotes an
+   already-credited principal — emitted immediately **after** the `FundingTargetUpdated` event.
+
+**Topics:**
+1. `fund_rchd` (Symbol) — ≤ 9 chars, no collision with existing topics
+2. `invoice_id` (Symbol)
+
+**Data Payload:**
+- `funded_amount` (i128) — total principal at the moment of the 0→1 transition (may exceed target on over-funded escrows)
+- `funding_target` (i128) — the effective target that was satisfied
+- `ledger_timestamp` (u64) — ledger timestamp at promotion time
+- `ledger_sequence` (u32) — ledger sequence at promotion time
+
+**Example (JSON Decoded):**
+```json
+{
+  "topics": ["fund_rchd", "INV_001"],
+  "data": {
+    "funded_amount": "10000000000",
+    "funding_target": "10000000000",
+    "ledger_timestamp": 1714180000,
+    "ledger_sequence": 1500
+  }
+}
+```
+
 ### `EscrowSettled`
 Emitted when the SME finalizes the escrow after maturity.
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1399,6 +1399,44 @@ pub struct FundingCancelled {
     pub funded_amount: i128,
 }
 
+/// Emitted exactly once when the escrow transitions from **open** (status 0) to **funded**
+/// (status 1) — i.e. the first time `funded_amount >= funding_target`.
+///
+/// This event fires in two situations:
+/// 1. Inside [`LiquifactEscrow::fund`] / [`LiquifactEscrow::fund_with_commitment`] /
+///    [`LiquifactEscrow::fund_batch`] when a deposit crosses the funding threshold.
+/// 2. Inside [`LiquifactEscrow::update_funding_target`] when a target lowering promotes
+///    an already-funded principal to satisfy the new (lower) target.
+///
+/// The event is **always emitted after** the per-deposit [`EscrowFunded`] event (case 1)
+/// or the [`FundingTargetUpdated`] event (case 2) so indexers can correlate the
+/// threshold-crossing deposit or the target change with the state transition.
+///
+/// # Topics
+/// - `name`: hardcoded `fund_rchd` symbol (≤ 9 chars).
+/// - `invoice_id`: the escrow invoice identifier for efficient filtering.
+///
+/// # Data payload
+/// - `funded_amount`: total principal credited at the moment of transition.
+/// - `funding_target`: the effective target that was satisfied.
+/// - `ledger_timestamp`: `env.ledger().timestamp()` at the moment of promotion.
+/// - `ledger_sequence`: `env.ledger().sequence()` at the moment of promotion.
+#[contractevent]
+pub struct FundingReached {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    /// Total principal credited when the invoice crossed the funding threshold.
+    pub funded_amount: i128,
+    /// The funding target that was satisfied.
+    pub funding_target: i128,
+    /// Ledger timestamp at the moment of the 0→1 status transition.
+    pub ledger_timestamp: u64,
+    /// Ledger sequence number at the moment of the 0→1 status transition.
+    pub ledger_sequence: u32,
+}
+
 #[contractevent]
 pub struct InvestorRefundedEvt {
     #[topic]
@@ -3471,7 +3509,7 @@ impl LiquifactEscrow {
         // If lowering the target causes it to equal (or fall to) the already-funded
         // amount, promote the escrow to funded and capture the immutable close snapshot
         // exactly once — mirroring the promotion logic in `fund`/`fund_with_commitment`.
-        if escrow.funded_amount > 0
+        let promoted = if escrow.funded_amount > 0
             && escrow.funded_amount >= new_target
             && !env.storage().instance().has(&DataKey::FundingCloseSnapshot)
         {
@@ -3485,7 +3523,10 @@ impl LiquifactEscrow {
                     closed_at_ledger_sequence: env.ledger().sequence(),
                 },
             );
-        }
+            true
+        } else {
+            false
+        };
 
         env.storage().instance().set(&DataKey::Escrow, &escrow);
 
@@ -3496,6 +3537,20 @@ impl LiquifactEscrow {
             new_target,
         }
         .publish(&env);
+
+        // Emit the dedicated funding-state-change event when target lowering causes the
+        // 0→1 status promotion, mirroring the emission in `fund_impl`.
+        if promoted {
+            FundingReached {
+                name: symbol_short!("fund_rchd"),
+                invoice_id: escrow.invoice_id.clone(),
+                funded_amount: escrow.funded_amount,
+                funding_target: new_target,
+                ledger_timestamp: env.ledger().timestamp(),
+                ledger_sequence: env.ledger().sequence(),
+            }
+            .publish(&env);
+        }
 
         escrow
     }
@@ -4194,6 +4249,23 @@ impl LiquifactEscrow {
             tier_lock_secs,
         }
         .publish(&env);
+
+        // Emit a dedicated funding-state-change event exactly once when the escrow
+        // transitions from open (status 0) to funded (status 1).  The `EscrowFunded`
+        // event above is a per-deposit record; this event is a per-state-change record,
+        // allowing indexers to react to the threshold crossing without inspecting the
+        // `status` field of every deposit event.
+        if escrow.status == 1 {
+            FundingReached {
+                name: symbol_short!("fund_rchd"),
+                invoice_id: escrow.invoice_id.clone(),
+                funded_amount: escrow.funded_amount,
+                funding_target: escrow.funding_target,
+                ledger_timestamp: env.ledger().timestamp(),
+                ledger_sequence: env.ledger().sequence(),
+            }
+            .publish(&env);
+        }
 
         escrow
     }

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -20,11 +20,11 @@
 use super::{
     AttestationDigestAppended, AttestationDigestRevoked, AttestationDigestUnrevoked,
     CollateralRecordedEvt, ContractUpgraded, DataKey, DeprecatedTransferAdminUsed, EscrowError,
-    EscrowFunded, EscrowInitialized, EscrowUnfunded, FundingCancelled, FundingTargetUpdated,
-    InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient, MaturityMaxHorizonUpdated,
-    MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept,
-    YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH,
-    SCHEMA_VERSION,
+    EscrowFunded, EscrowInitialized, EscrowUnfunded, FundingCancelled, FundingReached,
+    FundingTargetUpdated, InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient,
+    MaturityMaxHorizonUpdated, MaxUniqueInvestorsCapLowered, PrimaryAttestationBound,
+    RegistryRefRebound, TreasuryDustSwept, YieldTier, MAX_ATTESTATION_APPEND_ENTRIES,
+    MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -7607,3 +7607,769 @@ fn test_unfund_event_emitted() {
 
     assert_eq!(*last, expected.to_xdr(&env, &contract_id));
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FundingReached event tests (#692)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Helper: build a `FundingReached` expected XDR for comparison.
+///
+/// Reduces boilerplate in the tests below; every call site still names the
+/// fields explicitly so the assertion is self-documenting.
+fn expected_funding_reached_xdr(
+    env: &Env,
+    contract_id: &Address,
+    invoice_id: soroban_sdk::Symbol,
+    funded_amount: i128,
+    funding_target: i128,
+    ledger_timestamp: u64,
+    ledger_sequence: u32,
+) -> soroban_sdk::Val {
+    use crate::FundingReached;
+    FundingReached {
+        name: symbol_short!("fund_rchd"),
+        invoice_id,
+        funded_amount,
+        funding_target,
+        ledger_timestamp,
+        ledger_sequence,
+    }
+    .to_xdr(env, contract_id)
+}
+
+/// Verify that a single `fund` call which exactly hits the target emits both
+/// `EscrowFunded` (per-deposit) AND `FundingReached` (state-change), in that
+/// order, with correct field values.
+#[test]
+fn test_funding_reached_event_emitted_on_threshold_crossing_via_fund() {
+    use soroban_sdk::testutils::{Events as _, Ledger as _};
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|l| {
+        l.timestamp = 1_000;
+        l.sequence_number = 50;
+    });
+
+    let (contract_id, client) = deploy_with_id(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let target = 10_000i128;
+    let invoice_id = symbol_short!("FR001");
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FR001"),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let investor = Address::generate(&env);
+
+    // Fund exactly the target in one call.
+    client.fund(&investor, &target);
+
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+
+    // There must be at least 2 events: EscrowFunded + FundingReached.
+    assert!(
+        events_list.len() >= 2,
+        "expected at least EscrowFunded and FundingReached events, got {}",
+        events_list.len()
+    );
+
+    // The second-to-last event is EscrowFunded; the last is FundingReached.
+    let funded_event = &events_list[events_list.len() - 2];
+    let reached_event = events_list.last().unwrap();
+
+    // Verify EscrowFunded is correct.
+    let expected_funded = EscrowFunded {
+        name: symbol_short!("funded"),
+        invoice_id: invoice_id.clone(),
+        investor: investor.clone(),
+        amount: target,
+        funded_amount: target,
+        status: 1,
+        investor_effective_yield_bps: 800,
+        tier_lock_secs: 0,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(*funded_event, expected_funded, "EscrowFunded event mismatch");
+
+    // Verify FundingReached has the correct payload.
+    let expected_reached = expected_funding_reached_xdr(
+        &env,
+        &contract_id,
+        invoice_id.clone(),
+        target,
+        target,
+        1_000u64,
+        50u32,
+    );
+    assert_eq!(
+        *reached_event, expected_reached,
+        "FundingReached event mismatch"
+    );
+}
+
+/// Verify that `fund` calls which do NOT cross the threshold (funded_amount < target)
+/// do NOT emit a `FundingReached` event.
+#[test]
+fn test_funding_reached_not_emitted_when_threshold_not_crossed() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, client) = deploy_with_id(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let target = 10_000i128;
+    let invoice_id = symbol_short!("FR002");
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FR002"),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let investor = Address::generate(&env);
+
+    // Fund only half the target — status stays 0, no FundingReached.
+    client.fund(&investor, &(target / 2));
+
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+
+    // Only one event: the per-deposit EscrowFunded.
+    assert_eq!(
+        events_list.len(),
+        1,
+        "expected only EscrowFunded, not FundingReached when threshold not crossed"
+    );
+
+    let expected_funded = EscrowFunded {
+        name: symbol_short!("funded"),
+        invoice_id: invoice_id.clone(),
+        investor: investor.clone(),
+        amount: target / 2,
+        funded_amount: target / 2,
+        status: 0,
+        investor_effective_yield_bps: 800,
+        tier_lock_secs: 0,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(events_list[0], expected_funded);
+}
+
+/// Verify that the second of two deposits triggers `FundingReached` exactly once —
+/// only the deposit that crosses the threshold.
+#[test]
+fn test_funding_reached_emitted_only_on_crossing_deposit() {
+    use soroban_sdk::testutils::{Events as _, Ledger as _};
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|l| {
+        l.timestamp = 2_000;
+        l.sequence_number = 75;
+    });
+
+    let (contract_id, client) = deploy_with_id(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let target = 10_000i128;
+    let invoice_id = symbol_short!("FR003");
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FR003"),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let inv1 = Address::generate(&env);
+    let inv2 = Address::generate(&env);
+
+    // First deposit: partial, no FundingReached.
+    // events().all() returns events from the last invocation only.
+    client.fund(&inv1, &6_000i128);
+    let first_events = env.events().all();
+    assert_eq!(
+        first_events.events().len(),
+        1,
+        "first deposit must emit only EscrowFunded"
+    );
+
+    // Second deposit: crosses the threshold, FundingReached fires.
+    // events().all() again returns only THIS call's events: EscrowFunded + FundingReached.
+    client.fund(&inv2, &4_000i128);
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+
+    // 2 events from the crossing call: EscrowFunded + FundingReached.
+    assert_eq!(
+        events_list.len(),
+        2,
+        "crossing deposit must emit EscrowFunded + FundingReached (2 events from this call)"
+    );
+
+    // Second event (index 1) is FundingReached.
+    let expected_reached = expected_funding_reached_xdr(
+        &env,
+        &contract_id,
+        invoice_id.clone(),
+        10_000i128, // funded_amount at crossing
+        target,
+        2_000u64,
+        75u32,
+    );
+    assert_eq!(
+        events_list[1], expected_reached,
+        "FundingReached must be the second event of the crossing deposit call"
+    );
+}
+
+/// Verify that `fund_with_commitment` crossing the funding threshold emits both
+/// `EscrowFunded` and `FundingReached`.
+#[test]
+fn test_funding_reached_emitted_via_fund_with_commitment() {
+    use soroban_sdk::testutils::{Events as _, Ledger as _};
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|l| {
+        l.timestamp = 5_000;
+        l.sequence_number = 200;
+    });
+
+    let (contract_id, client) = deploy_with_id(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let target = 10_000i128;
+    let invoice_id = symbol_short!("FR004");
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FR004"),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let investor = Address::generate(&env);
+
+    // fund_with_commitment hitting exactly the target; lock 0 → base yield.
+    client.fund_with_commitment(&investor, &target, &0u64);
+
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+
+    // 2 events: EscrowFunded + FundingReached.
+    assert_eq!(
+        events_list.len(),
+        2,
+        "expected EscrowFunded + FundingReached from fund_with_commitment crossing"
+    );
+
+    let expected_reached = expected_funding_reached_xdr(
+        &env,
+        &contract_id,
+        invoice_id.clone(),
+        target,
+        target,
+        5_000u64,
+        200u32,
+    );
+    assert_eq!(
+        events_list[1], expected_reached,
+        "FundingReached must follow EscrowFunded from fund_with_commitment"
+    );
+}
+
+/// Verify that `fund_batch` emits one `EscrowFunded` per entry and exactly one
+/// `FundingReached` when the threshold is crossed during the batch.
+#[test]
+fn test_funding_reached_emitted_via_fund_batch() {
+    use soroban_sdk::testutils::{Events as _, Ledger as _};
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|l| {
+        l.timestamp = 3_000;
+        l.sequence_number = 120;
+    });
+
+    let (contract_id, client) = deploy_with_id(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let target = 10_000i128;
+    let invoice_id = symbol_short!("FR005");
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FR005"),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let inv1 = Address::generate(&env);
+    let inv2 = Address::generate(&env);
+    let inv3 = Address::generate(&env);
+
+    // Build a batch: inv1=4000, inv2=4000, inv3=2000 → crosses at inv3.
+    let mut entries = SorobanVec::new(&env);
+    entries.push_back((inv1.clone(), 4_000i128));
+    entries.push_back((inv2.clone(), 4_000i128));
+    entries.push_back((inv3.clone(), 2_000i128));
+
+    client.fund_batch(&entries);
+
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+
+    // 3 EscrowFunded events + 1 FundingReached = 4 total.
+    assert_eq!(
+        events_list.len(),
+        4,
+        "expected 3×EscrowFunded + 1×FundingReached from fund_batch"
+    );
+
+    // Last event is FundingReached.
+    let expected_reached = expected_funding_reached_xdr(
+        &env,
+        &contract_id,
+        invoice_id.clone(),
+        10_000i128,
+        target,
+        3_000u64,
+        120u32,
+    );
+    assert_eq!(
+        *events_list.last().unwrap(),
+        expected_reached,
+        "FundingReached must be last event in fund_batch sequence"
+    );
+}
+
+/// Verify that `update_funding_target` which promotes an already-funded-amount
+/// escrow to status 1 emits both `FundingTargetUpdated` AND `FundingReached`.
+#[test]
+fn test_funding_reached_emitted_via_update_funding_target_promotion() {
+    use crate::FundingReached;
+    use soroban_sdk::testutils::{Events as _, Ledger as _};
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|l| {
+        l.timestamp = 8_000;
+        l.sequence_number = 300;
+    });
+
+    let (contract_id, client) = deploy_with_id(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let original_target = 10_000i128;
+    let invoice_id = symbol_short!("FR006");
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FR006"),
+        &sme,
+        &original_target,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let investor = Address::generate(&env);
+
+    // Fund partially — escrow remains open.
+    client.fund(&investor, &7_000i128);
+    assert_eq!(client.get_escrow().status, 0);
+
+    // Lower target to match funded_amount → triggers promotion to status 1.
+    client.update_funding_target(&7_000i128);
+
+    // Capture all events (includes init-fund events too).
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+
+    // The last event must be FundingReached (FundingTargetUpdated fires before it).
+    let last = events_list
+        .last()
+        .expect("expected at least one event after update_funding_target");
+
+    let expected_reached = FundingReached {
+        name: symbol_short!("fund_rchd"),
+        invoice_id: invoice_id.clone(),
+        funded_amount: 7_000i128,
+        funding_target: 7_000i128,
+        ledger_timestamp: 8_000u64,
+        ledger_sequence: 300u32,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert_eq!(
+        *last, expected_reached,
+        "FundingReached must be the last event after update_funding_target promotion"
+    );
+
+    // Also verify the second-to-last event is FundingTargetUpdated.
+    use crate::FundingTargetUpdated;
+    let second_to_last = &events_list[events_list.len() - 2];
+    let expected_target_updated = FundingTargetUpdated {
+        name: symbol_short!("fund_tgt"),
+        invoice_id: invoice_id.clone(),
+        old_target: original_target,
+        new_target: 7_000i128,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(
+        *second_to_last, expected_target_updated,
+        "FundingTargetUpdated must precede FundingReached"
+    );
+}
+
+/// Verify that `update_funding_target` which does NOT cause a promotion (funded_amount < new_target)
+/// does NOT emit `FundingReached`.
+#[test]
+fn test_funding_reached_not_emitted_by_update_funding_target_no_promotion() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, client) = deploy_with_id(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let invoice_id = symbol_short!("FR007");
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FR007"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let investor = Address::generate(&env);
+    client.fund(&investor, &5_000i128);
+
+    // Raise target to 20_000 — funded_amount (5_000) < new_target (20_000), no promotion.
+    client.update_funding_target(&20_000i128);
+
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+
+    // Last event should be FundingTargetUpdated, not FundingReached.
+    let last = events_list.last().expect("expected at least one event");
+    use crate::FundingTargetUpdated;
+    let expected_tgt = FundingTargetUpdated {
+        name: symbol_short!("fund_tgt"),
+        invoice_id,
+        old_target: 10_000i128,
+        new_target: 20_000i128,
+    }
+    .to_xdr(&env, &contract_id);
+    assert_eq!(
+        *last, expected_tgt,
+        "last event must be FundingTargetUpdated (not FundingReached) when no promotion"
+    );
+}
+
+/// Verify the `fund_rchd` topic is distinct from all other known event topics, ensuring
+/// no topic collision with the existing event catalog.
+#[test]
+fn test_funding_reached_topic_no_collision() {
+    // All existing event name symbols from the catalog (docs/EVENT_SCHEMA.md).
+    let existing_topics: &[&str] = &[
+        "adm_acc",
+        "adm_can",
+        "adm_prop",
+        "admin",
+        "al_batch",
+        "al_ena",
+        "al_set",
+        "att_app",
+        "att_bind",
+        "att_rev",
+        "att_unrev",
+        "ben_rot",
+        "coll_rec",
+        "coll_clr",
+        "depr_xfer",
+        "dust_sw",
+        "escrow_ii",
+        "escrow_sd",
+        "fund_can",
+        "fund_ext",
+        "fund_tgt",
+        "funded",
+        "inv_cap",
+        "inv_claim",
+        "lh_cancel",
+        "lh_req",
+        "legal_h",
+        "legalhld",
+        "maturity",
+        "mtry_max",
+        "part_set",
+        "paused",
+        "raise_cap",
+        "floor_lo",
+        "reg_rebind",
+        "refunded",
+        "sme_wd",
+        "unfunded",
+        "upgrade",
+    ];
+
+    let new_topic = "fund_rchd";
+    assert!(
+        new_topic.len() <= 9,
+        "fund_rchd must be <= 9 chars (Soroban symbol_short! limit); len={}",
+        new_topic.len()
+    );
+
+    for &existing in existing_topics {
+        assert_ne!(
+            new_topic, existing,
+            "fund_rchd collides with existing topic '{existing}'"
+        );
+    }
+}
+
+/// Verify that `FundingReached` carries the over-funded amount correctly when a deposit
+/// pushes `funded_amount` above the target.
+#[test]
+fn test_funding_reached_payload_with_overfunding() {
+    use soroban_sdk::testutils::{Events as _, Ledger as _};
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|l| {
+        l.timestamp = 4_000;
+        l.sequence_number = 160;
+    });
+
+    let (contract_id, client) = deploy_with_id(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let target = 10_000i128;
+    let invoice_id = symbol_short!("FR008");
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FR008"),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let investor = Address::generate(&env);
+
+    // Fund 12_000 — 2_000 above target (over-funded).
+    let over_amount = 12_000i128;
+    client.fund(&investor, &over_amount);
+
+    let all_events = env.events().all();
+    let events_list = all_events.events();
+
+    // 2 events: EscrowFunded (with funded_amount=12_000, status=1) + FundingReached.
+    assert_eq!(events_list.len(), 2);
+
+    // FundingReached carries the actual funded_amount (12_000), not just the target.
+    let expected_reached = expected_funding_reached_xdr(
+        &env,
+        &contract_id,
+        invoice_id.clone(),
+        over_amount, // funded_amount = actual credited amount
+        target,      // funding_target = original target
+        4_000u64,
+        160u32,
+    );
+    assert_eq!(
+        events_list[1], expected_reached,
+        "FundingReached funded_amount must reflect the actual over-funded total"
+    );
+}
+
+/// Verify that after the escrow is already funded (status=1), further `fund` calls
+/// do NOT re-emit `FundingReached` (idempotency / single-fire guarantee).
+/// Note: additional principal can be added while status=1 is not possible since
+/// `require_funding_open` rejects it, so this test verifies the guard fires.
+#[test]
+fn test_funding_reached_not_emitted_after_already_funded() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let target = 10_000i128;
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "FR009"),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let investor = Address::generate(&env);
+
+    // Fund to exactly the target → status=1.
+    client.fund(&investor, &target);
+    assert_eq!(client.get_escrow().status, 1);
+
+    // Any further fund attempt must fail with EscrowNotOpenForFunding (status guard).
+    let investor2 = Address::generate(&env);
+    let result = client.try_fund(&investor2, &1_000i128);
+    assert_contract_error(result, EscrowError::EscrowNotOpenForFunding);
+}


### PR DESCRIPTION
Closes #692 
Add a dedicated FundingReached event (topic: fund_rchd) that fires exactly once when the escrow transitions from open (status 0) to funded (status 1).

Prior to this change, indexers had to inspect the status field of every per-deposit EscrowFunded event to detect the 0->1 transition. The new event provides a direct, unambiguous signal for the funding threshold crossing.

## Changes

### escrow/src/lib.rs
- Add FundingReached contractevent struct with topics name + invoice_id and data fields funded_amount, funding_target, ledger_timestamp, ledger_sequence
- Emit FundingReached in fund_impl after EscrowFunded when status becomes 1 (covers fund, fund_with_commitment, and fund_batch)
- Emit FundingReached in update_funding_target after FundingTargetUpdated when a target lowering causes the 0->1 promotion

### escrow/src/tests.rs
- Add FundingReached to shared test imports

### escrow/src/tests/funding.rs
- 10 new tests: threshold crossing via fund, fund_with_commitment, fund_batch, update_funding_target; no-emission paths; over-funding payload; topic collision check (fund_rchd unique among all 38 existing topics); already-funded guard

### docs/EVENT_SCHEMA.md + docs/escrow-events.md
- Document FundingReached with full topic/data layout and JSON example
- Update EscrowFunded catalog entry to include fund_batch

No fund movement changed. Topic fund_rchd has no collision with existing topics.