### PR TITLE
feat(attestation): add read-only view for attestation state

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1523,6 +1523,21 @@ pub struct AttestationDigestInfo {
     pub revoked: bool,
 }
 
+/// Read-only view of the current attestation state.
+/// Returns a sensible default (empty/None) when attestation is unset.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AttestationState {
+    /// The primary attestation hash, if bound.
+    pub primary_hash: Option<BytesN<32>>,
+    /// The append log of attestation digests.
+    pub append_log: Vec<BytesN<32>>,
+    /// Current length of the append log.
+    pub append_log_len: u32,
+    /// Remaining capacity in the append log.
+    pub remaining_capacity: u32,
+}
+
 #[contractevent]
 pub struct AllowlistEnabledChanged {
     #[topic]
@@ -2485,6 +2500,23 @@ impl LiquifactEscrow {
             .instance()
             .get(&DataKey::AttestationAppendLog)
             .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Read-only view exposing the current attestation state.
+    /// Returns a sensible default (empty/None) when attestation is unset.
+    /// This is an O(1) read that reuses stored values rather than recomputing.
+    pub fn get_attestation_state(env: Env) -> AttestationState {
+        let primary_hash = Self::get_primary_attestation_hash(env.clone());
+        let append_log = Self::get_attestation_append_log(env.clone());
+        let append_log_len = append_log.len();
+        let remaining_capacity = MAX_ATTESTATION_APPEND_ENTRIES.saturating_sub(append_log_len);
+
+        AttestationState {
+            primary_hash,
+            append_log,
+            append_log_len,
+            remaining_capacity,
+        }
     }
 
     /// Returns the digest and revocation flag at `index`.

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -499,6 +499,156 @@ fn test_unrevoke_not_revoked() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// get_attestation_state — read-only view
+// ---------------------------------------------------------------------------
+
+/// Returns default state when no attestation is set.
+#[test]
+fn test_get_attestation_state_default() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let state = client.get_attestation_state();
+    assert_eq!(state.primary_hash, None);
+    assert_eq!(state.append_log.len(), 0);
+    assert_eq!(state.append_log_len, 0);
+    assert_eq!(state.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES);
+}
+
+/// Returns correct state after binding primary hash.
+#[test]
+fn test_get_attestation_state_with_primary() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let d = digest(&env, 0xAA);
+    client.bind_primary_attestation_hash(&d);
+    
+    let state = client.get_attestation_state();
+    assert_eq!(state.primary_hash, Some(d));
+    assert_eq!(state.append_log.len(), 0);
+    assert_eq!(state.append_log_len, 0);
+    assert_eq!(state.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES);
+}
+
+/// Returns correct state after appending digests.
+#[test]
+fn test_get_attestation_state_with_append_log() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..3 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    
+    let state = client.get_attestation_state();
+    assert_eq!(state.primary_hash, None);
+    assert_eq!(state.append_log.len(), 3);
+    assert_eq!(state.append_log_len, 3);
+    assert_eq!(state.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES - 3);
+    
+    // Verify log contents
+    for i in 0u8..3 {
+        assert_eq!(state.append_log.get(i as u32).unwrap(), digest(&env, i));
+    }
+}
+
+/// Returns correct state with both primary and append log.
+#[test]
+fn test_get_attestation_state_full() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let primary = digest(&env, 0xCC);
+    client.bind_primary_attestation_hash(&primary);
+    
+    for i in 0u8..5 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    
+    let state = client.get_attestation_state();
+    assert_eq!(state.primary_hash, Some(primary));
+    assert_eq!(state.append_log.len(), 5);
+    assert_eq!(state.append_log_len, 5);
+    assert_eq!(state.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES - 5);
+}
+
+/// Returns correct state after revocation.
+#[test]
+fn test_get_attestation_state_after_revoke() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..3 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    client.revoke_attestation_digest(&1);
+    
+    let state = client.get_attestation_state();
+    assert_eq!(state.append_log.len(), 3);
+    assert_eq!(state.append_log_len, 3);
+    // Note: revocation doesn't remove from log, just marks as revoked
+}
+
+/// Returns correct state when append log is full.
+#[test]
+fn test_get_attestation_state_full_capacity() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..(MAX_ATTESTATION_APPEND_ENTRIES as u8) {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    
+    let state = client.get_attestation_state();
+    assert_eq!(state.append_log.len(), MAX_ATTESTATION_APPEND_ENTRIES);
+    assert_eq!(state.append_log_len, MAX_ATTESTATION_APPEND_ENTRIES);
+    assert_eq!(state.remaining_capacity, 0);
+}
+
+/// State view is consistent after multiple operations.
+#[test]
+fn test_get_attestation_state_consistency() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    
+    // Initial state
+    let state1 = client.get_attestation_state();
+    assert_eq!(state1.append_log_len, 0);
+    
+    // After append
+    client.append_attestation_digest(&digest(&env, 0x01));
+    let state2 = client.get_attestation_state();
+    assert_eq!(state2.append_log_len, 1);
+    
+    // After revoke
+    client.revoke_attestation_digest(&0);
+    let state3 = client.get_attestation_state();
+    assert_eq!(state3.append_log_len, 1); // Length unchanged
+    
+    // After unrevoke
+    client.unrevoke_attestation_digest(&0);
+    let state4 = client.get_attestation_state();
+    assert_eq!(state4.append_log_len, 1); // Length still unchanged
+}
+
+/// State view correctly reflects capacity after unrevoke.
+#[test]
+fn test_get_attestation_state_capacity_after_unrevoke() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..3 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    
+    let state1 = client.get_attestation_state();
+    assert_eq!(state1.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES - 3);
+    
+    client.revoke_attestation_digest(&1);
+    let state2 = client.get_attestation_state();
+    assert_eq!(state2.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES - 3);
+    
+    client.unrevoke_attestation_digest(&1);
+    let state3 = client.get_attestation_state();
+    assert_eq!(state3.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES - 3);
+}
+
+
 /// Unrevoking an index that was never revoked still returns
 /// `AttestationNotRevoked` even after an unrelated index was revoked.
 #[test]

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -522,7 +522,7 @@ fn test_get_attestation_state_with_primary() {
     let (client, _) = setup_with_init(&env);
     let d = digest(&env, 0xAA);
     client.bind_primary_attestation_hash(&d);
-    
+
     let state = client.get_attestation_state();
     assert_eq!(state.primary_hash, Some(d));
     assert_eq!(state.append_log.len(), 0);
@@ -538,13 +538,13 @@ fn test_get_attestation_state_with_append_log() {
     for i in 0u8..3 {
         client.append_attestation_digest(&digest(&env, i));
     }
-    
+
     let state = client.get_attestation_state();
     assert_eq!(state.primary_hash, None);
     assert_eq!(state.append_log.len(), 3);
     assert_eq!(state.append_log_len, 3);
     assert_eq!(state.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES - 3);
-    
+
     // Verify log contents
     for i in 0u8..3 {
         assert_eq!(state.append_log.get(i as u32).unwrap(), digest(&env, i));
@@ -558,11 +558,11 @@ fn test_get_attestation_state_full() {
     let (client, _) = setup_with_init(&env);
     let primary = digest(&env, 0xCC);
     client.bind_primary_attestation_hash(&primary);
-    
+
     for i in 0u8..5 {
         client.append_attestation_digest(&digest(&env, i));
     }
-    
+
     let state = client.get_attestation_state();
     assert_eq!(state.primary_hash, Some(primary));
     assert_eq!(state.append_log.len(), 5);
@@ -579,7 +579,7 @@ fn test_get_attestation_state_after_revoke() {
         client.append_attestation_digest(&digest(&env, i));
     }
     client.revoke_attestation_digest(&1);
-    
+
     let state = client.get_attestation_state();
     assert_eq!(state.append_log.len(), 3);
     assert_eq!(state.append_log_len, 3);
@@ -594,7 +594,7 @@ fn test_get_attestation_state_full_capacity() {
     for i in 0u8..(MAX_ATTESTATION_APPEND_ENTRIES as u8) {
         client.append_attestation_digest(&digest(&env, i));
     }
-    
+
     let state = client.get_attestation_state();
     assert_eq!(state.append_log.len(), MAX_ATTESTATION_APPEND_ENTRIES);
     assert_eq!(state.append_log_len, MAX_ATTESTATION_APPEND_ENTRIES);
@@ -606,21 +606,21 @@ fn test_get_attestation_state_full_capacity() {
 fn test_get_attestation_state_consistency() {
     let env = Env::default();
     let (client, _) = setup_with_init(&env);
-    
+
     // Initial state
     let state1 = client.get_attestation_state();
     assert_eq!(state1.append_log_len, 0);
-    
+
     // After append
     client.append_attestation_digest(&digest(&env, 0x01));
     let state2 = client.get_attestation_state();
     assert_eq!(state2.append_log_len, 1);
-    
+
     // After revoke
     client.revoke_attestation_digest(&0);
     let state3 = client.get_attestation_state();
     assert_eq!(state3.append_log_len, 1); // Length unchanged
-    
+
     // After unrevoke
     client.unrevoke_attestation_digest(&0);
     let state4 = client.get_attestation_state();
@@ -635,19 +635,27 @@ fn test_get_attestation_state_capacity_after_unrevoke() {
     for i in 0u8..3 {
         client.append_attestation_digest(&digest(&env, i));
     }
-    
+
     let state1 = client.get_attestation_state();
-    assert_eq!(state1.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES - 3);
-    
+    assert_eq!(
+        state1.remaining_capacity,
+        MAX_ATTESTATION_APPEND_ENTRIES - 3
+    );
+
     client.revoke_attestation_digest(&1);
     let state2 = client.get_attestation_state();
-    assert_eq!(state2.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES - 3);
-    
+    assert_eq!(
+        state2.remaining_capacity,
+        MAX_ATTESTATION_APPEND_ENTRIES - 3
+    );
+
     client.unrevoke_attestation_digest(&1);
     let state3 = client.get_attestation_state();
-    assert_eq!(state3.remaining_capacity, MAX_ATTESTATION_APPEND_ENTRIES - 3);
+    assert_eq!(
+        state3.remaining_capacity,
+        MAX_ATTESTATION_APPEND_ENTRIES - 3
+    );
 }
-
 
 /// Unrevoking an index that was never revoked still returns
 /// `AttestationNotRevoked` even after an unrelated index was revoked.


### PR DESCRIPTION
## Summary
Implement a read-only view function `get_attestation_state()` that returns the current attestation state in a single call, addressing issue #698.

## Changes
- Add `AttestationState` struct containing:
  - `primary_hash: Option<BytesN<32>>` - the primary attestation hash
  - `append_log: Vec<BytesN<32>>` - the append log entries
  - `append_log_len: u32` - current length of append log
  - `remaining_capacity: u32` - remaining capacity in append log
- Implement `get_attestation_state()` as O(1) read operation
- Returns sensible defaults (None/empty) when attestation is unset
- Reuses stored values without recomputation
- Add 8 comprehensive tests covering:
  - Default state (no attestation)
  - State with primary hash only
  - State with append log only
  - Full state (primary + append log)
  - State after revocation
  - Full capacity state
  - State consistency across operations
  - Capacity tracking after unrevoke

## Testing
All tests pass successfully, covering edge cases and state transitions.

Closes #698