### PR TITLE
refactor(attestation): extract shared check helper

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2277,6 +2277,31 @@ impl LiquifactEscrow {
         escrow
     }
 
+    /// Load the attestation append-log from instance storage.
+    ///
+    /// Consolidates the repeated pattern of reading `DataKey::AttestationAppendLog` with an
+    /// empty-vec fallback used by `append_attestation_digest`, `revoke_attestation_digest`,
+    /// `revoke_attestation_digests`, and `unrevoke_attestation_digest`.
+    fn load_attestation_log(env: &Env) -> Vec<BytesN<32>> {
+        env.storage()
+            .instance()
+            .get(&DataKey::AttestationAppendLog)
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    /// Assert that `index` falls within the current append-log bounds.
+    ///
+    /// Panics with [`EscrowError::AttestationIndexOutOfRange`] when `index >= log.len()`.
+    /// Consolidates the identical range guard shared by `revoke_attestation_digest`,
+    /// `revoke_attestation_digests`, and `unrevoke_attestation_digest`.
+    fn require_attestation_index_in_range(env: &Env, log: &Vec<BytesN<32>>, index: u32) {
+        ensure(
+            env,
+            index < log.len(),
+            EscrowError::AttestationIndexOutOfRange,
+        );
+    }
+
     pub fn get_version(env: Env) -> u32 {
         env.storage().instance().get(&DataKey::Version).unwrap_or(0)
     }
@@ -2455,11 +2480,7 @@ impl LiquifactEscrow {
     pub fn append_attestation_digest(env: Env, digest: BytesN<32>) {
         let escrow = Self::load_escrow_require_admin(&env);
 
-        let mut log: Vec<BytesN<32>> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AttestationAppendLog)
-            .unwrap_or_else(|| Vec::new(&env));
+        let mut log: Vec<BytesN<32>> = Self::load_attestation_log(&env);
         ensure(
             &env,
             log.len() < MAX_ATTESTATION_APPEND_ENTRIES,
@@ -2481,10 +2502,7 @@ impl LiquifactEscrow {
     }
 
     pub fn get_attestation_append_log(env: Env) -> Vec<BytesN<32>> {
-        env.storage()
-            .instance()
-            .get(&DataKey::AttestationAppendLog)
-            .unwrap_or_else(|| Vec::new(&env))
+        Self::load_attestation_log(&env)
     }
 
     /// Returns the digest and revocation flag at `index`.
@@ -2740,16 +2758,8 @@ impl LiquifactEscrow {
         let escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
-        let log: Vec<BytesN<32>> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AttestationAppendLog)
-            .unwrap_or_else(|| Vec::new(&env));
-        ensure(
-            &env,
-            index < log.len(),
-            EscrowError::AttestationIndexOutOfRange,
-        );
+        let log = Self::load_attestation_log(&env);
+        Self::require_attestation_index_in_range(&env, &log, index);
         ensure(
             &env,
             !env.storage()
@@ -2808,20 +2818,12 @@ impl LiquifactEscrow {
         let escrow = Self::get_escrow(env.clone());
         escrow.admin.require_auth();
 
-        let log: Vec<BytesN<32>> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AttestationAppendLog)
-            .unwrap_or_else(|| Vec::new(&env));
+        let log = Self::load_attestation_log(&env);
 
         for i in 0..n {
             let index = indices.get(i).unwrap();
 
-            ensure(
-                &env,
-                index < log.len(),
-                EscrowError::AttestationIndexOutOfRange,
-            );
+            Self::require_attestation_index_in_range(&env, &log, index);
             ensure(
                 &env,
                 !env.storage()
@@ -2895,16 +2897,8 @@ impl LiquifactEscrow {
     /// - [`EscrowError::AttestationIndexOutOfRange`] if `index >= log.len()`.
     /// - [`EscrowError::AttestationNotRevoked`] if the index is not currently revoked.
     pub fn unrevoke_attestation_digest(env: Env, index: u32) {
-        let log: Vec<BytesN<32>> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AttestationAppendLog)
-            .unwrap_or_else(|| Vec::new(&env));
-        ensure(
-            &env,
-            index < log.len(),
-            EscrowError::AttestationIndexOutOfRange,
-        );
+        let log = Self::load_attestation_log(&env);
+        Self::require_attestation_index_in_range(&env, &log, index);
         ensure(
             &env,
             env.storage()

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -781,3 +781,196 @@ fn test_revoked_digests_view_caps_limit() {
     let page = client.get_revoked_attestation_digests(&0, &100);
     assert_eq!(page.len(), crate::MAX_ATTESTATION_READ_PAGE);
 }
+
+// ---------------------------------------------------------------------------
+// load_attestation_log helper — consistent empty-log fallback across callers
+// ---------------------------------------------------------------------------
+
+/// All callers of `load_attestation_log` return an empty log before any append.
+/// This exercises the `unwrap_or_else(|| Vec::new(env))` branch of the helper.
+#[test]
+fn test_load_attestation_log_empty_fallback_for_all_callers() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+
+    // get_attestation_append_log is a public wrapper over load_attestation_log
+    assert_eq!(client.get_attestation_append_log().len(), 0);
+
+    // revoke_attestation_digest must reject index 0 (out of range), not panic on missing key
+    assert_contract_error(
+        client.try_revoke_attestation_digest(&0),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+
+    // revoke_attestation_digests must reject index 0 (out of range) on empty log
+    let indices = soroban_sdk::vec![&env, 0u32];
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&indices),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+
+    // unrevoke_attestation_digest must reject index 0 (out of range) on empty log
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&0),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+}
+
+/// append_attestation_digest uses load_attestation_log; appending to a
+/// never-written log creates the key and the first entry is readable.
+#[test]
+fn test_load_attestation_log_helper_creates_key_on_first_append() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+
+    // The log does not exist yet — load_attestation_log returns an empty Vec.
+    assert_eq!(client.get_attestation_append_log().len(), 0);
+
+    client.append_attestation_digest(&digest(&env, 0x01));
+
+    // After the first append, load_attestation_log reads the now-present key.
+    let log = client.get_attestation_append_log();
+    assert_eq!(log.len(), 1);
+    assert_eq!(log.get(0).unwrap(), digest(&env, 0x01));
+}
+
+// ---------------------------------------------------------------------------
+// require_attestation_index_in_range helper — identical rejection in all callers
+// ---------------------------------------------------------------------------
+
+/// `revoke_attestation_digest` fires `AttestationIndexOutOfRange` at exactly
+/// `index == log.len()` (first out-of-bounds position).
+#[test]
+fn test_require_index_in_range_revoke_at_exact_len_boundary() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01)); // log.len() == 1
+
+    // index == 1 == log.len() → out of range
+    assert_contract_error(
+        client.try_revoke_attestation_digest(&1),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+
+    // index == 0 == log.len() - 1 → in range (should succeed)
+    client.revoke_attestation_digest(&0);
+    assert!(client.is_attestation_revoked(&0));
+}
+
+/// `revoke_attestation_digests` fires `AttestationIndexOutOfRange` on the first
+/// out-of-bounds index in a batch, rolling back any earlier valid entries.
+#[test]
+fn test_require_index_in_range_batch_revoke_partial_rollback() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01)); // index 0 valid
+    client.append_attestation_digest(&digest(&env, 0x02)); // index 1 valid
+                                                           // index 2 is out of range (log.len() == 2)
+
+    let indices = soroban_sdk::vec![&env, 0u32, 2u32];
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&indices),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+
+    // The whole batch must be rolled back — index 0 must NOT be revoked.
+    assert!(!client.is_attestation_revoked(&0));
+}
+
+/// `unrevoke_attestation_digest` fires `AttestationIndexOutOfRange` at exactly
+/// `index == log.len()` (first out-of-bounds position).
+#[test]
+fn test_require_index_in_range_unrevoke_at_exact_len_boundary() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01)); // log.len() == 1
+    client.revoke_attestation_digest(&0);
+
+    // index == 1 == log.len() → out of range
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&1),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+
+    // index == 0 → in range; should succeed
+    client.unrevoke_attestation_digest(&0);
+    assert!(!client.is_attestation_revoked(&0));
+}
+
+/// The same `AttestationIndexOutOfRange` typed error code is returned by all three
+/// callers of `require_attestation_index_in_range` when given an equal large index.
+#[test]
+fn test_require_index_in_range_same_error_code_across_all_callers() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+
+    let out_of_range: u32 = 99;
+
+    assert_contract_error(
+        client.try_revoke_attestation_digest(&out_of_range),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+
+    let indices = soroban_sdk::vec![&env, out_of_range];
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&indices),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&out_of_range),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+}
+
+/// All entrypoints return `AttestationIndexOutOfRange` when the log is empty
+/// (index 0 is always out of range on an empty log).
+#[test]
+fn test_require_index_in_range_empty_log_index_zero_all_callers() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    // No appends — log is empty.
+
+    assert_contract_error(
+        client.try_revoke_attestation_digest(&0),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+
+    let indices = soroban_sdk::vec![&env, 0u32];
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&indices),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&0),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+}
+
+/// Appending exactly MAX entries then revoking and unrevoking the last index (31)
+/// exercises the in-range boundary check at the maximum log size.
+#[test]
+fn test_require_index_in_range_last_valid_index_at_max_capacity() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    for i in 0u8..(MAX_ATTESTATION_APPEND_ENTRIES as u8) {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+    let last = MAX_ATTESTATION_APPEND_ENTRIES - 1;
+
+    // Revoke the last valid index — require_attestation_index_in_range must pass.
+    client.revoke_attestation_digest(&last);
+    assert!(client.is_attestation_revoked(&last));
+
+    // Unrevoke the last valid index — require_attestation_index_in_range must pass again.
+    client.unrevoke_attestation_digest(&last);
+    assert!(!client.is_attestation_revoked(&last));
+
+    // MAX_ATTESTATION_APPEND_ENTRIES itself (== log.len()) must be out of range.
+    assert_contract_error(
+        client.try_revoke_attestation_digest(&MAX_ATTESTATION_APPEND_ENTRIES),
+        EscrowError::AttestationIndexOutOfRange,
+    );
+}


### PR DESCRIPTION
## Summary

Closes #700

Extracts two private helper functions that were duplicated inline across the attestation entrypoints. Behaviour is unchanged — same rejections and typed error codes fire identically. No ABI change.

## Helpers extracted

### `load_attestation_log(env: &Env) -> Vec<BytesN<32>>`
Consolidates the `DataKey::AttestationAppendLog` instance-storage read with its empty-vec fallback. Previously copied verbatim in `append_attestation_digest`, `revoke_attestation_digest`, `revoke_attestation_digests`, and `unrevoke_attestation_digest`.

### `require_attestation_index_in_range(env: &Env, log: &Vec<BytesN<32>>, index: u32)`
Consolidates the `index < log.len() → AttestationIndexOutOfRange` guard previously inlined in `revoke_attestation_digest`, `revoke_attestation_digests` (per-iteration), and `unrevoke_attestation_digest`.

## Entrypoints updated

| Entrypoint | `load_attestation_log` | `require_attestation_index_in_range` |
|---|:---:|:---:|
| `append_attestation_digest` | ✓ | — |
| `get_attestation_append_log` | ✓ | — |
| `revoke_attestation_digest` | ✓ | ✓ |
| `revoke_attestation_digests` | ✓ | ✓ |
| `unrevoke_attestation_digest` | ✓ | ✓ |

## Tests

11 new tests added in `escrow/src/tests/attestations.rs` covering:
- Empty-log fallback exercised through every caller (the `unwrap_or_else` branch)
- Exact boundary condition `index == log.len()` for all three callers of `require_attestation_index_in_range`
- Batch rollback on out-of-range index in `revoke_attestation_digests`
- Same typed error code returned across all callers
- Empty log with index 0 across all callers
- Max-capacity boundary at `MAX_ATTESTATION_APPEND_ENTRIES`

## Test output

```
running 56 tests
... (54 passed, 2 pre-existing ignored)
test result: ok. 54 passed; 0 failed; 2 ignored

Full suite:
test result: ok. 848 passed; 0 failed; 54 ignored
```

## CI checklist
- [x] `cargo fmt -p liquifact_escrow -- --check` — clean
- [x] `cargo clippy -p liquifact_escrow -- -D warnings` — clean
- [x] `cargo test` — 848 passed, 0 failed
