### PR TITLE
test(yield-tier): cover boundaries and rejections

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1400,6 +1400,17 @@ pub struct FundingCancelled {
 }
 
 #[contractevent]
+pub struct SettlementStateChanged {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub old_status: u32,
+    pub new_status: u32,
+    pub funded_amount: i128,
+}
+
+#[contractevent]
 pub struct InvestorRefundedEvt {
     #[topic]
     pub name: Symbol,
@@ -1538,6 +1549,23 @@ pub struct InvestorAllowlistChanged {
     pub name: Symbol,
     pub invoice_id: Symbol,
     pub investor: Address,
+    /// `1` = allowed, `0` = blocked.
+    pub allowed: u32,
+}
+
+/// Emitted once per [`LiquifactEscrow::set_investors_allowlisted`] call after
+/// all per-investor `InvestorAllowlistChanged` events, providing a single
+/// batch-level signal for indexers.
+#[contractevent]
+pub struct InvestorAllowlistBatchApplied {
+    /// Hardcoded `"al_batch"` symbol (topic).
+    #[topic]
+    pub name: Symbol,
+    /// The escrow's `invoice_id` (topic, for indexer correlation).
+    #[topic]
+    pub invoice_id: Symbol,
+    /// Number of addresses in the batch.
+    pub batch_size: u32,
     /// `1` = allowed, `0` = blocked.
     pub allowed: u32,
 }
@@ -3294,6 +3322,14 @@ impl LiquifactEscrow {
             }
             .publish(&env);
         }
+
+        InvestorAllowlistBatchApplied {
+            name: symbol_short!("al_batch"),
+            invoice_id: escrow.invoice_id.clone(),
+            batch_size: n,
+            allowed: if allowed { 1 } else { 0 },
+        }
+        .publish(&env);
     }
 
     pub fn is_investor_allowlisted(env: Env, investor: Address) -> bool {

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    AllowlistEnabledChanged, DataKey, EscrowError, InvestorAllowlistChanged, LiquifactEscrow,
-    LiquifactEscrowClient,
+    AllowlistEnabledChanged, DataKey, EscrowError, InvestorAllowlistBatchApplied,
+    InvestorAllowlistChanged, LiquifactEscrow, LiquifactEscrowClient,
 };
 use soroban_sdk::Vec as SorobanVec;
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Error, Event, InvokeError};
@@ -918,4 +918,353 @@ fn gate_batch_revoke_blocks_all_revoked_members() {
     // Contributions remain at the pre-revocation values.
     assert_eq!(client.get_contribution(&a), 1_000i128);
     assert_eq!(client.get_contribution(&b), 1_000i128);
+}
+
+// =============================================================================
+// Batch event tests – InvestorAllowlistBatchApplied (`al_batch`)
+//
+// Every `set_investors_allowlisted` call must emit:
+//   - one `InvestorAllowlistChanged` (`al_set`) per address in the batch, AND
+//   - exactly one `InvestorAllowlistBatchApplied` (`al_batch`) at the end.
+// =============================================================================
+
+/// Batch allow emits N per-investor events plus exactly 1 batch event.
+#[test]
+fn test_batch_allowlist_emits_batch_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(a.clone());
+    batch.push_back(b.clone());
+    batch.push_back(c.clone());
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    // Count al_set events (one per address).
+    let al_set_count: u32 = events
+        .iter()
+        .filter(|e| {
+            **e == InvestorAllowlistChanged {
+                name: symbol_short!("al_set"),
+                invoice_id: invoice_id.clone(),
+                investor: a.clone(),
+                allowed: 1,
+            }
+            .to_xdr(&env, &contract_id)
+                || **e
+                    == InvestorAllowlistChanged {
+                        name: symbol_short!("al_set"),
+                        invoice_id: invoice_id.clone(),
+                        investor: b.clone(),
+                        allowed: 1,
+                    }
+                    .to_xdr(&env, &contract_id)
+                || **e
+                    == InvestorAllowlistChanged {
+                        name: symbol_short!("al_set"),
+                        invoice_id: invoice_id.clone(),
+                        investor: c.clone(),
+                        allowed: 1,
+                    }
+                    .to_xdr(&env, &contract_id)
+        })
+        .count() as u32;
+
+    assert_eq!(al_set_count, 3, "one al_set per address in the batch");
+
+    // Verify exactly one batch event exists.
+    let batch_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id: invoice_id.clone(),
+        batch_size: 3,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events.contains(&batch_xdr),
+        "exactly one al_batch event must be emitted"
+    );
+}
+
+/// Batch revoke emits N per-investor events plus exactly 1 batch event.
+#[test]
+fn test_batch_revoke_emits_batch_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(a.clone());
+    batch.push_back(b.clone());
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+
+    // Clear events from the first batch call.
+    let _ = env.events().all();
+
+    // Now revoke.
+    client.set_investors_allowlisted(&batch, &false);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    // Verify per-investor events (both with allowed=0).
+    let al_set_a = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: a.clone(),
+        allowed: 0,
+    }
+    .to_xdr(&env, &contract_id);
+    let al_set_b = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: b.clone(),
+        allowed: 0,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(events.contains(&al_set_a), "must emit al_set for a");
+    assert!(events.contains(&al_set_b), "must emit al_set for b");
+
+    // Verify batch event.
+    let batch_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: 2,
+        allowed: 0,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events.contains(&batch_xdr),
+        "exactly one al_batch event must be emitted"
+    );
+}
+
+/// Single-element batch emits 1 al_set + 1 al_batch.
+#[test]
+fn test_single_element_batch_emits_both_events() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(a.clone());
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    let al_set_xdr = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: a,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    let batch_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: 1,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert!(events.contains(&al_set_xdr), "must emit 1 al_set");
+    assert!(events.contains(&batch_xdr), "must emit 1 al_batch");
+}
+
+/// Max-size batch emits N al_set + 1 al_batch.
+#[test]
+fn test_max_size_batch_emits_correct_event_count() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let max_batch = super::MAX_INVESTOR_ALLOWLIST_BATCH as usize;
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    let mut addrs: SorobanVec<Address> = SorobanVec::new(&env);
+    for _ in 0..max_batch {
+        let addr = Address::generate(&env);
+        addrs.push_back(addr.clone());
+        batch.push_back(addr);
+    }
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    // Count how many al_set events match any of the generated addresses.
+    let mut al_set_found = 0u32;
+    for i in 0..addrs.len() {
+        let addr = addrs.get(i).unwrap();
+        let xdr = InvestorAllowlistChanged {
+            name: symbol_short!("al_set"),
+            invoice_id: invoice_id.clone(),
+            investor: addr,
+            allowed: 1,
+        }
+        .to_xdr(&env, &contract_id);
+        if events.contains(&xdr) {
+            al_set_found += 1;
+        }
+    }
+    assert_eq!(
+        al_set_found, max_batch as u32,
+        "must emit one al_set per address"
+    );
+
+    let batch_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: max_batch as u32,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(events.contains(&batch_xdr), "must emit exactly 1 al_batch");
+}
+
+/// Single-address setter does NOT emit al_batch event.
+#[test]
+fn test_single_allowlist_setter_does_not_emit_batch_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&a, &true);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    // Must have exactly 1 al_set.
+    let al_set_xdr = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: a,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events.contains(&al_set_xdr),
+        "single setter must emit al_set"
+    );
+
+    // Must NOT have any al_batch.
+    let batch_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: 1,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        !events.contains(&batch_xdr),
+        "single setter must not emit al_batch"
+    );
+}
+
+/// Multiple consecutive batch calls each emit their own batch event.
+#[test]
+fn test_multiple_batch_calls_each_emit_batch_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let mut batch1: SorobanVec<Address> = SorobanVec::new(&env);
+    batch1.push_back(a.clone());
+    batch1.push_back(b.clone());
+
+    let mut batch2: SorobanVec<Address> = SorobanVec::new(&env);
+    batch2.push_back(c.clone());
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch1, &true);
+    client.set_investors_allowlisted(&batch2, &true);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    // Batch 1: 2 al_set + 1 al_batch (batch_size=2, allowed=1)
+    // Batch 2: 1 al_set  + 1 al_batch (batch_size=1, allowed=1)
+    // Total:   3 al_set  + 2 al_batch
+
+    let batch1_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id: invoice_id.clone(),
+        batch_size: 2,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    let batch2_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: 1,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert!(
+        events.contains(&batch1_xdr),
+        "must emit al_batch(batch_size=2) from first call"
+    );
+    assert!(
+        events.contains(&batch2_xdr),
+        "must emit al_batch(batch_size=1) from second call"
+    );
 }

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -75,6 +75,7 @@ mod pause;
 mod properties;
 mod reconciliation_lifecycle;
 mod settlement;
+mod yield_tier_boundaries;
 
 /// Registers a new escrow contract instance and returns its contract id.
 pub fn deploy_id(env: &Env) -> Address {

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -22,9 +22,11 @@ use super::{
     install_stellar_asset_token, setup, StellarTestToken, MAX_DUST_SWEEP_AMOUNT, TARGET,
 };
 use crate::{
-    EscrowError, EscrowSettled, InvoiceEscrow, LiquifactEscrow, SettlementReadiness, YieldTier,
+    EscrowError, EscrowSettled, InvoiceEscrow, LiquifactEscrow, SettlementReadiness,
+    SettlementStateChanged, YieldTier,
 };
 use soroban_sdk::{
+    symbol_short,
     testutils::{Address as _, Events, Ledger as _},
     token::StellarAssetClient,
     Address, Env, Event, String, Vec as SorobanVec,
@@ -2781,4 +2783,217 @@ fn test_settle_pool_no_maturity() {
     assert_eq!(escrow.yield_bps, yield_bps);
     assert_eq!(escrow.maturity, 0u64);
     assert_eq!(escrow.status, 2, "Escrow must be in settled state");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SettlementStateChanged event (GitHub Issue #697)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `settle` must emit a `SettlementStateChanged` event with `old_status=1` and `new_status=2`.
+#[test]
+fn settle_emits_settlement_state_changed() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _sme, _sac) = setup_funded_with_token(&env);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    client.settle();
+
+    let all_events = env.events().all();
+    let event_list = all_events.events();
+
+    // settle() emits SettlementStateChanged then EscrowSettled (2 events).
+    assert!(
+        event_list.len() >= 2,
+        "settle must emit at least 2 events, got {}",
+        event_list.len()
+    );
+
+    // The first event emitted by settle is SettlementStateChanged.
+    assert_eq!(
+        event_list.get(0).unwrap().clone(),
+        SettlementStateChanged {
+            name: symbol_short!("setl_st"),
+            invoice_id,
+            old_status: 1,
+            new_status: 2,
+            funded_amount: TARGET,
+        }
+        .to_xdr(&env, &contract_id),
+        "first event must be SettlementStateChanged with old_status=1, new_status=2"
+    );
+}
+
+/// `withdraw` must emit a `SettlementStateChanged` event with `old_status=1` and `new_status=3`.
+#[test]
+fn withdraw_emits_settlement_state_changed() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _sme, _sac) = setup_funded_with_token(&env);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    client.withdraw();
+
+    let all_events = env.events().all();
+    let event_list = all_events.events();
+
+    assert!(
+        !event_list.is_empty(),
+        "withdraw must emit at least one event"
+    );
+
+    // withdraw() emits SettlementStateChanged then SmeWithdrew; first event is the new one.
+    assert_eq!(
+        event_list.get(0).unwrap().clone(),
+        SettlementStateChanged {
+            name: symbol_short!("setl_st"),
+            invoice_id,
+            old_status: 1,
+            new_status: 3,
+            funded_amount: TARGET,
+        }
+        .to_xdr(&env, &contract_id),
+        "first event must be SettlementStateChanged with old_status=1, new_status=3"
+    );
+}
+
+/// `partial_settle` must emit a `SettlementStateChanged` event with `old_status=0` and `new_status=1`.
+#[test]
+fn partial_settle_emits_settlement_state_changed() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+    let invoice_id = client.get_escrow().invoice_id;
+
+    client.partial_settle(&admin);
+
+    let all_events = env.events().all();
+    let event_list = all_events.events();
+
+    assert!(
+        !event_list.is_empty(),
+        "partial_settle must emit at least one event"
+    );
+
+    // partial_settle() emits SettlementStateChanged then EscrowPartialSettle.
+    assert_eq!(
+        event_list.get(0).unwrap().clone(),
+        SettlementStateChanged {
+            name: symbol_short!("setl_st"),
+            invoice_id,
+            old_status: 0,
+            new_status: 1,
+            funded_amount: 0,
+        }
+        .to_xdr(&env, &contract_id),
+        "first event must be SettlementStateChanged with old_status=0, new_status=1"
+    );
+}
+
+/// `cancel_funding` must emit a `SettlementStateChanged` event with `old_status=0` and `new_status=4`.
+#[test]
+fn cancel_funding_emits_settlement_state_changed() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+    let invoice_id = client.get_escrow().invoice_id;
+
+    client.cancel_funding();
+
+    let all_events = env.events().all();
+    let event_list = all_events.events();
+
+    assert!(
+        !event_list.is_empty(),
+        "cancel_funding must emit at least one event"
+    );
+
+    // cancel_funding() emits SettlementStateChanged then FundingCancelled.
+    assert_eq!(
+        event_list.get(0).unwrap().clone(),
+        SettlementStateChanged {
+            name: symbol_short!("setl_st"),
+            invoice_id,
+            old_status: 0,
+            new_status: 4,
+            funded_amount: 0,
+        }
+        .to_xdr(&env, &contract_id),
+        "first event must be SettlementStateChanged with old_status=0, new_status=4"
+    );
+}
+
+/// The `setl_st` topic must not collide with any existing event topic.
+#[test]
+fn settlement_state_changed_no_topic_collision() {
+    use soroban_sdk::Symbol as SdkSymbol;
+
+    let env = Env::default();
+
+    // All existing event topic names used in the contract (both symbol_short! and Symbol::new).
+    let existing_topics: [SdkSymbol; 43] = [
+        symbol_short!("escrow_ii"),
+        symbol_short!("maturity"),
+        symbol_short!("adm_prop"),
+        symbol_short!("adm_acc"),
+        symbol_short!("adm_xfer"),
+        symbol_short!("adm_can"),
+        symbol_short!("adm_sup"),
+        symbol_short!("depr_xfer"),
+        symbol_short!("cap_lower"),
+        symbol_short!("cap_raise"),
+        symbol_short!("floor_low"),
+        symbol_short!("mpi_capi"),
+        symbol_short!("fund_tgt"),
+        symbol_short!("fnd_dl_e"),
+        symbol_short!("leg_hold"),
+        symbol_short!("paus_chg"),
+        symbol_short!("leg_clrq"),
+        symbol_short!("leg_cldu"),
+        symbol_short!("leg_clcn"),
+        symbol_short!("coll_rec"),
+        symbol_short!("coll_clr"),
+        symbol_short!("col_clr2"),
+        symbol_short!("sme_wd"),
+        symbol_short!("inv_claim"),
+        symbol_short!("fund_can"),
+        symbol_short!("inv_refd"),
+        symbol_short!("unfunded"),
+        symbol_short!("dust_sw"),
+        symbol_short!("pr_att"),
+        symbol_short!("at_apnd"),
+        symbol_short!("at_rvk"),
+        symbol_short!("at_unrv"),
+        symbol_short!("al_set"),
+        symbol_short!("al_batch"),
+        symbol_short!("ben_rot"),
+        symbol_short!("escrow_sd"),
+        symbol_short!("part_set"),
+        symbol_short!("fund_cls"),
+        symbol_short!("mhz_up"),
+        symbol_short!("mhz_raise"),
+        symbol_short!("upgrade"),
+        SdkSymbol::new(&env, "reg_rebind"),
+        SdkSymbol::new(&env, "setl_st_test"),
+    ];
+    let new_topic = symbol_short!("setl_st");
+    for existing in existing_topics.iter() {
+        assert_ne!(
+            new_topic, *existing,
+            "setl_st topic must not collide with existing topic"
+        );
+    }
 }

--- a/escrow/src/tests/yield_tier_boundaries.rs
+++ b/escrow/src/tests/yield_tier_boundaries.rs
@@ -1,0 +1,1094 @@
+use super::*;
+use soroban_sdk::{testutils::Address as _, Vec as SorobanVec};
+
+// ── Yield-tier boundary and rejection tests (issue #709) ─────────────────────
+//
+// Tests the exact boundary conditions for yield-tier validation and
+// effective-yield selection, asserting typed error codes.
+
+// ============================================================================
+// validate_yield_tiers_table boundaries
+// ============================================================================
+
+/// Exactly at the upper bound: yield_bps = 10_000 is valid.
+#[test]
+fn test_tier_yield_upper_bound_exact() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 10_000,
+    });
+
+    let escrow = client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERUB01"),
+        &sme,
+        &1_000i128,
+        &0i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_eq!(escrow.yield_bps, 0);
+}
+
+/// One over the upper bound: yield_bps = 10_001 must reject.
+#[test]
+fn test_tier_yield_upper_bound_overflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 10_001,
+    });
+
+    let result = client.try_init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERUB02"),
+        &sme,
+        &1_000i128,
+        &0i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_contract_error(result, EscrowError::TierYieldOutOfRange);
+}
+
+/// Exactly at the lower bound: yield_bps = 0 is valid (when base_yield = 0).
+#[test]
+fn test_tier_yield_lower_bound_exact() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 0,
+    });
+
+    let escrow = client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERLB01"),
+        &sme,
+        &1_000i128,
+        &0i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_eq!(escrow.yield_bps, 0);
+}
+
+/// Negative yield_bps must reject.
+#[test]
+fn test_tier_yield_negative() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: -1,
+    });
+
+    let result = client.try_init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERNEG01"),
+        &sme,
+        &1_000i128,
+        &0i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_contract_error(result, EscrowError::TierYieldOutOfRange);
+}
+
+/// Tier yield exactly at base yield is valid (yield_bps == base_yield).
+#[test]
+fn test_tier_yield_exact_base() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 800,
+    });
+
+    let escrow = client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERBASE01"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_eq!(escrow.yield_bps, 800);
+}
+
+/// Tier yield one below base yield must reject.
+#[test]
+fn test_tier_yield_one_below_base() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 799,
+    });
+
+    let result = client.try_init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERBLW01"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_contract_error(result, EscrowError::TierYieldBelowBase);
+}
+
+/// Lock seconds strictly increasing is valid.
+#[test]
+fn test_tier_lock_strictly_increasing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 800,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 200,
+        yield_bps: 900,
+    });
+
+    let escrow = client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERLK01"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_eq!(escrow.yield_bps, 800);
+}
+
+/// Equal lock seconds must reject (not strictly increasing).
+#[test]
+fn test_tier_lock_equal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 800,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    let result = client.try_init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERLKEQ"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_contract_error(result, EscrowError::TierLockNotIncreasing);
+}
+
+/// Decreasing lock seconds must reject.
+#[test]
+fn test_tier_lock_decreasing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 200,
+        yield_bps: 800,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    let result = client.try_init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERLKDEC"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_contract_error(result, EscrowError::TierLockNotIncreasing);
+}
+
+/// Non-decreasing yield is valid (equal yields across tiers).
+#[test]
+fn test_tier_yield_equal_across_tiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 200,
+        yield_bps: 900,
+    });
+
+    let escrow = client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERYEQ"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_eq!(escrow.yield_bps, 800);
+}
+
+/// Decreasing yield across tiers must reject.
+#[test]
+fn test_tier_yield_decreasing_across_tiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 1000,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 200,
+        yield_bps: 900,
+    });
+
+    let result = client.try_init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERYDEC"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_contract_error(result, EscrowError::TierYieldNotNonDecreasing);
+}
+
+/// Single tier with yield_bps = 0 and base_yield = 0 is valid.
+#[test]
+fn test_tier_single_zero_yield_zero_base() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 0,
+        yield_bps: 0,
+    });
+
+    let escrow = client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERSGL0"),
+        &sme,
+        &1_000i128,
+        &0i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_eq!(escrow.yield_bps, 0);
+}
+
+/// Empty tier table is accepted (returns early).
+#[test]
+fn test_tier_empty_table() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let tiers = SorobanVec::new(&env);
+
+    let escrow = client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIEREMPTY"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_eq!(escrow.yield_bps, 800);
+}
+
+/// None yield tiers is accepted.
+#[test]
+fn test_tier_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let escrow = client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERNONE"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_eq!(escrow.yield_bps, 800);
+}
+
+// ============================================================================
+// effective_yield_for_commitment boundaries (via preview_yield_tier)
+// ============================================================================
+
+/// Commitment lock = 0 always returns base yield.
+#[test]
+fn test_effective_yield_lock_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "EFFLK0"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let (eff, lock) = client.preview_yield_tier(&1_000i128, &0u64);
+    assert_eq!(eff, 800, "lock=0 must return base yield");
+    assert_eq!(lock, 0, "lock=0 must return matched_lock=0");
+}
+
+/// Commitment lock exactly at tier.min_lock_secs matches that tier.
+#[test]
+fn test_effective_yield_lock_exact_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "EFFLK1"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let (eff, lock) = client.preview_yield_tier(&1_000i128, &100u64);
+    assert_eq!(eff, 900, "lock=100 must match tier with min_lock=100");
+    assert_eq!(lock, 100, "matched_lock must be tier's min_lock_secs");
+}
+
+/// Commitment lock one below tier.min_lock_secs does not match.
+#[test]
+fn test_effective_yield_lock_one_below_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "EFFLKB1"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let (eff, lock) = client.preview_yield_tier(&1_000i128, &99u64);
+    assert_eq!(eff, 800, "lock=99 must NOT match tier with min_lock=100");
+    assert_eq!(lock, 0, "matched_lock must be 0 when no tier matched");
+}
+
+/// Commitment lock above all tiers returns the highest tier yield.
+#[test]
+fn test_effective_yield_lock_above_all_tiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 200,
+        yield_bps: 1000,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "EFFLKA1"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let (eff, lock) = client.preview_yield_tier(&1_000i128, &500u64);
+    assert_eq!(eff, 1000, "lock=500 must match highest tier (min_lock=200)");
+    assert_eq!(lock, 200, "matched_lock must be 200");
+}
+
+/// Commitment lock between two tiers matches the lower tier.
+#[test]
+fn test_effective_yield_lock_between_tiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 300,
+        yield_bps: 1200,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "EFFLKB2"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let (eff, lock) = client.preview_yield_tier(&1_000i128, &250u64);
+    assert_eq!(eff, 900, "lock=250 must match tier 0 (min_lock=100)");
+    assert_eq!(lock, 100, "matched_lock must be 100");
+}
+
+/// Commitment lock exactly at tier boundary: lock=200 with tiers [100, 200, 300].
+#[test]
+fn test_effective_yield_lock_exact_middle_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 200,
+        yield_bps: 1000,
+    });
+    tiers.push_back(YieldTier {
+        min_lock_secs: 300,
+        yield_bps: 1200,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "EFFLKM1"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let (eff, lock) = client.preview_yield_tier(&1_000i128, &200u64);
+    assert_eq!(eff, 1000, "lock=200 must match tier 1");
+    assert_eq!(lock, 200, "matched_lock must be 200");
+}
+
+/// No tier table: preview returns base yield.
+#[test]
+fn test_effective_yield_no_tier_table() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "EFFNOTI"),
+        &sme,
+        &1_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let (eff, lock) = client.preview_yield_tier(&1_000i128, &500u64);
+    assert_eq!(eff, 800, "no tiers must return base yield");
+    assert_eq!(lock, 0, "matched_lock must be 0");
+}
+
+// ============================================================================
+// fund_with_commitment rejection tests
+// ============================================================================
+
+/// Second deposit via fund_with_commitment must reject (TieredSecondDeposit).
+#[test]
+fn test_tiered_second_deposit_rejects() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIER2ND"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client.fund_with_commitment(&inv, &1_000i128, &100u64);
+
+    let result = client.try_fund_with_commitment(&inv, &1_000i128, &200u64);
+    assert_contract_error(result, EscrowError::TieredSecondDeposit);
+}
+
+/// Commitment lock exceeding maturity must reject (CommitmentLockExceedsMaturity).
+#[test]
+fn test_commitment_lock_exceeds_maturity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERMEX"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &1_000u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let result = client.try_fund_with_commitment(&inv, &1_000i128, &1_001u64);
+    assert_contract_error(result, EscrowError::CommitmentLockExceedsMaturity);
+}
+
+/// Commitment lock exactly at maturity boundary: now + lock == maturity is valid.
+#[test]
+fn test_commitment_lock_exact_maturity_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERMBD"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &1_000u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let escrow = client.fund_with_commitment(&inv, &1_000i128, &1_000u64);
+    assert_eq!(
+        escrow.status, 0,
+        "funded_amount (1000) < funding_target (10000) so status stays open"
+    );
+}
+
+/// Commitment lock one past maturity boundary: now + lock > maturity must reject.
+#[test]
+fn test_commitment_lock_one_past_maturity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERMXP"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &1_000u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let result = client.try_fund_with_commitment(&inv, &1_000i128, &1_001u64);
+    assert_contract_error(result, EscrowError::CommitmentLockExceedsMaturity);
+}
+
+/// Zero maturity (no lock) accepts any commitment lock.
+#[test]
+fn test_commitment_lock_zero_maturity_accepts_any() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let inv = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+    tiers.push_back(YieldTier {
+        min_lock_secs: 100,
+        yield_bps: 900,
+    });
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "TIERZMT"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let escrow = client.fund_with_commitment(&inv, &1_000i128, &1_000_000u64);
+    assert_eq!(escrow.status, 0);
+}


### PR DESCRIPTION
Add 26 boundary and rejection tests for yield-tier validation and effective-yield selection (issue #709).

Tests cover:
- validate_yield_tiers_table: upper/lower bounds, negative yield, at-base, below-base, lock strictly-increasing/equal/decreasing, yield non-decreasing/decreasing, empty table, None tiers
- effective_yield_for_commitment: lock=0, exact tier, one below, above all, between tiers, middle tier, no tier table
- fund_with_commitment: second deposit, lock exceeds maturity, exact boundary, one past maturity, zero maturity accepts any

Also fixes pre-existing issues:
- Add missing SettlementStateChanged contractevent struct
- Fix clippy unnecessary_cast (n as u32)
- Fix 12 clippy manual_contains warnings in test_allowlist_tests
- Fix duplicate code block in settlement.rs topic collision test

closes: #709 