### PR TITLE
Enhancement/contracts protocol fee event

### DIFF
--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -33,7 +33,7 @@ short routing symbol passed with `symbol_short!(...)`, such as `funded` or
 
 ## Event Catalog
 
-The current contract defines 36 event structs.
+The current contract defines 37 event structs.
 
 | Rust event | `name` symbol | Entrypoint(s) |
 |---|---:|---|
@@ -72,6 +72,7 @@ The current contract defines 36 event structs.
 | `MaxUniqueInvestorsCapRaised` | `raise_cap` | `raise_max_unique_investors` |
 | `MinContributionFloorLowered` | `floor_lo` | `lower_min_contribution_floor` |
 | `PrimaryAttestationBound` | `att_bind` | `bind_primary_attestation_hash` |
+| `ProtocolFeeWithdrawn` | `prot_fee` | `withdraw` |
 | `RegistryRefRebound` | `reg_rebind` | `set_registry` |
 | `SmeWithdrew` | `sme_wd` | `withdraw` |
 | `TreasuryDustSwept` | `dust_sw` | `sweep_terminal_dust` |
@@ -340,6 +341,31 @@ Data:
 | Field | Type |
 |---|---|
 | `amount` | `i128` |
+| `recipient` | `Address` |
+| `fee` | `i128` |
+
+### `ProtocolFeeWithdrawn`
+
+Emitted after successful `withdraw` only when the computed protocol fee is
+non-zero. This records the treasury leg separately from the SME net withdrawal
+event so accounting integrations do not need to re-derive the protocol cut.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `protocol_fee_withdrawn` |
+| 1 | `name` | `Symbol` | `prot_fee` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `fee_amount` | `i128` |
+| `fee_bps` | `i64` |
+| `treasury` | `Address` |
+| `sme_net_amount` | `i128` |
 
 ### `InvestorPayoutClaimed`
 

--- a/escrow/src/external_calls.rs
+++ b/escrow/src/external_calls.rs
@@ -180,6 +180,7 @@ pub fn transfer_funding_token_with_balance_checks(
 /// fee-on-transfer, rebasing, or hook behaviors. Non-compliant tokens will cause this
 /// function to fail with a typed error, serving as a safety boundary. Such tokens should be
 /// excluded through governance allowlists and integration review processes.
+/// 
 pub fn transfer_into_escrow_with_balance_checks(
     env: &Env,
     token: &Address,

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1380,6 +1380,28 @@ pub struct SmeWithdrew {
     pub fee: i128,
 }
 
+/// Emitted from [`LiquifactEscrow::withdraw`] when a non-zero protocol fee is
+/// transferred to [`DataKey::Treasury`].
+///
+/// This event records the treasury leg separately from [`SmeWithdrew`] so
+/// accounting integrations can observe the exact fee amount, effective basis
+/// points, treasury recipient, and SME net payout without re-deriving the split.
+#[contractevent]
+pub struct ProtocolFeeWithdrawn {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    /// Protocol fee amount transferred to the immutable treasury address.
+    pub fee_amount: i128,
+    /// Effective protocol fee basis points used for this withdrawal.
+    pub fee_bps: i64,
+    /// Immutable treasury address that received `fee_amount`.
+    pub treasury: Address,
+    /// Net amount transferred to the SME after deducting `fee_amount`.
+    pub sme_net_amount: i128,
+}
+
 #[contractevent]
 pub struct InvestorPayoutClaimed {
     #[topic]
@@ -4337,7 +4359,7 @@ impl LiquifactEscrow {
     /// 6. Status transition to 3, `DistributedPrincipal` update (by the full gross
     ///    `funded_amount`), storage write.
     /// 7. SEP-41 token transfers (fee → treasury, net → SME) with balance-delta verification.
-    /// 8. Event emission ([`SmeWithdrew`], carrying `amount = sme_payout` and `fee`).
+    /// 8. Event emission ([`ProtocolFeeWithdrawn`] when `fee > 0`, then [`SmeWithdrew`]).
     ///
     /// # Errors
     /// - [`EscrowError::LegalHoldBlocksWithdrawal`] — hold is active.
@@ -4423,6 +4445,15 @@ impl LiquifactEscrow {
                 &treasury,
                 fee,
             );
+            ProtocolFeeWithdrawn {
+                name: symbol_short!("prot_fee"),
+                invoice_id: escrow.invoice_id.clone(),
+                fee_amount: fee,
+                fee_bps,
+                treasury,
+                sme_net_amount: net,
+            }
+            .publish(&env);
         }
         if net > 0 {
             external_calls::transfer_funding_token_with_balance_checks(

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -22,9 +22,9 @@ use super::{
     CollateralRecordedEvt, ContractUpgraded, DataKey, DeprecatedTransferAdminUsed, EscrowError,
     EscrowFunded, EscrowInitialized, EscrowUnfunded, FundingCancelled, FundingTargetUpdated,
     InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient, MaturityMaxHorizonUpdated,
-    MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept,
-    YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH,
-    SCHEMA_VERSION,
+    MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, ProtocolFeeWithdrawn,
+    RegistryRefRebound, TreasuryDustSwept, YieldTier, MAX_ATTESTATION_APPEND_ENTRIES,
+    MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -907,6 +907,62 @@ fn setup_withdraw_with_token<'a>(
     (client, escrow_id, token, sme)
 }
 
+/// Helper: same as `setup_withdraw_with_token`, but initializes the escrow with
+/// an explicit protocol fee and returns the treasury address for fee assertions.
+fn setup_withdraw_with_token_and_fee<'a>(
+    env: &'a Env,
+    target: i128,
+    invoice_id: &'a str,
+    protocol_fee_bps: i64,
+) -> (
+    LiquifactEscrowClient<'a>,
+    soroban_sdk::Address,
+    soroban_sdk::token::TokenClient<'a>,
+    soroban_sdk::Address,
+    soroban_sdk::Address,
+) {
+    use crate::LiquifactEscrow;
+    use soroban_sdk::token::{StellarAssetClient, TokenClient};
+
+    let sac = env.register_stellar_asset_contract_v2(soroban_sdk::Address::generate(env));
+    let token_id = sac.address();
+    let sac_admin = StellarAssetClient::new(env, &token_id);
+    let token = TokenClient::new(env, &token_id);
+
+    let escrow_id = env.register(LiquifactEscrow, ());
+    let client = LiquifactEscrowClient::new(env, &escrow_id);
+    let admin = soroban_sdk::Address::generate(env);
+    let sme = soroban_sdk::Address::generate(env);
+    let treasury = soroban_sdk::Address::generate(env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, invoice_id),
+        &sme,
+        &target,
+        &800i64,
+        &0u64,
+        &token_id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &Some(protocol_fee_bps),
+    );
+
+    let investor = soroban_sdk::Address::generate(env);
+    sac_admin.mint(&investor, &target);
+    client.fund(&investor, &target);
+
+    (client, escrow_id, token, sme, treasury)
+}
+
 /// SME receives exactly `funded_amount` tokens and the escrow contract balance
 /// drops to zero after a successful `withdraw`.
 #[test]
@@ -943,6 +999,86 @@ fn withdraw_transfers_funded_amount_to_sme() {
         client.get_escrow().status,
         3u32,
         "status must be 3 after withdraw"
+    );
+}
+
+/// `withdraw` emits a dedicated protocol-fee event when the computed treasury
+/// cut is non-zero.
+#[test]
+fn withdraw_emits_protocol_fee_event_when_fee_nonzero() {
+    use crate::ProtocolFeeWithdrawn;
+    use soroban_sdk::{symbol_short, testutils::Events};
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let target = 20_000_000i128;
+    let fee_bps = 250i64;
+    let expected_fee = 500_000i128;
+    let expected_net = 19_500_000i128;
+    let (client, escrow_id, token, sme, treasury) =
+        setup_withdraw_with_token_and_fee(&env, target, "WD_PF001", fee_bps);
+
+    client.withdraw();
+
+    let all_events = env.events().all().filter_by_contract(&escrow_id);
+    let escrow = client.get_escrow();
+
+    assert_eq!(token.balance(&treasury), expected_fee);
+    assert_eq!(token.balance(&sme), expected_net);
+
+    let expected_xdr = ProtocolFeeWithdrawn {
+        name: symbol_short!("prot_fee"),
+        invoice_id: escrow.invoice_id.clone(),
+        fee_amount: expected_fee,
+        fee_bps,
+        treasury,
+        sme_net_amount: expected_net,
+    }
+    .to_xdr(&env, &escrow_id);
+
+    assert!(
+        all_events.events().contains(&expected_xdr),
+        "ProtocolFeeWithdrawn must record treasury fee and SME net amount"
+    );
+}
+
+/// `withdraw` does not emit the protocol-fee event when floor rounding computes
+/// a zero fee, preserving the no-fee observable path.
+#[test]
+fn withdraw_skips_protocol_fee_event_when_computed_fee_zero() {
+    use crate::ProtocolFeeWithdrawn;
+    use soroban_sdk::{symbol_short, testutils::Events};
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let target = 99i128;
+    let fee_bps = 1i64;
+    let (client, escrow_id, token, sme, treasury) =
+        setup_withdraw_with_token_and_fee(&env, target, "WD_PF002", fee_bps);
+
+    client.withdraw();
+
+    let all_events = env.events().all().filter_by_contract(&escrow_id);
+    let escrow = client.get_escrow();
+
+    assert_eq!(token.balance(&treasury), 0);
+    assert_eq!(token.balance(&sme), target);
+
+    let unexpected_xdr = ProtocolFeeWithdrawn {
+        name: symbol_short!("prot_fee"),
+        invoice_id: escrow.invoice_id.clone(),
+        fee_amount: 0,
+        fee_bps,
+        treasury,
+        sme_net_amount: target,
+    }
+    .to_xdr(&env, &escrow_id);
+
+    assert!(
+        !all_events.events().contains(&unexpected_xdr),
+        "ProtocolFeeWithdrawn must be skipped when computed fee is zero"
     );
 }
 


### PR DESCRIPTION
## Summary

- Add a dedicated `ProtocolFeeWithdrawn` event emitted from `withdraw()` when the protocol fee is non-zero.
- Record the fee amount, effective fee bps, treasury address, and SME net amount for indexers/accounting integrations.
- Register the new `prot_fee` event topic in `docs/EVENT_SCHEMA.md`.

## Testing

- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`

Closes #655