### PR TITLE
feat(collateral): emit state-change event (#707)

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1350,23 +1350,6 @@ pub struct CollateralClearedEvt {
     pub recorded_at: u64,
 }
 
-/// Emitted after [`LiquifactEscrow::clear_sme_collateral_commitment`] removes
-/// the SME-reported collateral metadata.
-///
-/// This supplements [`CollateralClearedEvt`] with a short event name and the
-/// full cleared commitment identity so indexers can reconstruct the
-/// record-to-clear lifecycle without a storage read after removal.
-#[contractevent]
-pub struct CollateralCommitmentCleared {
-    #[topic]
-    pub name: Symbol,
-    #[topic]
-    pub invoice_id: Symbol,
-    pub asset: Symbol,
-    pub amount: i128,
-    pub recorded_at: u64,
-}
-
 #[contractevent]
 pub struct SmeWithdrew {
     #[topic]
@@ -2718,15 +2701,6 @@ impl LiquifactEscrow {
             .remove(&DataKey::SmeCollateralPledge);
 
         CollateralClearedEvt {
-            name: symbol_short!("coll_clr"),
-            invoice_id: escrow.invoice_id.clone(),
-            asset: commitment.asset.clone(),
-            amount: commitment.amount,
-            recorded_at: commitment.recorded_at,
-        }
-        .publish(&env);
-
-        CollateralCommitmentCleared {
             name: symbol_short!("coll_clr"),
             invoice_id: escrow.invoice_id.clone(),
             asset: commitment.asset.clone(),

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -1,6 +1,8 @@
 use super::super::external_calls::transfer_funding_token_with_balance_checks;
 use super::*;
-use crate::{CollateralRecordedEvt, DataKey, InvoiceEscrow, LegalHoldChanged};
+use crate::{
+    CollateralClearedEvt, CollateralRecordedEvt, DataKey, InvoiceEscrow, LegalHoldChanged,
+};
 use soroban_sdk::{
     contract, contractimpl, symbol_short, vec, IntoVal, Map, MuxedAddress, Symbol, TryFromVal, Val,
 };
@@ -666,6 +668,51 @@ fn test_collateral_replacement_event_contains_prior_amount() {
         expected_second.to_xdr(&env, &contract_id),
         "Second event should have prior_amount = 5000"
     );
+}
+
+#[test]
+fn test_collateral_clear_emits_one_dedicated_event_with_cleared_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = deploy_with_id(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "COLEV003");
+
+    env.as_contract(&contract_id, || {
+        env.storage().instance().set(
+            &DataKey::Escrow,
+            &InvoiceEscrow {
+                invoice_id: invoice_id.clone(),
+                admin,
+                sme_address: sme,
+                amount: 10_000i128,
+                funding_target: 10_000i128,
+                funded_amount: 0i128,
+                yield_bps: 800i64,
+                maturity: 0u64,
+                status: 0u32,
+            },
+        );
+    });
+
+    let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+    // Drain the record event before exercising the separate clear transition.
+    let _ = env.events().all();
+
+    client.clear_sme_collateral_commitment();
+    // Capture immediately: subsequent contract calls can replace the test event buffer.
+    let events = env.events().all().filter_by_contract(&contract_id);
+
+    assert_eq!(events.events().len(), 1, "clear must emit exactly one event");
+    let expected = CollateralClearedEvt {
+        name: symbol_short!("coll_clr"),
+        invoice_id,
+        asset: symbol_short!("USDC"),
+        amount: 5_000i128,
+        recorded_at: commitment.recorded_at,
+    };
+    assert_eq!(events.events()[0], expected.to_xdr(&env, &contract_id));
 }
 
 #[test]

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -704,7 +704,11 @@ fn test_collateral_clear_emits_one_dedicated_event_with_cleared_payload() {
     // Capture immediately: subsequent contract calls can replace the test event buffer.
     let events = env.events().all().filter_by_contract(&contract_id);
 
-    assert_eq!(events.events().len(), 1, "clear must emit exactly one event");
+    assert_eq!(
+        events.events().len(),
+        1,
+        "clear must emit exactly one event"
+    );
     let expected = CollateralClearedEvt {
         name: symbol_short!("coll_clr"),
         invoice_id,


### PR DESCRIPTION
Closes #707

- Emit one dedicated `coll_clr` collateral-clear event per successful state transition.
- Remove the duplicate event emission that reused the same topic.
- Add regression coverage for event count and cleared collateral payload.

## Validation

- `cargo fmt --check` — not run: Cargo unavailable in local environment
- `cargo clippy --all-targets -- -D warnings` — not run: Cargo unavailable
- `cargo test` — not run: Cargo unavailable