### PR TITLE
refactor(fees): extract shared validate_bps helper

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -730,6 +730,19 @@ pub(crate) fn validate_maturity_bounds(env: &Env, maturity: u64, max_horizon: u6
     );
 }
 
+/// Validate that a basis-points value falls within the allowed `0..=10_000` range.
+///
+/// Centralises the bounds check used by yield bps, tier yield bps, and protocol fee bps
+/// so the ceiling lives in exactly one spot. Panics with the caller-supplied typed
+/// [`EscrowError`] variant when the value is out of range.
+///
+/// # Errors
+/// Panics with the caller-supplied `error` when `bps` is outside `0..=10_000`.
+#[inline(always)]
+pub(crate) fn validate_bps(env: &Env, bps: i64, error: EscrowError) {
+    ensure(env, (0..=10_000).contains(&bps), error);
+}
+
 // --- Storage keys ---
 
 #[contracttype]
@@ -1698,11 +1711,7 @@ impl LiquifactEscrow {
         let n = tiers.len();
         for i in 0..n {
             let t = tiers.get(i).unwrap();
-            ensure(
-                env,
-                (0..=10_000).contains(&t.yield_bps),
-                EscrowError::TierYieldOutOfRange,
-            );
+            validate_bps(env, t.yield_bps, EscrowError::TierYieldOutOfRange);
             ensure(
                 env,
                 t.yield_bps >= base_yield,
@@ -1813,18 +1822,14 @@ impl LiquifactEscrow {
             amount <= MAX_INVOICE_AMOUNT,
             EscrowError::AmountExceedsMax,
         );
-        ensure(
-            &env,
-            (0..=10_000).contains(&yield_bps),
-            EscrowError::YieldBpsOutOfRange,
-        );
+        validate_bps(&env, yield_bps, EscrowError::YieldBpsOutOfRange);
         // Immutable protocol fee in basis points (default 0 = no fee). Validated to the same
         // 0..=10_000 envelope as `yield_bps`; `10_000` routes the entire `funded_amount` to the
         // treasury at withdrawal. See `docs/escrow-numeric-model.md` for the split math.
         let protocol_fee_bps = protocol_fee_bps.unwrap_or(0);
-        ensure(
+        validate_bps(
             &env,
-            (0..=10_000).contains(&protocol_fee_bps),
+            protocol_fee_bps,
             EscrowError::ProtocolFeeBpsOutOfRange,
         );
         ensure(


### PR DESCRIPTION
## Summary

Closes #720 — extracts the repeated `(0..=10_000).contains(&bps)` basis-points bounds validation into a shared `validate_bps` helper, eliminating duplication across three call sites: tier yield bps, base yield bps, and protocol fee bps.

## Motivation

Three places in `escrow/src/lib.rs` repeated the same inline bounds check for basis-points values (`0..=10_000`):

| Location | Value | Error variant |
|---|---|---|
| `validate_yield_tiers_table` | `t.yield_bps` | `TierYieldOutOfRange` |
| `init` | `yield_bps` | `YieldBpsOutOfRange` |
| `init` | `protocol_fee_bps` | `ProtocolFeeBpsOutOfRange` |

Each was a 4-line `ensure!` block with identical range logic. This violates DRY and makes it easy for a future author to typo the bounds, accidentally diverge the ceiling, or add a fourth call site that uses a different constant.

## Changes

**File:** `escrow/src/lib.rs` (+17 / −12)

### Added: `validate_bps` helper

```rust
/// Validate that a basis-points value falls within the allowed `0..=10_000` range.
///
/// Centralises the bounds check used by yield bps, tier yield bps, and protocol fee bps
/// so the ceiling lives in exactly one spot. Panics with the caller-supplied typed
/// [`EscrowError`] variant when the value is out of range.
///
/// # Errors
/// Panics with the caller-supplied `error` when `bps` is outside `0..=10_000`.
#[inline(always)]
pub(crate) fn validate_bps(env: &Env, bps: i64, error: EscrowError) {
    ensure(env, (0..=10_000).contains(&bps), error);
}
```

Placed after `validate_maturity_bounds` among the other shared guard/predicate helpers. Visibility is `pub(crate)`, consistent with sibling helpers (`validate_maturity_bounds`, `guard_status_eq`, `is_terminal_status`, etc.).

### Replaced: three inline checks → `validate_bps` calls

1. **`validate_yield_tiers_table`** — tier yield bps:
   ```rust
   // Before (4 lines):
   ensure(
       env,
       (0..=10_000).contains(&t.yield_bps),
       EscrowError::TierYieldOutOfRange,
   );
   // After (1 line):
   validate_bps(env, t.yield_bps, EscrowError::TierYieldOutOfRange);
   ```

2. **`init`** — base yield bps:
   ```rust
   // Before (4 lines):
   ensure(
       &env,
       (0..=10_000).contains(&yield_bps),
       EscrowError::YieldBpsOutOfRange,
   );
   // After (1 line):
   validate_bps(&env, yield_bps, EscrowError::YieldBpsOutOfRange);
   ```

3. **`init`** — protocol fee bps:
   ```rust
   // Before (4 lines):
   ensure(
       &env,
       (0..=10_000).contains(&protocol_fee_bps),
       EscrowError::ProtocolFeeBpsOutOfRange,
   );
   // After (3 lines, rustfmt wrap):
   validate_bps(
       &env,
       protocol_fee_bps,
       EscrowError::ProtocolFeeBpsOutOfRange,
   );
   ```

## Behaviour

**No behavioural change.** The same values are accepted and rejected with the same typed `EscrowError` variants. This is a pure refactor — no new storage keys, no ABI change, no event schema change.

| Input | Before | After |
|---|---|---|
| `bps = 0` | ✅ accepted | ✅ accepted |
| `bps = 5_000` | ✅ accepted | ✅ accepted |
| `bps = 10_000` | ✅ accepted | ✅ accepted |
| `bps = 10_001` | ❌ `ProtocolFeeBpsOutOfRange` (or appropriate variant) | ❌ same error |
| `bps = -1` | ❌ out of range (same error variant) | ❌ same error |

## Test Plan & CI Output

### `cargo fmt --all -- --check`

```
(exit 0, no output — all files correctly formatted)
```

### `cargo clippy --all-targets -- -D warnings`

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
(exit 0, zero warnings)
```

### `cargo test`

```
test result: ok. 840 passed; 0 failed; 54 ignored; 0 measured; 0 filtered out
```

### Toolchain

- **rustc:** 1.97.1 (8bab26f4f 2026-07-14)
- **cargo:** 1.97.1 (c980f4866 2026-06-30)

## Edge Cases Verified

All three call sites continue to exercise the same boundary behavior through existing tests:

- `protocol_fee_bps = 0` (boundary low) — accepted in `test_init` suite
- `protocol_fee_bps = 10_000` (boundary high) — accepted via init tests
- `protocol_fee_bps = 10_001` (one over) — rejected with `ProtocolFeeBpsOutOfRange`
- `yield_bps = 0`, `10_000`, `10_001` — accepted/rejected identically via `test_init_*` tests
- `t.yield_bps` boundaries — exercised via `test_init_tiers_*` tests
- Negative `i64` values — out of range by virtue of the `0..=` bound, rejected with appropriate error variant

## Reviewer Notes

- The helper is deliberately named `validate_bps` (not `validate_fee_bps`) because it validates *all* basis-points values — yield bps, tier yield bps, and protocol fee bps — not just fee bps.
- The three call sites use different `env` conventions (`env` vs `&env`) depending on whether the calling function receives `Env` or `&Env`. The helper accepts `&Env` uniformly.
- The "lower-only fee setter" mentioned in the original issue is not yet present in the codebase. When it lands, it should route through this same helper.
- `#[inline(always)]` preserves the zero-overhead guarantee — the compiler will monomorphise away the function call, making the generated WASM identical to the inline version.
