### PR TITLE
feat(escrow): add distinct batch allowlist event alongside per-investor events

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -3315,7 +3315,7 @@ impl LiquifactEscrow {
         InvestorAllowlistBatchApplied {
             name: symbol_short!("al_batch"),
             invoice_id: escrow.invoice_id.clone(),
-            batch_size: n as u32,
+            batch_size: n,
             allowed: if allowed { 1 } else { 0 },
         }
         .publish(&env);

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1542,6 +1542,23 @@ pub struct InvestorAllowlistChanged {
     pub allowed: u32,
 }
 
+/// Emitted once per [`LiquifactEscrow::set_investors_allowlisted`] call after
+/// all per-investor `InvestorAllowlistChanged` events, providing a single
+/// batch-level signal for indexers.
+#[contractevent]
+pub struct InvestorAllowlistBatchApplied {
+    /// Hardcoded `"al_batch"` symbol (topic).
+    #[topic]
+    pub name: Symbol,
+    /// The escrow's `invoice_id` (topic, for indexer correlation).
+    #[topic]
+    pub invoice_id: Symbol,
+    /// Number of addresses in the batch.
+    pub batch_size: u32,
+    /// `1` = allowed, `0` = blocked.
+    pub allowed: u32,
+}
+
 #[contractevent]
 pub struct LegalHoldClearCancelled {
     #[topic]
@@ -3294,6 +3311,14 @@ impl LiquifactEscrow {
             }
             .publish(&env);
         }
+
+        InvestorAllowlistBatchApplied {
+            name: symbol_short!("al_batch"),
+            invoice_id: escrow.invoice_id.clone(),
+            batch_size: n as u32,
+            allowed: if allowed { 1 } else { 0 },
+        }
+        .publish(&env);
     }
 
     pub fn is_investor_allowlisted(env: Env, investor: Address) -> bool {

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    AllowlistEnabledChanged, DataKey, EscrowError, InvestorAllowlistChanged, LiquifactEscrow,
-    LiquifactEscrowClient,
+    AllowlistEnabledChanged, DataKey, EscrowError, InvestorAllowlistBatchApplied,
+    InvestorAllowlistChanged, LiquifactEscrow, LiquifactEscrowClient,
 };
 use soroban_sdk::Vec as SorobanVec;
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Error, Event, InvokeError};
@@ -918,4 +918,380 @@ fn gate_batch_revoke_blocks_all_revoked_members() {
     // Contributions remain at the pre-revocation values.
     assert_eq!(client.get_contribution(&a), 1_000i128);
     assert_eq!(client.get_contribution(&b), 1_000i128);
+}
+
+// =============================================================================
+// Batch event tests – InvestorAllowlistBatchApplied (`al_batch`)
+//
+// Every `set_investors_allowlisted` call must emit:
+//   - one `InvestorAllowlistChanged` (`al_set`) per address in the batch, AND
+//   - exactly one `InvestorAllowlistBatchApplied` (`al_batch`) at the end.
+// =============================================================================
+
+/// Batch allow emits N per-investor events plus exactly 1 batch event.
+#[test]
+fn test_batch_allowlist_emits_batch_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(a.clone());
+    batch.push_back(b.clone());
+    batch.push_back(c.clone());
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    for addr in [&a, &b, &c] {
+        let expected = InvestorAllowlistChanged {
+            name: symbol_short!("al_set"),
+            invoice_id: invoice_id.clone(),
+            investor: addr.clone(),
+            allowed: 1,
+        }
+        .to_xdr(&env, &contract_id);
+        assert!(
+            events.iter().any(|e| *e == expected),
+            "must emit al_set for each address"
+        );
+    }
+
+    let batch_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: 3,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events.iter().any(|e| *e == batch_xdr),
+        "exactly one al_batch event must be emitted"
+    );
+}
+
+/// Batch revoke emits N per-investor events plus exactly 1 batch event.
+#[test]
+fn test_batch_revoke_emits_batch_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(a.clone());
+    batch.push_back(b.clone());
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+
+    // Clear events from the first batch call.
+    let _ = env.events().all();
+
+    // Now revoke.
+    client.set_investors_allowlisted(&batch, &false);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    let al_set_a = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: a,
+        allowed: 0,
+    }
+    .to_xdr(&env, &contract_id);
+    let al_set_b = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: b,
+        allowed: 0,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events.iter().any(|e| *e == al_set_a),
+        "must emit al_set for a"
+    );
+    assert!(
+        events.iter().any(|e| *e == al_set_b),
+        "must emit al_set for b"
+    );
+
+    let batch_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: 2,
+        allowed: 0,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events.iter().any(|e| *e == batch_xdr),
+        "exactly one al_batch event must be emitted"
+    );
+}
+
+/// Single-element batch emits 1 al_set + 1 al_batch.
+#[test]
+fn test_single_element_batch_emits_both_events() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(a.clone());
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    let al_set_xdr = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: a,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    let batch_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: 1,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert!(
+        events.iter().any(|e| *e == al_set_xdr),
+        "must emit 1 al_set"
+    );
+    assert!(
+        events.iter().any(|e| *e == batch_xdr),
+        "must emit 1 al_batch"
+    );
+}
+
+/// Max-size batch emits N al_set + 1 al_batch.
+#[test]
+fn test_max_size_batch_emits_correct_event_count() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let max_batch = super::MAX_INVESTOR_ALLOWLIST_BATCH as usize;
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    let mut addrs: SorobanVec<Address> = SorobanVec::new(&env);
+    for _ in 0..max_batch {
+        let addr = Address::generate(&env);
+        addrs.push_back(addr.clone());
+        batch.push_back(addr);
+    }
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    let mut al_set_found = 0u32;
+    for i in 0..addrs.len() {
+        let addr = addrs.get(i).unwrap();
+        let xdr = InvestorAllowlistChanged {
+            name: symbol_short!("al_set"),
+            invoice_id: invoice_id.clone(),
+            investor: addr,
+            allowed: 1,
+        }
+        .to_xdr(&env, &contract_id);
+        if events.iter().any(|e| *e == xdr) {
+            al_set_found += 1;
+        }
+    }
+    assert_eq!(
+        al_set_found, max_batch as u32,
+        "must emit one al_set per address"
+    );
+
+    let batch_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: max_batch as u32,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events.iter().any(|e| *e == batch_xdr),
+        "must emit exactly 1 al_batch"
+    );
+}
+
+/// Single-address setter does NOT emit al_batch event.
+#[test]
+fn test_single_allowlist_setter_does_not_emit_batch_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&a, &true);
+
+    let binding = env.events().all();
+    let events = binding.events();
+
+    let al_set_xdr = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: a,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events.iter().any(|e| *e == al_set_xdr),
+        "single setter must emit al_set"
+    );
+
+    let batch_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: 1,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        !events.iter().any(|e| *e == batch_xdr),
+        "single setter must not emit al_batch"
+    );
+}
+
+/// Multiple consecutive batch calls each emit their own batch event.
+#[test]
+fn test_multiple_batch_calls_each_emit_batch_event() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init_gate(&env, &client);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let mut batch1: SorobanVec<Address> = SorobanVec::new(&env);
+    batch1.push_back(a.clone());
+    batch1.push_back(b.clone());
+
+    let mut batch2: SorobanVec<Address> = SorobanVec::new(&env);
+    batch2.push_back(c.clone());
+
+    client.set_allowlist_active(&true);
+
+    // Snapshot events from first batch call.
+    client.set_investors_allowlisted(&batch1, &true);
+    let binding1 = env.events().all();
+    let events1 = binding1.events();
+
+    // Snapshot events from second batch call.
+    client.set_investors_allowlisted(&batch2, &true);
+    let binding2 = env.events().all();
+    let events2 = binding2.events();
+
+    let al_set_a = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: a,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    let al_set_b = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: b,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events1.iter().any(|e| *e == al_set_a),
+        "batch1 must emit al_set for a"
+    );
+    assert!(
+        events1.iter().any(|e| *e == al_set_b),
+        "batch1 must emit al_set for b"
+    );
+
+    let batch1_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id: invoice_id.clone(),
+        batch_size: 2,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events1.iter().any(|e| *e == batch1_xdr),
+        "must emit al_batch(batch_size=2) from first call"
+    );
+
+    let al_set_c = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: c,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events2.iter().any(|e| *e == al_set_c),
+        "batch2 must emit al_set for c"
+    );
+
+    let batch2_xdr = InvestorAllowlistBatchApplied {
+        name: symbol_short!("al_batch"),
+        invoice_id,
+        batch_size: 1,
+        allowed: 1,
+    }
+    .to_xdr(&env, &contract_id);
+    assert!(
+        events2.iter().any(|e| *e == batch2_xdr),
+        "must emit al_batch(batch_size=1) from second call"
+    );
 }


### PR DESCRIPTION
## Summary

Adds a distinct `InvestorAllowlistBatchApplied` (`al_batch`) batch-level event to `set_investors_allowlisted`, addressing.

Each `set_investors_allowlisted` call now emits:
- One `InvestorAllowlistChanged` (`al_set`) per address (unchanged)
- Exactly one `InvestorAllowlistBatchApplied` (`al_batch`) at the end

This provides a single batch-level signal for indexers, enabling efficient batch-level aggregation without scanning individual per-address events.

## Changes

- **escrow/src/lib.rs**: Added `InvestorAllowlistBatchApplied` event struct and batch event emission in `set_investors_allowlisted`
- **escrow/src/test_allowlist_tests.rs**: Added 6 new tests covering batch event behavior (allow/revoke/single-element/max-size/no-batch-for-singular/multiple-calls)

## Event Schema

| Field | Type | Description |
|-------|------|-------------|
| name | Symbol (topic) | Hardcoded "al_batch" |
| invoice_id | Symbol (topic) | Escrow invoice ID |
| batch_size | u32 | Number of addresses in the batch |
| allowed | u32 | 1 = allowed, 0 = blocked |

## Tests

All 45 allowlist tests pass (0 failures). All new tests verified.

closes: #629 
