### PR TITLE
test(fees): cover boundaries and rejections

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -4338,43 +4338,35 @@ impl LiquifactEscrow {
         let end = (start + actual_limit).min(len);
 
         // Load yield tier table once (if configured)
-        let tier_table: Option<Vec<YieldTier>> = env
-            .storage()
-            .instance()
-            .get(&DataKey::YieldTierTable);
+        let tier_table: Option<Vec<YieldTier>> =
+            env.storage().instance().get(&DataKey::YieldTierTable);
 
         // Load base yield once
         let escrow: InvoiceEscrow = env
             .storage()
             .instance()
             .get(&DataKey::Escrow)
-            .unwrap_or_else(|| {
-                panic_with_error!(&env, EscrowError::EscrowNotInitialized)
-            });
+            .unwrap_or_else(|| panic_with_error!(&env, EscrowError::EscrowNotInitialized));
         let base_yield = escrow.yield_bps;
 
         let mut result = Vec::new(&env);
         for i in start..end {
             let addr = index.get(i).unwrap();
-            
+
             // Only include if still actively allowlisted
             let is_al: bool = env
                 .storage()
                 .persistent()
                 .get(&DataKey::InvestorAllowlisted(addr.clone()))
                 .unwrap_or(false);
-            
+
             if !is_al {
                 continue;
             }
 
             // Determine tier index based on effective yield
-            let tier_index = Self::get_tier_index_for_investor(
-                &env,
-                &addr,
-                base_yield,
-                &tier_table,
-            );
+            let tier_index =
+                Self::get_tier_index_for_investor(&env, &addr, base_yield, &tier_table);
 
             result.push_back(AllowlistEntry {
                 investor: addr,
@@ -4560,7 +4552,10 @@ impl LiquifactEscrow {
                 closed_at_ledger_sequence: snap.closed_at_ledger_sequence,
             }
             .publish(&env);
-        }
+            true
+        } else {
+            false
+        };
 
         env.storage().instance().set(&DataKey::Escrow, &escrow);
 
@@ -6735,8 +6730,7 @@ impl LiquifactEscrow {
         }
 
         // 5. Contribution read and over-withdrawal guard (checked arithmetic)
-        let contribution: i128 =
-            Self::get_persistent_investor_contribution(&env, investor.clone());
+        let contribution: i128 = Self::get_persistent_investor_contribution(&env, investor.clone());
         let remaining_contribution = contribution
             .checked_sub(amount)
             .unwrap_or_else(|| fail(&env, EscrowError::OverWithdrawal));

--- a/escrow/src/tests/cap_validation.rs
+++ b/escrow/src/tests/cap_validation.rs
@@ -2738,8 +2738,7 @@ fn test_lower_protocol_fee_bps_requires_admin_auth() {
 }
 
 #[test]
-#[should_panic]
-fn test_lower_protocol_fee_bps_unauthorized_panics() {
+fn test_lower_protocol_fee_bps_unauthorized_typed_error() {
     let env = Env::default();
     env.mock_all_auths();
     let admin = Address::generate(&env);
@@ -2769,7 +2768,76 @@ fn test_lower_protocol_fee_bps_unauthorized_panics() {
     );
 
     env.mock_auths(&[]);
-    client.lower_protocol_fee_bps(&300i64);
+    assert_contract_error(
+        client.try_lower_protocol_fee_bps(&300i64),
+        EscrowError::Unauthorized,
+    );
+}
+
+#[test]
+fn test_lower_protocol_fee_bps_rejects_exact_boundary_at_10000() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FEE_LO_BOUND_MAX"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &Some(1_000i64),
+    );
+
+    assert_contract_error(
+        client.try_lower_protocol_fee_bps(&10_000i64),
+        EscrowError::ProtocolFeeBpsOutOfRange,
+    );
+}
+
+#[test]
+fn test_lower_protocol_fee_bps_rejects_exact_boundary_at_zero() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "FEE_LO_BOUND_ZERO"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &Some(500i64),
+    );
+
+    assert_contract_error(
+        client.try_lower_protocol_fee_bps(&0i64),
+        EscrowError::ProtocolFeeBpsNotLower,
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes: #719.

This PR adds boundary coverage for `lower_protocol_fee_bps` to lock in the expected contract behavior for:

- unauthorized callers returning `EscrowError::Unauthorized`
- rejection of the exact upper-bound value at `10_000` bps
- rejection of the zero/invalid lower-bound case at `0` bps

The change is intentionally test-focused and avoids broad contract logic changes. A small compile/behavior correction surfaced during verification and is included as part of the branch.

## Testing

- `cargo fmt --all`
- Attempted targeted fee-related test runs; the broader suite still hits unrelated compile issues in other modules