### PR TITLE
feat: add admin update_funding_deadline entrypoint for the open windo…

### DIFF
--- a/docs/escrow-ledger-time.md
+++ b/docs/escrow-ledger-time.md
@@ -280,6 +280,32 @@ and the current deadline has not elapsed:
 
 Indexers should listen for this event to track extended countdowns per invoice.
 
+### `update_funding_deadline` — set, change, or clear
+
+`update_funding_deadline(new_deadline: Option<u64>)` is the general-purpose setter and is also
+restricted to the Open state (status == 0). It does not require a prior deadline and does not
+require the new value to be later than the old one.
+
+| Status | `update_funding_deadline` result |
+|--------|----------------------------------|
+| 0 — Open | ✅ Allowed |
+| 1 — Funded | ❌ `FundingDeadlineUpdateNotOpen` |
+| 2 — Settled | ❌ `FundingDeadlineUpdateNotOpen` |
+| 3 — Withdrawn | ❌ `FundingDeadlineUpdateNotOpen` |
+| 4 — Cancelled | ❌ `FundingDeadlineUpdateNotOpen` |
+
+**Validation:**
+- No deadline need already exist.
+- `Some(d)` requires `d > env.ledger().timestamp()` (`FundingDeadlinePassed`).
+- If `maturity > 0`, `Some(d)` requires `d < maturity` (`FundingDeadlineBeyondMaturity`).
+- `None` clears the deadline; `is_funding_expired()` then returns `false`.
+
+**Event:** `FundingDeadlineUpdated` carries `invoice_id`, `old_deadline`, and `new_deadline`,
+either of which may be `None`.
+
+Indexers tracking countdowns should handle a `new_deadline` of `None` as removal of the
+funding window rather than as an expiry.
+
 ---
 
 ## `MaturityUpdatedEvent`

--- a/docs/escrow-lifecycle.md
+++ b/docs/escrow-lifecycle.md
@@ -306,7 +306,40 @@ this entrypoint.
 - `new_deadline` must be strictly greater than the stored deadline (`FundingDeadlineNotExtended`).
 - When `maturity > 0`, `new_deadline` must be strictly less than maturity (`FundingDeadlineBeyondMaturity`).
 
-**Events:** `FundingDeadlineExtended` carries `invoice_id`, `old_deadline`, and `new_deadline`.
+**Events:** `FundingDeadlineExtended` carries `invoice_id`, `old_deadline`, and `new_deadline`. 
+
+### General deadline setter
+
+`update_funding_deadline(new_deadline: Option<u64>)` is the general-purpose admin setter for
+the funding window, consistent with `update_funding_target()` and `update_maturity()`. It is a
+superset of `extend_funding_deadline()` and additionally supports setting a deadline where none
+was configured at `init`, moving an existing deadline backward while it stays in the future, and
+clearing the deadline entirely by passing `None`.
+
+| Status | `update_funding_deadline` result |
+|--------|----------------------------------|
+| 0 — Open | ✅ Allowed when `new_deadline` is `None`, or `Some(d)` with `d > now` and `d < maturity` (when maturity configured) |
+| 1 — Funded | ❌ `FundingDeadlineUpdateNotOpen` |
+| 2 — Settled | ❌ `FundingDeadlineUpdateNotOpen` |
+| 3 — Withdrawn | ❌ `FundingDeadlineUpdateNotOpen` |
+| 4 — Cancelled | ❌ `FundingDeadlineUpdateNotOpen` |
+
+**Validation rules** (mirroring the `funding_deadline` branch of `init`):
+
+- No prior deadline is required; `None` may be replaced with `Some(d)`.
+- When `new_deadline` is `Some(d)`, `d` must be strictly greater than the current ledger
+  timestamp (`FundingDeadlinePassed`).
+- When `maturity > 0`, `d` must be strictly less than maturity (`FundingDeadlineBeyondMaturity`).
+- Passing `None` removes the stored key, after which `is_funding_expired()` returns `false`.
+
+**Events:** `FundingDeadlineUpdated` carries `invoice_id`, `old_deadline`, and `new_deadline`.
+Either timestamp may be `None`: `old_deadline` is `None` when no deadline was previously set,
+and `new_deadline` is `None` when the admin cleared it.
+
+**Choosing between the two:** use `extend_funding_deadline()` when the intent is specifically a
+forward-only extension and the stricter guarantees (deadline must exist, must not have elapsed,
+must strictly increase) are wanted. Use `update_funding_deadline()` for general configuration.
+
 
 
 ---

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1252,6 +1252,21 @@ pub struct FundingDeadlineExtended {
     pub new_deadline: u64,
 }
 
+/// Emitted by [`LiquifactEscrow::update_funding_deadline`] when the admin sets,
+/// changes, or clears the funding deadline while the escrow is open.
+///
+/// `old_deadline` is `None` when no deadline was configured before the call;
+/// `new_deadline` is `None` when the admin cleared the deadline.
+#[contractevent]
+pub struct FundingDeadlineUpdated {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub old_deadline: Option<u64>,
+    pub new_deadline: Option<u64>,
+}
+
 #[contractevent]
 pub struct LegalHoldChanged {
     #[topic]
@@ -4774,6 +4789,87 @@ impl LiquifactEscrow {
         .publish(&env);
 
         escrow
+    }
+    /// Set, change, or clear the funding deadline while the escrow is still open.
+    ///
+    /// This is the general-purpose admin setter for the funding window, and is
+    /// consistent with the other open-state setters
+    /// ([`LiquifactEscrow::update_funding_target`], [`LiquifactEscrow::update_maturity`]).
+    /// Unlike [`LiquifactEscrow::extend_funding_deadline`], which only ever pushes an
+    /// existing deadline forward, this entrypoint accepts an `Option<u64>` and can:
+    ///
+    /// - set a deadline when none was configured at `init`,
+    /// - move an existing deadline forward or backward, provided it stays in the future,
+    /// - clear the deadline entirely by passing `None`, restoring the
+    ///   "no deadline" semantics that [`LiquifactEscrow::is_funding_expired`] reads as
+    ///   never expired.
+    ///
+    /// Validation mirrors the `funding_deadline` branch of [`LiquifactEscrow::init`]:
+    /// a supplied deadline must be strictly in the future, and must fall strictly
+    /// before a non-zero maturity.
+    ///
+    /// # Authorization
+    /// Requires the signature of the current [`InvoiceEscrow::admin`].
+    ///
+    /// # Errors
+    /// - [`EscrowError::FundingDeadlineUpdateNotOpen`] if the escrow is not status `0`.
+    /// - [`EscrowError::FundingDeadlinePassed`] if `new_deadline` is `Some(d)` and
+    ///   `d` is not strictly greater than the current ledger timestamp.
+    /// - [`EscrowError::FundingDeadlineBeyondMaturity`] if `new_deadline` is `Some(d)`,
+    ///   a non-zero maturity is configured, and `d >= maturity`.
+    ///
+    /// # Events
+    /// Emits [`FundingDeadlineUpdated`] with `invoice_id`, `old_deadline`, and
+    /// `new_deadline`, either of which may be `None`.
+    pub fn update_funding_deadline(env: Env, new_deadline: Option<u64>) -> Option<u64> {
+        let escrow = Self::load_escrow_require_admin(&env);
+
+        guard_status_eq(
+            &env,
+            escrow.status,
+            0,
+            EscrowError::FundingDeadlineUpdateNotOpen,
+        );
+
+        let old_deadline = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&DataKey::FundingDeadline);
+
+        match new_deadline {
+            Some(deadline) => {
+                let now = env.ledger().timestamp();
+                ensure(&env, deadline > now, EscrowError::FundingDeadlinePassed);
+                if escrow.maturity > 0 {
+                    ensure(
+                        &env,
+                        deadline < escrow.maturity,
+                        EscrowError::FundingDeadlineBeyondMaturity,
+                    );
+                }
+                env.storage()
+                    .instance()
+                    .set(&DataKey::FundingDeadline, &deadline);
+            }
+            None => {
+                env.storage().instance().remove(&DataKey::FundingDeadline);
+            }
+        }
+
+        env.storage().instance().extend_ttl(
+            INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
+            INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
+        );
+
+        FundingDeadlineUpdated {
+            name: symbol_short!("fund_upd"),
+            invoice_id: escrow.invoice_id,
+            old_deadline,
+            new_deadline,
+        }
+        .publish(&env);
+
+        new_deadline
     }
 
     /// Extend the configured funding deadline while the escrow is still open.

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -7607,3 +7607,244 @@ fn test_unfund_event_emitted() {
 
     assert_eq!(*last, expected.to_xdr(&env, &contract_id));
 }
+
+// ── Issue #637: update_funding_deadline ──────────────────────────────────────
+// General-purpose admin setter for the funding window. Unlike
+// `extend_funding_deadline` (issue #551, forward-only), this accepts an
+// `Option<u64>` and can set from none, move in either direction while the
+// value stays in the future, or clear the deadline entirely.
+
+fn init_with_optional_deadline<'a>(
+    env: &'a Env,
+    client: &LiquifactEscrowClient<'a>,
+    admin: &Address,
+    sme: &Address,
+    deadline: Option<u64>,
+    maturity: u64,
+) -> StellarTestToken<'a> {
+    let token = install_stellar_asset_token(env);
+    let treasury = Address::generate(env);
+    client.init(
+        admin,
+        &String::from_str(env, "FDU01"),
+        sme,
+        &TARGET,
+        &800i64,
+        &maturity,
+        &token.id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &deadline,
+        &None,
+        &None::<i64>,
+    );
+    token
+}
+
+#[test]
+fn test_update_funding_deadline_sets_from_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    init_with_optional_deadline(&env, &client, &admin, &sme, None, 0);
+
+    assert_eq!(client.get_funding_deadline(), None);
+
+    let target = env.ledger().timestamp() + 500;
+    let returned = client.update_funding_deadline(&Some(target));
+
+    assert_eq!(returned, Some(target));
+    assert_eq!(client.get_funding_deadline(), Some(target));
+}
+
+#[test]
+fn test_update_funding_deadline_extends_forward() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let initial = env.ledger().timestamp() + 100;
+    init_with_optional_deadline(&env, &client, &admin, &sme, Some(initial), 0);
+
+    let extended = initial + 400;
+    assert_eq!(
+        client.update_funding_deadline(&Some(extended)),
+        Some(extended)
+    );
+    assert_eq!(client.get_funding_deadline(), Some(extended));
+}
+
+#[test]
+fn test_update_funding_deadline_shortens_while_future() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let initial = env.ledger().timestamp() + 1_000;
+    init_with_optional_deadline(&env, &client, &admin, &sme, Some(initial), 0);
+
+    // Pulling the deadline back is allowed as long as it stays in the future.
+    // This is the case `extend_funding_deadline` deliberately rejects.
+    let shortened = env.ledger().timestamp() + 50;
+    assert_eq!(
+        client.update_funding_deadline(&Some(shortened)),
+        Some(shortened)
+    );
+    assert_eq!(client.get_funding_deadline(), Some(shortened));
+}
+
+#[test]
+fn test_update_funding_deadline_clears_to_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let initial = env.ledger().timestamp() + 200;
+    init_with_optional_deadline(&env, &client, &admin, &sme, Some(initial), 0);
+
+    assert_eq!(client.update_funding_deadline(&None::<u64>), None);
+    assert_eq!(client.get_funding_deadline(), None);
+    assert!(
+        !client.is_funding_expired(),
+        "an absent deadline must read as never expired"
+    );
+}
+
+#[test]
+fn test_update_funding_deadline_rejects_past_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let initial = env.ledger().timestamp() + 500;
+    init_with_optional_deadline(&env, &client, &admin, &sme, Some(initial), 0);
+
+    let mut ledger_info = env.ledger().get();
+    ledger_info.timestamp = 1_000;
+    env.ledger().set(ledger_info);
+
+    let past = env.ledger().timestamp() - 1;
+    assert_contract_error(
+        client.try_update_funding_deadline(&Some(past)),
+        EscrowError::FundingDeadlinePassed,
+    );
+    assert_eq!(
+        client.get_funding_deadline(),
+        Some(initial),
+        "a rejected update must not alter the stored deadline"
+    );
+}
+
+#[test]
+fn test_update_funding_deadline_rejects_current_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let initial = env.ledger().timestamp() + 500;
+    init_with_optional_deadline(&env, &client, &admin, &sme, Some(initial), 0);
+
+    let now = env.ledger().timestamp();
+    assert_contract_error(
+        client.try_update_funding_deadline(&Some(now)),
+        EscrowError::FundingDeadlinePassed,
+    );
+}
+
+#[test]
+fn test_update_funding_deadline_rejects_at_or_after_maturity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let maturity = env.ledger().timestamp() + 10_000;
+    let initial = env.ledger().timestamp() + 100;
+    init_with_optional_deadline(&env, &client, &admin, &sme, Some(initial), maturity);
+
+    assert_contract_error(
+        client.try_update_funding_deadline(&Some(maturity)),
+        EscrowError::FundingDeadlineBeyondMaturity,
+    );
+    assert_contract_error(
+        client.try_update_funding_deadline(&Some(maturity + 1)),
+        EscrowError::FundingDeadlineBeyondMaturity,
+    );
+    assert_eq!(client.get_funding_deadline(), Some(initial));
+}
+
+#[test]
+fn test_update_funding_deadline_rejects_when_not_open() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    let initial = env.ledger().timestamp() + 500;
+    let token = init_with_optional_deadline(&env, &client, &admin, &sme, Some(initial), 0);
+
+    // Fill the target to promote the escrow out of status 0.
+    token.stellar.mint(&investor, &TARGET);
+    client.fund(&investor, &TARGET);
+    assert_eq!(client.get_escrow().status, 1);
+
+    assert_contract_error(
+        client.try_update_funding_deadline(&Some(initial + 100)),
+        EscrowError::FundingDeadlineUpdateNotOpen,
+    );
+}
+
+#[test]
+fn test_update_funding_deadline_reflected_by_is_funding_expired() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let initial = env.ledger().timestamp() + 100;
+    init_with_optional_deadline(&env, &client, &admin, &sme, Some(initial), 0);
+
+    assert!(!client.is_funding_expired());
+
+    // Push the window out, then advance past the original deadline.
+    let extended = initial + 1_000;
+    client.update_funding_deadline(&Some(extended));
+
+    let mut ledger_info = env.ledger().get();
+    ledger_info.timestamp = initial + 10;
+    env.ledger().set(ledger_info);
+
+    assert!(
+        !client.is_funding_expired(),
+        "is_funding_expired must read the updated deadline, not the original"
+    );
+
+    let mut ledger_info = env.ledger().get();
+    ledger_info.timestamp = extended + 1;
+    env.ledger().set(ledger_info);
+
+    assert!(client.is_funding_expired());
+}
+
+#[test]
+fn test_update_funding_deadline_emits_event() {
+    use soroban_sdk::testutils::Events as _;
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let initial = env.ledger().timestamp() + 100;
+    init_with_optional_deadline(&env, &client, &admin, &sme, Some(initial), 0);
+
+    let updated = initial + 500;
+    client.update_funding_deadline(&Some(updated));
+
+    let last = env.events().all().events().last().unwrap().clone();
+    let expected = crate::FundingDeadlineUpdated {
+        name: symbol_short!("fund_upd"),
+        invoice_id: client.get_escrow().invoice_id.clone(),
+        old_deadline: Some(initial),
+        new_deadline: Some(updated),
+    }
+    .to_xdr(&env, &client.address);
+    assert_eq!(
+        last, expected,
+        "update_funding_deadline must publish FundingDeadlineUpdated"
+    );
+    assert_eq!(client.get_funding_deadline(), Some(updated));
+}


### PR DESCRIPTION
Closes #637

## Summary

Adds `update_funding_deadline(new_deadline: Option<u64>)`, an admin-gated,
open-state-only setter for the escrow funding window. It sits alongside the
existing `extend_funding_deadline()` and is consistent with the other
open-state setters (`update_funding_target()`, `update_maturity()`).

## Scope note for reviewers

The issue describes the funding deadline as write-once with no post-deployment
entrypoint. That is only partly accurate as of `main`:

- `extend_funding_deadline()` (issue #551) already exists and pushes an
  existing deadline **forward only**.
- `docs/escrow-lifecycle.md:255` and `docs/escrow-ledger-time.md:260` already
  referenced `update_funding_deadline()` by name, and the doc comment on error
  `171` (`FundingDeadlineUpdateNotOpen`) did too — the entrypoint was
  anticipated but never implemented.

This PR implements the anticipated entrypoint as a superset of the existing
one, rather than modifying `extend_funding_deadline()` (no behavior change to
an existing entrypoint, no test churn).

| Capability | `extend_funding_deadline` | `update_funding_deadline` |
|---|---|---|
| Set when none configured at `init` | ❌ | ✅ |
| Move forward | ✅ | ✅ |
| Move backward (still future) | ❌ | ✅ |
| Clear to `None` | ❌ | ✅ |

## Changes

- **`escrow/src/lib.rs`** — new entrypoint and `FundingDeadlineUpdated`
  contractevent carrying `Option<u64>` for both old and new values.
- **`escrow/src/tests/funding.rs`** — 10 tests.
- **`docs/escrow-lifecycle.md`, `docs/escrow-ledger-time.md`** — document both
  entrypoints and when to use each.

## Security notes

- **Authorization:** admin-only via `load_escrow_require_admin`, the same guard
  used by every other open-state setter.
- **State gate:** `guard_status_eq(status, 0, FundingDeadlineUpdateNotOpen)`.
  The deadline cannot be changed once investors have committed, preventing
  retroactive funding-window changes.
- **Future-dated only:** `Some(d)` requires `d > env.ledger().timestamp()`.
  An admin cannot back-date the window to force an immediate expiry.
- **Maturity invariant preserved:** when `maturity > 0`, `d < maturity` is
  enforced, so the funding window can never reach or pass settlement.
- **No new error variants.** Reuses `FundingDeadlineUpdateNotOpen` (171),
  `FundingDeadlinePassed` (164), and `FundingDeadlineBeyondMaturity` (204).
  Validation mirrors the `funding_deadline` branch of `init` exactly.
- **Clearing is not an expiry.** `None` removes the storage key, restoring the
  documented "no deadline" semantics where `is_funding_expired()` returns
  `false`. Indexers are told to treat a `None` in the event as removal, not
  expiry.
- **Failed calls are inert** — tests assert the stored deadline is unchanged
  after a rejected update.

## Test results

`cargo test`: **850 passed, 0 failed, 54 ignored** (baseline was 840; +10 new).
`cargo fmt --all -- --check` and `cargo build` clean.

## Known harness limitation

The test env retains only the most recent contract event, so the event test
asserts on the last event's XDR rather than on a count. This matches the
pattern in the neighboring (currently `#[ignore]`d) `extend_funding_deadline`
event test.