### PR TITLE
test: add coverage for attestation bind and bounded append-log flow

### DIFF
--- a/docs/escrow-attestations.md
+++ b/docs/escrow-attestations.md
@@ -27,17 +27,28 @@ independently and recompute the hash to confirm the anchor matches.
 | Property | Value |
 |---|---|
 | Auth | `InvoiceEscrow::admin` |
-| Write policy | **Single-set** — panics if already bound |
+| Write policy | **Single-set** — rejects a second bind with a typed error |
 | Storage key | `DataKey::PrimaryAttestationHash` |
 | Event | `PrimaryAttestationBound { invoice_id, digest }` |
 
 Binds the canonical compliance document digest for this escrow instance. Intended for the
 initial KYC/KYB bundle that covers the SME and the invoice at origination.
 
+**Typed error:** any bind attempt while `DataKey::PrimaryAttestationHash` is already set fails
+with `EscrowError::PrimaryAttestationAlreadyBound` (50) — regardless of whether the new digest
+matches the bound one. There is no update or replace path; a new digest requires a new escrow
+instance or the append log below.
+
 **Frontrunning note:** whichever transaction lands first wins. Observers must read on-chain
 state (or parse events) after ledger finality — there is no replay lock or commit-reveal scheme.
 In practice, the admin key is governance-controlled, so frontrunning is only a concern if the
 admin key is compromised.
+
+**Tested by** (`escrow/src/tests/attestations.rs`):
+- `test_get_primary_hash_none_before_bind` — getter default before any bind
+- `test_bind_primary_hash_same_digest_fails` / `test_bind_primary_hash_different_digest_fails` —
+  write-once holds regardless of digest value
+- `test_bind_primary_hash_non_admin_fails` — admin-gated via `mock_auths`
 
 ### `append_attestation_digest(digest: BytesN<32>)`
 
@@ -54,17 +65,29 @@ cycles, updated KYB documents, AML screening refreshes, or legal hold evidence b
 The log is an ordered sequence, not a set — duplicate digests are allowed (e.g. re-confirming
 an unchanged document at a new ledger timestamp via the event).
 
-The 33rd append panics with `"attestation append log capacity reached"`. If more than 32
-incremental anchors are needed, deploy a new escrow instance or extend the log off-chain using
-the event stream.
+**Typed error:** the 33rd append (`log.len() == MAX_ATTESTATION_APPEND_ENTRIES`) fails with
+`EscrowError::AttestationAppendLogCapacityReached` (51). If more than 32 incremental anchors
+are needed, deploy a new escrow instance or extend the log off-chain using the event stream.
 
-### `get_attestation_log_stats() -> (u32, u32)`
+**Tested by** (`escrow/src/tests/attestations.rs`):
+- `test_append_single_entry_stored` / `test_append_multiple_entries_ordered` — insertion order
+  via `get_attestation_append_log`
+- `test_append_emits_event_with_index_zero` / `test_append_event_index_increments_across_calls` —
+  `AttestationDigestAppended.index` matches the entry's position in the log
+- `test_append_exactly_max_entries_succeeds` — the 32nd entry (inclusive upper boundary) succeeds
+- `test_append_beyond_max_panics` / `test_attestation_log_stats_full_and_after_capacity_error` —
+  the 33rd entry fails, first via `#[should_panic]`, then via the typed
+  `AttestationAppendLogCapacityReached` error on `try_append_attestation_digest`
+- `test_append_non_admin_panics` — admin-gated via `mock_auths`
 
-Returns the current append-log usage and remaining capacity as `(used, remaining)`.
-This is a pure read view for integrators that want to warn before the log fills. The returned
-values satisfy `used + remaining == MAX_ATTESTATION_APPEND_ENTRIES`, and `remaining` drops to
-`0` once the log is full and the next append would fail with
-`AttestationAppendLogCapacityReached`.
+### `get_attestation_state() -> AttestationState`
+
+Read-only view exposing `primary_hash`, the full `append_log`, `append_log_len`, and
+`remaining_capacity` in one call. `append_log_len + remaining_capacity ==
+MAX_ATTESTATION_APPEND_ENTRIES` always holds, and `remaining_capacity` drops to `0` once the
+log is full and the next `append_attestation_digest` call would fail with
+`AttestationAppendLogCapacityReached`. See `test_get_attestation_state_*` in
+`escrow/src/tests/attestations.rs` for the full state-transition coverage.
 
 ### `revoke_attestation_digest(index: u32)`
 

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -204,6 +204,57 @@ fn test_append_single_entry_stored() {
     assert_eq!(log.get(0).unwrap(), d);
 }
 
+/// `append_attestation_digest` emits `AttestationDigestAppended` with the correct
+/// index and digest on the first append.
+#[test]
+fn test_append_emits_event_with_index_zero() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let contract_id = client.address.clone();
+    let d = digest(&env, 0x11);
+
+    client.append_attestation_digest(&d);
+
+    let invoice_id = client.get_escrow().invoice_id;
+    let all_events = env.events().all();
+    assert_eq!(
+        all_events.events().last().unwrap().clone(),
+        AttestationDigestAppended {
+            name: symbol_short!("att_app"),
+            invoice_id,
+            index: 0,
+            digest: d,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+/// The `index` field of `AttestationDigestAppended` increments monotonically
+/// across sequential appends, matching the entry's position in the log.
+#[test]
+fn test_append_event_index_increments_across_calls() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let contract_id = client.address.clone();
+    let invoice_id = client.get_escrow().invoice_id;
+
+    for i in 0u8..4 {
+        let d = digest(&env, i);
+        client.append_attestation_digest(&d);
+        let all_events = env.events().all();
+        assert_eq!(
+            all_events.events().last().unwrap().clone(),
+            AttestationDigestAppended {
+                name: symbol_short!("att_app"),
+                invoice_id: invoice_id.clone(),
+                index: i as u32,
+                digest: d,
+            }
+            .to_xdr(&env, &contract_id)
+        );
+    }
+}
+
 /// Multiple appends preserve insertion order.
 #[test]
 fn test_append_multiple_entries_ordered() {
@@ -949,75 +1000,4 @@ fn test_revoked_digests_view_caps_limit() {
     }
     let page = client.get_revoked_attestation_digests(&0, &100);
     assert_eq!(page.len(), crate::MAX_ATTESTATION_READ_PAGE);
-}
-
-// ---------------------------------------------------------------------------
-// revoke_attestation_digest — typed EscrowError edge cases (issue #378)
-// ---------------------------------------------------------------------------
-
-/// index > log.len() (large value) returns `AttestationIndexOutOfRange`.
-#[test]
-fn test_revoke_large_index_out_of_range() {
-    let env = Env::default();
-    let (client, _) = setup_with_init(&env);
-    client.append_attestation_digest(&digest(&env, 0x01));
-    assert_contract_error(
-        client.try_revoke_attestation_digest(&99),
-        EscrowError::AttestationIndexOutOfRange,
-    );
-}
-
-/// Revoking the first entry (index 0) in a multi-entry log succeeds.
-#[test]
-fn test_revoke_first_entry() {
-    let env = Env::default();
-    let (client, _) = setup_with_init(&env);
-    client.append_attestation_digest(&digest(&env, 0x01));
-    client.append_attestation_digest(&digest(&env, 0x02));
-    client.revoke_attestation_digest(&0);
-    assert!(client.is_attestation_revoked(&0));
-    assert!(!client.is_attestation_revoked(&1));
-}
-
-/// Revoking the last entry in a multi-entry log succeeds.
-#[test]
-fn test_revoke_last_entry() {
-    let env = Env::default();
-    let (client, _) = setup_with_init(&env);
-    for i in 0u8..3 {
-        client.append_attestation_digest(&digest(&env, i));
-    }
-    client.revoke_attestation_digest(&2);
-    assert!(!client.is_attestation_revoked(&0));
-    assert!(!client.is_attestation_revoked(&1));
-    assert!(client.is_attestation_revoked(&2));
-}
-
-/// Third revoke attempt on same index still returns `AttestationAlreadyRevoked`.
-#[test]
-fn test_repeated_revoke_returns_typed_error() {
-    let env = Env::default();
-    let (client, _) = setup_with_init(&env);
-    client.append_attestation_digest(&digest(&env, 0x10));
-    client.revoke_attestation_digest(&0);
-    assert_contract_error(
-        client.try_revoke_attestation_digest(&0),
-        EscrowError::AttestationAlreadyRevoked,
-    );
-    // A second retry also returns the same typed error.
-    assert_contract_error(
-        client.try_revoke_attestation_digest(&0),
-        EscrowError::AttestationAlreadyRevoked,
-    );
-}
-
-/// Non-admin `try_revoke_attestation_digest` returns an authorization error.
-#[test]
-fn test_revoke_non_admin_returns_error() {
-    let env = Env::default();
-    let (client, _) = setup_with_init(&env);
-    client.append_attestation_digest(&digest(&env, 0xFF));
-    env.mock_auths(&[]);
-    // Any error (not Ok) satisfies the auth-rejection requirement.
-    assert!(client.try_revoke_attestation_digest(&0).is_err());
 }


### PR DESCRIPTION
## Summary

Closes #618. Most of the write-once/capacity/auth coverage this issue asks for already existed in `escrow/src/tests/attestations.rs` from earlier merged work (#505, #588, #783, etc. against related issues #555/#699). This PR:

- **Fixes a merge artifact**: the last ~70 lines of `attestations.rs` were an exact duplicate of an earlier block (five test functions defined twice under identical names), which fails to compile with a duplicate-definition error. Removed the duplicate.
- **Closes the one real coverage gap**: no test asserted the `AttestationDigestAppended` event at all (even the analogous bind-event test was `#[ignore]`d). Added `test_append_emits_event_with_index_zero` and `test_append_event_index_increments_across_calls`, verifying the event's `index` field increments monotonically and matches the entry's position in the log — this is explicitly called out in the issue text.
- **Docs cross-link** (`docs/escrow-attestations.md`): added "Tested by" references under `bind_primary_attestation_hash` and `append_attestation_digest` pointing at the specific covering tests, added the missing `PrimaryAttestationAlreadyBound` (50) typed-error callout for bind, and corrected two stale inaccuracies — the doc referenced a `get_attestation_log_stats() -> (u32, u32)` function that doesn't exist (the real accessor is `get_attestation_state() -> AttestationState`), and described the capacity error as a raw panic string when it's actually the typed `EscrowError::AttestationAppendLogCapacityReached` (51).
- No production (`lib.rs`) changes — no real gap surfaced in the bind/append logic itself.

## ⚠️ Pre-existing build failures on `main` (unrelated to this PR)

While validating locally I found `main` currently fails both `cargo build` and `cargo fmt --check` for reasons that have nothing to do with this PR's diff (which only touches `escrow/src/tests/attestations.rs` and `docs/escrow-attestations.md`):

- `cargo build` (`escrow` crate): `E0081` — `EscrowError::OverWithdrawal` and `EscrowError::UnfundLegalHoldActive` both assigned discriminant `222` (`escrow/src/lib.rs:586,589`, introduced 2026-07-24 per `git blame`); plus `E0599` "not found" errors for `LiquifactEscrow::legal_hold_active` / `is_allowlist_active` / `is_investor_allowlisted` at their call sites (`lib.rs:681,707,710`, introduced 2026-07-19/24), even though those functions are defined inside the `impl LiquifactEscrow` block.
- `cargo fmt -p liquifact_escrow -- --check`: fails to parse `lib.rs:4563` (missing semicolon reported by rustfmt) — this matches the "latent rustfmt drift in lib.rs" that `.github/workflows/ci.yml` already documents and soft-fails on.

I did **not** touch `lib.rs` to fix these — they're outside this issue's scope ("no production change unless a real gap surfaces, then file/fix separately") and mixing an unrelated hotfix into a test-only PR would make review harder. Flagging here so reviewers aren't surprised if CI's `cargo build` step is red through no fault of this diff; happy to file a separate issue/PR for the `lib.rs` fixes if useful.

## Test plan

- [x] `rustfmt --check --edition 2021 escrow/src/tests/attestations.rs` — clean
- [ ] `cargo build` / `cargo test` — currently blocked by the pre-existing `main` breakage described above; the new/changed code in this PR is syntactically self-contained (single test module, no new external deps) but could not be exercised end-to-end for that reason
- [x] Manually verified duplicate test functions removed (was: exact duplicate block, five fns defined twice)
- [x] Manually verified `AttestationDigestAppended` event field types/topic match the contract definition (`lib.rs:1810-1816`) and existing event-assertion pattern used elsewhere in the same file

## Security notes

- Write-once invariant for `bind_primary_attestation_hash` is asserted for both same-digest and different-digest re-bind attempts (`PrimaryAttestationAlreadyBound`, 50).
- Append-log capacity bound is asserted at both boundaries: the 32nd entry succeeds, the 33rd fails with the typed `AttestationAppendLogCapacityReached` (51) via `try_append_attestation_digest`.
- Both entrypoints already had non-admin rejection coverage via `mock_auths` — unchanged, verified still present.
- No production logic was modified.