### PR TITLE
feat(beneficiary): emit state-change event and document invariants

### DIFF
--- a/docs/ESCROW_BENEFICIARY_ROTATION.md
+++ b/docs/ESCROW_BENEFICIARY_ROTATION.md
@@ -104,12 +104,12 @@ So after a successful rotation:
 
 ### Eventing for indexers
 
-- `rotate_beneficiary` emits **`BeneficiaryRotated`** (with `prior_sme` and `new_sme`).
+- `rotate_beneficiary` emits **`BeneficiaryRotated`** (with `prior_sme` and `new_sme`) and **`BenChange`** (with `prior_sme`, `new_sme`, and `amount`).
 - After rotation, later SME disbursement emits **`SmeWithdrew`**.
 
 Indexers should:
 
-1. update their internal “active SME” mapping on `BeneficiaryRotated`, then
+1. update their internal “active SME” mapping on `BeneficiaryRotated` or `BenChange`, then
 2. attribute a later `SmeWithdrew` to the SME that was current after the rotation.
 
 ---
@@ -126,6 +126,18 @@ Fields:
 - `invoice_id`: the escrow invoice id
 - `prior_sme`: previous SME address
 - `new_sme`: updated SME address
+
+### `BenChange`
+
+Emitted after successful `rotate_beneficiary` as a dedicated <= 9 chars topic event.
+
+Fields:
+
+- `name`: `ben_chg`
+- `invoice_id`: the escrow invoice id
+- `prior_sme`: previous SME address
+- `new_sme`: updated SME address
+- `amount`: the escrow target amount
 
 ---
 

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -33,7 +33,7 @@ short routing symbol passed with `symbol_short!(...)`, such as `funded` or
 
 ## Event Catalog
 
-The current contract defines 36 event structs.
+The current contract defines 38 event structs.
 
 | Rust event | `name` symbol | Entrypoint(s) |
 |---|---:|---|
@@ -47,6 +47,7 @@ The current contract defines 36 event structs.
 | `AttestationDigestRevoked` | `att_rev` | `revoke_attestation_digest` |
 | `AttestationDigestUnrevoked` | `att_unrev` | `unrevoke_attestation_digest` |
 | `BeneficiaryRotated` | `ben_rot` | `rotate_beneficiary` |
+| `BenChange` | `ben_chg` | `rotate_beneficiary` |
 | `CollateralClearedEvt` | — | `clear_sme_collateral_commitment` |
 | `CollateralRecordedEvt` | `coll_rec` | `record_sme_collateral_commitment` |
 | `ContractUpgraded` | `upgrade` | `upgrade` |
@@ -263,6 +264,26 @@ Data:
 |---|---|
 | `prior_sme` | `Address` |
 | `new_sme` | `Address` |
+
+### `BenChange`
+
+Emitted after successful `rotate_beneficiary` as a dedicated <= 9 chars topic event.
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `BenChange` |
+| 1 | `name` | `Symbol` | `ben_chg` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `prior_sme` | `Address` |
+| `new_sme` | `Address` |
+| `amount` | `i128` |
 
 ### `FundingTargetUpdated`
 

--- a/docs/beneficiary.md
+++ b/docs/beneficiary.md
@@ -1,0 +1,75 @@
+# SME Beneficiary Model and Invariants
+
+This document describes the design, storage layout, behavioral invariants, and entrypoint interaction model of the SME beneficiary in the LiquiFact escrow contract.
+
+## Data Model & Storage
+
+The beneficiary is represented in the contract state as the `sme_address` (Address) field within the `InvoiceEscrow` struct.
+
+### Storage Layout
+
+The `InvoiceEscrow` struct is persisted in contract instance storage under `DataKey::Escrow`:
+
+```rust
+pub struct InvoiceEscrow {
+    pub invoice_id: Symbol,
+    pub admin: Address,
+    pub sme_address: Address, // Current SME beneficiary address
+    pub amount: i128,
+    pub funding_target: i128,
+    pub funded_amount: i128,
+    pub yield_bps: i64,
+    pub maturity: u64,
+    pub status: u32,
+}
+```
+
+## Behavioral Invariants
+
+The contract maintains the following invariants regarding the beneficiary:
+
+### 1. Identity & Rotation Governance
+- **Dual Authorization Requirement:** The `sme_address` cannot be modified unilaterally by either the `admin` or the `sme_address` alone. Any update requires a valid signature from both the current admin and the current SME beneficiary.
+- **Reject No-Op Rotations:** Rotation to the same address currently configured as the beneficiary is rejected with error code 162 (`NewSmeSameAsCurrent`).
+- **Maturity & State Gates:** Rotation is only permitted before the invoice escrow is settled, withdrawn, or cancelled. The `status` must be either `0` (open) or `1` (funded). Otherwise, the call is rejected with error code 161 (`RotationNotOpen`).
+- **Legal Hold Lockout:** If a compliance/legal hold is active, any attempt to rotate the beneficiary is blocked immediately with error code 160 (`LegalHoldBlocksBeneficiaryRotation`).
+
+### 2. Disbursement Destination
+- **Disbursement Routing:** The `withdraw` entrypoint sends the net funded amount (gross funded amount minus the protocol fee) exclusively to the stored `sme_address` at the time of the withdrawal. Once status is transitioned to `3` (withdrawn), the funds are dispersed and the state is terminal.
+
+### 3. Gated Entrypoints
+Only the configured `sme_address` is authorized to invoke or sign the following operations:
+- `withdraw` (SME pull principal/yield)
+- `record_sme_collateral_commitment` (Report metadata for off-chain risk)
+- `clear_sme_collateral_commitment` (Clear reported collateral metadata)
+- `partial_settle` (Authorized by either the SME or the admin)
+
+## Worked Example
+
+### 1. Initialization
+An escrow is initialized with a target amount of `100_000_000` XLM.
+- **Admin:** `G_ADMIN`
+- **SME Beneficiary:** `G_SME_A`
+- **Status:** `0` (open)
+
+The contract stores `sme_address = G_SME_A`.
+
+### 2. Rotation
+The SME wants to rotate the beneficiary to a new wallet, `G_SME_B`.
+- The rotation transaction must include signatures from both `G_SME_A` and `G_ADMIN`.
+- The admin invokes `rotate_beneficiary(new_sme_address = G_SME_B)`.
+- The contract verifies the dual authorization and updates `sme_address` to `G_SME_B`.
+- The contract emits:
+  1. `BeneficiaryRotated` event carrying:
+     - `prior_sme`: `G_SME_A`
+     - `new_sme`: `G_SME_B`
+  2. `BenChange` event (topic name: `ben_chg`) carrying:
+     - `prior_sme`: `G_SME_A`
+     - `new_sme`: `G_SME_B`
+     - `amount`: `100_000_000`
+
+### 3. Withdrawal
+Once funding target is met and the status changes to `1` (funded), the beneficiary withdraws.
+- `G_SME_B` calls `withdraw()`.
+- The contract checks `sme_address.require_auth()` which validates `G_SME_B`'s signature.
+- The contract disperses the funds to `G_SME_B`.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1116,6 +1116,17 @@ pub struct BeneficiaryRotated {
 }
 
 #[contractevent]
+pub struct BenChange {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub prior_sme: Address,
+    pub new_sme: Address,
+    pub amount: i128,
+}
+
+#[contractevent]
 pub struct EscrowPartialSettle {
     #[topic]
     pub name: Symbol,
@@ -1540,6 +1551,15 @@ pub struct InvestorAllowlistChanged {
     pub investor: Address,
     /// `1` = allowed, `0` = blocked.
     pub allowed: u32,
+}
+
+#[contractevent]
+pub struct AllowlistStateChanged {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub total_count: u32,
 }
 
 #[contractevent]
@@ -2241,8 +2261,17 @@ impl LiquifactEscrow {
         BeneficiaryRotated {
             name: symbol_short!("ben_rot"),
             invoice_id: escrow.invoice_id.clone(),
+            prior_sme: prior_sme.clone(),
+            new_sme: new_sme_address.clone(),
+        }
+        .publish(&env);
+
+        BenChange {
+            name: symbol_short!("ben_chg"),
+            invoice_id: escrow.invoice_id.clone(),
             prior_sme,
             new_sme: new_sme_address,
+            amount: escrow.amount,
         }
         .publish(&env);
 

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -1983,13 +1983,29 @@ fn test_rotate_beneficiary_success_dual_auth() {
     assert_eq!(updated.sme_address, new_sme);
     assert_eq!(client.get_escrow().sme_address, new_sme);
 
+    let all_evts = rotate_events.events();
+    let total_evts = all_evts.len();
+    assert!(total_evts >= 2);
+
     assert_eq!(
-        rotate_events.events().last().unwrap().clone(),
+        all_evts.get(total_evts - 2).unwrap().clone(),
         crate::BeneficiaryRotated {
             name: symbol_short!("ben_rot"),
             invoice_id: client.get_escrow().invoice_id,
+            prior_sme: sme.clone(),
+            new_sme: new_sme.clone(),
+        }
+        .to_xdr(&env, &contract_id)
+    );
+
+    assert_eq!(
+        all_evts.get(total_evts - 1).unwrap().clone(),
+        crate::BenChange {
+            name: symbol_short!("ben_chg"),
+            invoice_id: client.get_escrow().invoice_id,
             prior_sme: sme,
             new_sme,
+            amount: client.get_escrow().amount,
         }
         .to_xdr(&env, &contract_id)
     );


### PR DESCRIPTION
Closes #737
Closes #736

## PR Description

I implemented a dedicated event for beneficiary state changes (rotation) and added detailed documentation for the beneficiary data model and its invariants.

First, I resolved a compilation error in the production code of the escrow contract. The `AllowlistStateChanged` struct was referenced in allowlist updates but was not defined. I added the struct declaration to `lib.rs` to allow the codebase to compile successfully.

Second, I defined a new event struct `BenChange` in `lib.rs` with a short topic name (`ben_chg` which is 7 characters). This event contains:
* `name`: routing symbol (`ben_chg`)
* `invoice_id`: the Symbol of the invoice escrow
* `prior_sme`: the previous SME address
* `new_sme`: the updated SME address
* `amount`: the target escrow amount

I published this event at the end of the `rotate_beneficiary` entrypoint. Emitting this dedicated event alongside `BeneficiaryRotated` enables indexers to track beneficiary state updates with a short topic name, without having to infer state changes from other event records.

Third, I created a new documentation file `docs/beneficiary.md` explaining the beneficiary data model, its invariants (such as governance via dual authorization, maturity state gates, and disbursement destination), and the entrypoints that interact with the beneficiary. I also updated the event catalog in `docs/EVENT_SCHEMA.md` and `docs/ESCROW_BENEFICIARY_ROTATION.md` to document the new event.

Finally, I updated the unit tests in `escrow/src/tests/admin.rs` to verify that both `BeneficiaryRotated` and `BenChange` events are successfully published in the correct order and with correct fields immediately following beneficiary rotation.

## Changes Made
* Added `AllowlistStateChanged` struct definition to `escrow/src/lib.rs` to fix the compilation error
* Added `BenChange` event struct definition to `escrow/src/lib.rs` to support the dedicated state-change event for #737
* Modified `rotate_beneficiary` in `escrow/src/lib.rs` to emit `BenChange` for #737
* Created `docs/beneficiary.md` detailing the data model, invariants, and entrypoints to document the beneficiary model for #736
* Updated `docs/ESCROW_BENEFICIARY_ROTATION.md` and `docs/EVENT_SCHEMA.md` to document the new `BenChange` event for #737
* Updated `test_rotate_beneficiary_success_dual_auth` in `escrow/src/tests/admin.rs` to assert `BenChange` event publication for #737