### PR TITLE
refactor(escrow): centralize paginated view window clamping

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2278,6 +2278,35 @@ impl LiquifactEscrow {
         escrow
     }
 
+    /// Resolve a `(start, limit)` pagination request against a collection of `len` items.
+    ///
+    /// Returns `Some((start, end))` where `end` is exclusive and `end <= len`, or `None` when
+    /// the requested page is entirely out of range (i.e. when `start >= len` or `limit == 0`).
+    /// Arithmetic is saturating: a `start + capped_limit` that would overflow `u32` is clamped
+    /// at `len` rather than wrapping.
+    ///
+    /// The caller is responsible for supplying the appropriate per-operation ceiling as
+    /// `ceiling` so that the returned window never exceeds that cap.
+    ///
+    /// # Arguments
+    /// * `start`   — 0-based index of the first item to include (inclusive).
+    /// * `limit`   — requested page size (caller-supplied, uncapped).
+    /// * `ceiling` — maximum page size enforced by this entrypoint (e.g. [`MAX_INVESTOR_READ_BATCH`]).
+    /// * `len`     — total number of items in the backing collection.
+    ///
+    /// # Returns
+    /// * `Some((start, end))` — the resolved `[start, end)` window.
+    /// * `None`               — the page is empty (out-of-bounds or zero limit).
+    pub(crate) fn paginate_window(start: u32, limit: u32, ceiling: u32, len: u32) -> Option<(u32, u32)> {
+        if start >= len || limit == 0 {
+            return None;
+        }
+        let capped = limit.min(ceiling);
+        // Saturating add: if start + capped would overflow, clamp at len (which is <= u32::MAX).
+        let end = start.saturating_add(capped).min(len);
+        Some((start, end))
+    }
+
     /// Load the current escrow and require admin authorization in one step.
     ///
     /// Consolidates the repeated `let escrow = Self::get_escrow(env.clone()); escrow.admin.require_auth();`
@@ -2648,13 +2677,11 @@ impl LiquifactEscrow {
             .get(&DataKey::InvestorIndex)
             .unwrap_or_else(|| Vec::new(&env));
 
-        let len = index.len();
-        if start >= len || limit == 0 {
-            return Vec::new(&env);
-        }
-
-        let actual_limit = limit.min(MAX_INVESTOR_READ_BATCH);
-        let end = (start + actual_limit).min(len);
+        let (start, end) =
+            match Self::paginate_window(start, limit, MAX_INVESTOR_READ_BATCH, index.len()) {
+                Some(w) => w,
+                None => return Vec::new(&env),
+            };
 
         let mut result = Vec::new(&env);
         for i in start..end {
@@ -2890,15 +2917,16 @@ impl LiquifactEscrow {
         limit: u32,
     ) -> Vec<AttestationDigestInfo> {
         let log = Self::get_attestation_append_log(env.clone());
-        let len = log.len();
-        if start >= len || limit == 0 {
-            return Vec::new(&env);
-        }
+        let capped = limit.min(MAX_ATTESTATION_READ_PAGE);
+        let (scan_start, scan_end) =
+            match Self::paginate_window(start, capped, MAX_ATTESTATION_READ_PAGE, log.len()) {
+                Some(w) => w,
+                None => return Vec::new(&env),
+            };
 
-        let actual_limit = limit.min(MAX_ATTESTATION_READ_PAGE);
         let mut result = Vec::new(&env);
-        let mut i = start;
-        while i < len && result.len() < actual_limit {
+        let mut i = scan_start;
+        while i < scan_end && result.len() < capped {
             if Self::is_attestation_revoked(env.clone(), i) {
                 let digest = log.get(i).unwrap();
                 result.push_back(AttestationDigestInfo {
@@ -3344,13 +3372,11 @@ impl LiquifactEscrow {
             .get(&DataKey::AllowlistIndex)
             .unwrap_or_else(|| Vec::new(&env));
 
-        let len = index.len();
-        if start >= len || limit == 0 {
-            return Vec::new(&env);
-        }
-
-        let actual_limit = limit.min(50);
-        let end = (start + actual_limit).min(len);
+        let (start, end) =
+            match Self::paginate_window(start, limit, MAX_INVESTOR_READ_BATCH, index.len()) {
+                Some(w) => w,
+                None => return Vec::new(&env),
+            };
 
         let mut result = Vec::new(&env);
         for i in start..end {

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -71,6 +71,7 @@ mod integration;
 mod integration_status_guards;
 mod legal_hold;
 mod migration_errors;
+mod paginated_views;
 mod pause;
 mod properties;
 mod reconciliation_lifecycle;

--- a/escrow/src/tests/paginated_views.rs
+++ b/escrow/src/tests/paginated_views.rs
@@ -1,0 +1,553 @@
+// Tests for the shared paginate_window helper and the three public paginated read views:
+//   get_investors, get_allowlisted_investors, get_revoked_attestation_digests.
+//
+// Each test uses a fresh Env so state cannot leak across cases.
+
+use soroban_sdk::{Address, Env};
+
+// ── paginate_window unit tests ────────────────────────────────────────────────
+//
+// paginate_window is a private associated function, so we test it through
+// LiquifactEscrow::paginate_window via `crate::` access inside the same crate.
+
+#[test]
+fn paginate_window_empty_collection_returns_none() {
+    // len == 0 → always None regardless of start/limit
+    assert_eq!(crate::LiquifactEscrow::paginate_window(0, 10, 50, 0), None);
+    assert_eq!(crate::LiquifactEscrow::paginate_window(5, 10, 50, 0), None);
+}
+
+#[test]
+fn paginate_window_start_past_end_returns_none() {
+    // start >= len → None
+    assert_eq!(crate::LiquifactEscrow::paginate_window(5, 10, 50, 5), None);
+    assert_eq!(crate::LiquifactEscrow::paginate_window(100, 10, 50, 5), None);
+}
+
+#[test]
+fn paginate_window_zero_limit_returns_none() {
+    // limit == 0 → None even when start is valid
+    assert_eq!(crate::LiquifactEscrow::paginate_window(0, 0, 50, 10), None);
+    assert_eq!(crate::LiquifactEscrow::paginate_window(3, 0, 50, 10), None);
+}
+
+#[test]
+fn paginate_window_first_page() {
+    // start=0, limit=5, ceiling=50, len=10 → (0, 5)
+    assert_eq!(
+        crate::LiquifactEscrow::paginate_window(0, 5, 50, 10),
+        Some((0, 5))
+    );
+}
+
+#[test]
+fn paginate_window_continuation_page() {
+    // start=5, limit=5, ceiling=50, len=10 → (5, 10)
+    assert_eq!(
+        crate::LiquifactEscrow::paginate_window(5, 5, 50, 10),
+        Some((5, 10))
+    );
+}
+
+#[test]
+fn paginate_window_limit_exceeds_remaining_items() {
+    // start=7, limit=50, ceiling=50, len=10 → (7, 10)  (clamped at len)
+    assert_eq!(
+        crate::LiquifactEscrow::paginate_window(7, 50, 50, 10),
+        Some((7, 10))
+    );
+}
+
+#[test]
+fn paginate_window_ceiling_enforced() {
+    // limit > ceiling → ceiling is applied; start=0, limit=100, ceiling=20, len=50 → (0, 20)
+    assert_eq!(
+        crate::LiquifactEscrow::paginate_window(0, 100, 20, 50),
+        Some((0, 20))
+    );
+}
+
+#[test]
+fn paginate_window_saturating_add_does_not_overflow() {
+    // start near u32::MAX with a non-zero limit should not panic
+    let result = crate::LiquifactEscrow::paginate_window(u32::MAX - 1, 50, 50, u32::MAX);
+    // start (u32::MAX-1) < len (u32::MAX), limit > 0 → Some((u32::MAX-1, u32::MAX))
+    assert_eq!(result, Some((u32::MAX - 1, u32::MAX)));
+}
+
+// ── Helper: init with real defaults ──────────────────────────────────────────
+
+fn do_init(
+    env: &Env,
+    client: &crate::LiquifactEscrowClient<'_>,
+    admin: &Address,
+    sme: &Address,
+    token: &Address,
+    treasury: &Address,
+) {
+    client.init(
+        admin,
+        &soroban_sdk::String::from_str(env, "INV-PG-001"),
+        sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        token,
+        &None,
+        treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+}
+
+// ── get_investors ─────────────────────────────────────────────────────────────
+
+#[test]
+fn get_investors_empty_before_any_funding() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = super::deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    do_init(
+        &env,
+        &client,
+        &admin,
+        &sme,
+        &Address::generate(&env),
+        &Address::generate(&env),
+    );
+    let result = client.get_investors(&0, &10);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn get_investors_zero_limit_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = super::setup(&env);
+    super::default_init(&client, &env, &admin, &sme);
+
+    let investor = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let _ = client.get_investors(&0, &0);
+    // Just verify it doesn't panic and returns empty
+    let result = client.get_investors(&0, &0);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn get_investors_first_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_id = sac.address();
+    let sac_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+
+    let escrow_id = env.register(crate::LiquifactEscrow, ());
+    let client = crate::LiquifactEscrowClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INV-PG-FIRST"),
+        &sme,
+        &500_000_000i128,
+        &800i64,
+        &0u64,
+        &token_id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    // Fund with 5 investors
+    let mut investors = soroban_sdk::Vec::new(&env);
+    for _ in 0..5 {
+        let inv = Address::generate(&env);
+        sac_admin.mint(&inv, &100_000_000i128);
+        client.fund(&inv, &100_000_000i128);
+        investors.push_back(inv);
+    }
+
+    // First page of 3
+    let page = client.get_investors(&0, &3);
+    assert_eq!(page.len(), 3);
+    assert_eq!(page.get(0).unwrap(), investors.get(0).unwrap());
+    assert_eq!(page.get(1).unwrap(), investors.get(1).unwrap());
+    assert_eq!(page.get(2).unwrap(), investors.get(2).unwrap());
+}
+
+#[test]
+fn get_investors_continuation_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_id = sac.address();
+    let sac_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+
+    let escrow_id = env.register(crate::LiquifactEscrow, ());
+    let client = crate::LiquifactEscrowClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INV-PG-CONT"),
+        &sme,
+        &500_000_000i128,
+        &800i64,
+        &0u64,
+        &token_id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let mut investors = soroban_sdk::Vec::new(&env);
+    for _ in 0..5 {
+        let inv = Address::generate(&env);
+        sac_admin.mint(&inv, &100_000_000i128);
+        client.fund(&inv, &100_000_000i128);
+        investors.push_back(inv);
+    }
+
+    // Page 2: start=3, limit=3 → should return items 3 and 4 only
+    let page = client.get_investors(&3, &3);
+    assert_eq!(page.len(), 2);
+    assert_eq!(page.get(0).unwrap(), investors.get(3).unwrap());
+    assert_eq!(page.get(1).unwrap(), investors.get(4).unwrap());
+}
+
+#[test]
+fn get_investors_start_past_end_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_id = sac.address();
+    let sac_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+
+    let escrow_id = env.register(crate::LiquifactEscrow, ());
+    let client = crate::LiquifactEscrowClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INV-PG-PAST"),
+        &sme,
+        &200_000_000i128,
+        &800i64,
+        &0u64,
+        &token_id,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let inv = Address::generate(&env);
+    sac_admin.mint(&inv, &200_000_000i128);
+    client.fund(&inv, &200_000_000i128);
+
+    // Only 1 investor; start=5 is past the end
+    let result = client.get_investors(&5, &10);
+    assert_eq!(result.len(), 0);
+}
+
+// ── get_allowlisted_investors ─────────────────────────────────────────────────
+
+fn setup_allowlist_escrow(
+    env: &Env,
+) -> (crate::LiquifactEscrowClient<'_>, Address, Address) {
+    let client = super::deploy(env);
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, "INV-AL-PG"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(env),
+        &None,
+        &Address::generate(env),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    (client, admin, sme)
+}
+
+#[test]
+fn get_allowlisted_investors_empty_when_none_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _sme) = setup_allowlist_escrow(&env);
+    let result = client.get_allowlisted_investors(&0, &10);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn get_allowlisted_investors_zero_limit_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _sme) = setup_allowlist_escrow(&env);
+    let inv = Address::generate(&env);
+    client.set_investor_allowlisted(&inv, &true);
+    let result = client.get_allowlisted_investors(&0, &0);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn get_allowlisted_investors_start_past_end_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _sme) = setup_allowlist_escrow(&env);
+    let inv = Address::generate(&env);
+    client.set_investor_allowlisted(&inv, &true);
+    // Only 1 investor; start=5 is past the end
+    let result = client.get_allowlisted_investors(&5, &10);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn get_allowlisted_investors_first_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _sme) = setup_allowlist_escrow(&env);
+
+    let mut addrs = soroban_sdk::Vec::new(&env);
+    for _ in 0..5 {
+        let addr = Address::generate(&env);
+        client.set_investor_allowlisted(&addr, &true);
+        addrs.push_back(addr);
+    }
+
+    let page = client.get_allowlisted_investors(&0, &3);
+    assert_eq!(page.len(), 3);
+    assert_eq!(page.get(0).unwrap(), addrs.get(0).unwrap());
+    assert_eq!(page.get(1).unwrap(), addrs.get(1).unwrap());
+    assert_eq!(page.get(2).unwrap(), addrs.get(2).unwrap());
+}
+
+#[test]
+fn get_allowlisted_investors_continuation_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _sme) = setup_allowlist_escrow(&env);
+
+    let mut addrs = soroban_sdk::Vec::new(&env);
+    for _ in 0..5 {
+        let addr = Address::generate(&env);
+        client.set_investor_allowlisted(&addr, &true);
+        addrs.push_back(addr);
+    }
+
+    // Continuation: start=3, limit=3 → items 3 and 4
+    let page = client.get_allowlisted_investors(&3, &3);
+    assert_eq!(page.len(), 2);
+    assert_eq!(page.get(0).unwrap(), addrs.get(3).unwrap());
+    assert_eq!(page.get(1).unwrap(), addrs.get(4).unwrap());
+}
+
+#[test]
+fn get_allowlisted_investors_excludes_revoked_addresses() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _sme) = setup_allowlist_escrow(&env);
+
+    let addr_a = Address::generate(&env);
+    let addr_b = Address::generate(&env);
+    let addr_c = Address::generate(&env);
+    client.set_investor_allowlisted(&addr_a, &true);
+    client.set_investor_allowlisted(&addr_b, &true);
+    client.set_investor_allowlisted(&addr_c, &true);
+
+    // Revoke addr_b
+    client.set_investor_allowlisted(&addr_b, &false);
+
+    // Full page scan should only return addr_a and addr_c
+    let result = client.get_allowlisted_investors(&0, &10);
+    assert_eq!(result.len(), 2);
+    assert!(result.contains(&addr_a));
+    assert!(result.contains(&addr_c));
+    assert!(!result.contains(&addr_b));
+}
+
+// ── get_revoked_attestation_digests ───────────────────────────────────────────
+
+fn setup_attestation_escrow(
+    env: &Env,
+) -> (crate::LiquifactEscrowClient<'_>, Address) {
+    let client = super::deploy(env);
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, "INV-ATT-PG"),
+        &sme,
+        &100_000_000_000i128,
+        &800i64,
+        &0u64,
+        &Address::generate(env),
+        &None,
+        &Address::generate(env),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    (client, admin)
+}
+
+fn make_digest(seed: u8) -> soroban_sdk::BytesN<32> {
+    let env = Env::default();
+    soroban_sdk::BytesN::from_array(&env, &[seed; 32])
+}
+
+#[test]
+fn get_revoked_attestation_digests_empty_log_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_attestation_escrow(&env);
+    let result = client.get_revoked_attestation_digests(&0, &10);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn get_revoked_attestation_digests_zero_limit_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_attestation_escrow(&env);
+    let digest = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
+    client.append_attestation_digest(&digest);
+    client.revoke_attestation_digests(&soroban_sdk::vec![&env, 0u32]);
+    let result = client.get_revoked_attestation_digests(&0, &0);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn get_revoked_attestation_digests_start_past_end_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_attestation_escrow(&env);
+    let digest = soroban_sdk::BytesN::from_array(&env, &[2u8; 32]);
+    client.append_attestation_digest(&digest);
+    client.revoke_attestation_digests(&soroban_sdk::vec![&env, 0u32]);
+    // Log has length 1, start=5 is past the end
+    let result = client.get_revoked_attestation_digests(&5, &10);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn get_revoked_attestation_digests_no_revocations_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_attestation_escrow(&env);
+    let digest = soroban_sdk::BytesN::from_array(&env, &[3u8; 32]);
+    client.append_attestation_digest(&digest);
+    // Entry exists but is not revoked
+    let result = client.get_revoked_attestation_digests(&0, &10);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn get_revoked_attestation_digests_page_of_revoked_entries() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_attestation_escrow(&env);
+
+    // Append 4 digests
+    for seed in 0u8..4 {
+        let digest = soroban_sdk::BytesN::from_array(&env, &[seed; 32]);
+        client.append_attestation_digest(&digest);
+    }
+
+    // Revoke indices 1 and 3
+    client.revoke_attestation_digests(&soroban_sdk::vec![&env, 1u32, 3u32]);
+
+    // Full scan from start=0
+    let result = client.get_revoked_attestation_digests(&0, &20);
+    assert_eq!(result.len(), 2);
+    assert_eq!(
+        result.get(0).unwrap().digest,
+        soroban_sdk::BytesN::from_array(&env, &[1u8; 32])
+    );
+    assert_eq!(
+        result.get(1).unwrap().digest,
+        soroban_sdk::BytesN::from_array(&env, &[3u8; 32])
+    );
+}
+
+#[test]
+fn get_revoked_attestation_digests_continuation_start() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_attestation_escrow(&env);
+
+    // Append 4 digests and revoke all
+    for seed in 0u8..4 {
+        let digest = soroban_sdk::BytesN::from_array(&env, &[seed; 32]);
+        client.append_attestation_digest(&digest);
+    }
+    client.revoke_attestation_digests(&soroban_sdk::vec![&env, 0u32, 1u32, 2u32, 3u32]);
+
+    // Start at index 2 → should see digests at log positions 2 and 3
+    let result = client.get_revoked_attestation_digests(&2, &10);
+    assert_eq!(result.len(), 2);
+    assert_eq!(
+        result.get(0).unwrap().digest,
+        soroban_sdk::BytesN::from_array(&env, &[2u8; 32])
+    );
+    assert_eq!(
+        result.get(1).unwrap().digest,
+        soroban_sdk::BytesN::from_array(&env, &[3u8; 32])
+    );
+}


### PR DESCRIPTION
## Summary

`get_investors`, `get_allowlisted_investors`, and `get_revoked_attestation_digests` each re-implemented the same `start`/`limit` window clamping against a backing length. Duplicated arithmetic is the kind of code where one path silently drifts into an off-by-one or an underflow — and one already had: `get_allowlisted_investors` capped its limit at the literal `50` instead of `MAX_INVESTOR_READ_BATCH`.

This PR introduces a single shared `paginate_window` helper and routes all three views through it.

---

## Changes

### `escrow/src/lib.rs`

**New helper — `LiquifactEscrow::paginate_window`**

```rust
pub(crate) fn paginate_window(
    start: u32, limit: u32, ceiling: u32, len: u32,
) -> Option<(u32, u32)>
```

Returns `Some((start, end))` for a valid `[start, end)` window clamped to `len`, or `None` when the page is empty (`start >= len` or `limit == 0`). Arithmetic is saturating to prevent `u32` overflow.

**`get_investors`** — replaced open-coded clamp with `paginate_window(..., MAX_INVESTOR_READ_BATCH, ...)`.

**`get_allowlisted_investors`** — replaced open-coded clamp; **fixed bug** where ceiling was hard-coded as `50` instead of `MAX_INVESTOR_READ_BATCH`.

**`get_revoked_attestation_digests`** — replaced open-coded clamp with `paginate_window(..., MAX_ATTESTATION_READ_PAGE, ...)`; scan loop now walks `scan_start..scan_end` instead of `start..len`.

All three public signatures and return types are unchanged.

### `escrow/src/tests/paginated_views.rs` (new file)

| Test group | Cases |
|---|---|
| `paginate_window` | empty collection, `start` past end, zero `limit`, first page, continuation, `limit` exceeds remaining, ceiling enforced, saturating-add overflow safety |
| `get_investors` | empty before funding, zero limit, first page, continuation, start past end |
| `get_allowlisted_investors` | empty, zero limit, start past end, first page, continuation, revoked addresses excluded |
| `get_revoked_attestation_digests` | empty log, zero limit, start past end, no revocations, page of revoked entries, continuation start |

### `escrow/src/tests.rs`

Added `mod paginated_views;` to the module tree.

---

## Bug fixed

`get_allowlisted_investors` hard-coded `limit.min(50)` instead of `limit.min(MAX_INVESTOR_READ_BATCH)`. If `MAX_INVESTOR_READ_BATCH` is ever raised above 50, `get_investors` would silently accept the larger page while `get_allowlisted_investors` would not. The shared helper with the constant makes both consistent.

---

## Security notes

- **Pure reads only** — no state is mutated by any of the three views or by `paginate_window`.
- **Saturating arithmetic** — `start.saturating_add(capped)` prevents `u32` wrap-around on extreme inputs.
- **Ceiling always enforced** — `paginate_window` applies `limit.min(ceiling)` before clamping at `len`, so no caller can bypass the per-entrypoint cap.
- **Backward compatible** — empty collections and missing storage keys return an empty `Vec` as before.

---

Closes #830
Closes #831
Closes #832
Closes #834