### PR TITLE
feat(yield-tier): add paginated enumeration view

### DIFF
--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -793,6 +793,15 @@ Returns the yield-tier ladder configured at `init`, or an empty `Vec` when no ti
 - **Empty vec** — returned for both "no tiers passed at init" and "legacy instance predating tier support"; callers must not treat an empty result as an error.
 - **Pure read** — no auth required, no state mutation.
 
+## `get_yield_tiers_page(start, limit) → Vec<YieldTier>`
+
+Returns a read-only paginated view of the configured yield-tier ladder using the same `start`/`limit` contract as the existing investor and allowlist read views.
+
+- **Start beyond the end** — returns an empty page.
+- **Limit zero** — returns an empty page.
+- **Limit above the pagination ceiling** — clamps to the shared pagination ceiling (`MAX_INVESTOR_READ_BATCH`).
+- **Ordering** — preserves the immutable tier-table order established at `init`.
+
 ### `YieldTier` fields
 
 | Field | Type | Description |

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2665,6 +2665,34 @@ impl LiquifactEscrow {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
+    /// Returns a paginated view of the configured yield-tier ladder.
+    ///
+    /// Reads the same immutable table as [`LiquifactEscrow::get_yield_tiers`] and preserves
+    /// the validated ordering enforced at `init`.
+    ///
+    /// # Arguments
+    /// * `start` - The starting index (0-based) of the pagination.
+    /// * `limit` - The maximum number of yield tiers to return (capped at [`MAX_INVESTOR_READ_BATCH`]).
+    ///
+    /// # Returns
+    /// A `Vec<YieldTier>` containing the yield tiers within the requested page.
+    pub fn get_yield_tiers_page(env: Env, start: u32, limit: u32) -> Vec<YieldTier> {
+        let tiers = Self::get_yield_tiers(env.clone());
+        let len = tiers.len();
+        if start >= len || limit == 0 {
+            return Vec::new(&env);
+        }
+
+        let actual_limit = limit.min(MAX_INVESTOR_READ_BATCH);
+        let end = (start + actual_limit).min(len);
+
+        let mut result = Vec::new(&env);
+        for i in start..end {
+            result.push_back(tiers.get(i).unwrap());
+        }
+        result
+    }
+
     /// Pure read — no auth, no storage writes, safe for simulation.
     ///
     /// Returns `(effective_yield_bps, matched_lock_secs)` for a hypothetical contribution of

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -6298,6 +6298,146 @@ fn test_get_yield_tiers_is_pure_read_no_state_change() {
     );
 }
 
+#[test]
+fn test_get_yield_tiers_page_returns_empty_when_no_tiers_configured() {
+    let env = Env::default();
+
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (tok, tre) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "EMPTY01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let page = client.get_yield_tiers_page(&0, &2);
+
+    assert_eq!(page.len(), 0, "empty storage should return an empty page");
+}
+
+#[test]
+fn test_get_yield_tiers_page_pagination() {
+    let env = Env::default();
+
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+
+    let admin = Address::generate(&env);
+
+    let sme = Address::generate(&env);
+
+    let (tok, tre) = free_addresses(&env);
+
+    let mut tiers = SorobanVec::new(&env);
+
+    let tier_specs = [
+        (0u64, 900i64),
+        (1u64, 950i64),
+        (2u64, 1_000i64),
+        (3u64, 1_050i64),
+        (4u64, 1_100i64),
+    ];
+
+    for (index, (base_lock, yield_bps)) in tier_specs.iter().enumerate() {
+        tiers.push_back(YieldTier {
+            min_lock_secs: *base_lock + (index as u64) * 60_000,
+            yield_bps: *yield_bps,
+        });
+    }
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "PAGE01"),
+        &sme,
+        &100_000i128,
+        &800i64,
+        &0u64,
+        &tok,
+        &None,
+        &tre,
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let empty = client.get_yield_tiers_page(&0, &0);
+    assert_eq!(empty.len(), 0, "limit zero should return an empty page");
+
+    let page1 = client.get_yield_tiers_page(&0, &2);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1.get(0).unwrap().min_lock_secs, 0u64);
+    assert_eq!(page1.get(0).unwrap().yield_bps, 900i64);
+    assert_eq!(page1.get(1).unwrap().min_lock_secs, 60_001u64);
+    assert_eq!(page1.get(1).unwrap().yield_bps, 950i64);
+
+    let page2 = client.get_yield_tiers_page(&2, &2);
+    assert_eq!(page2.len(), 2);
+    assert_eq!(page2.get(0).unwrap().min_lock_secs, 120_002u64);
+    assert_eq!(page2.get(0).unwrap().yield_bps, 1_000i64);
+    assert_eq!(page2.get(1).unwrap().min_lock_secs, 180_003u64);
+    assert_eq!(page2.get(1).unwrap().yield_bps, 1_050i64);
+
+    let page3 = client.get_yield_tiers_page(&4, &2);
+    assert_eq!(page3.len(), 1);
+    assert_eq!(page3.get(0).unwrap().min_lock_secs, 240_004u64);
+    assert_eq!(page3.get(0).unwrap().yield_bps, 1_100i64);
+
+    let page4 = client.get_yield_tiers_page(&6, &2);
+    assert_eq!(
+        page4.len(),
+        0,
+        "start beyond end should return an empty page"
+    );
+
+    let capped = client.get_yield_tiers_page(&0, &(crate::MAX_INVESTOR_READ_BATCH + 10));
+    assert_eq!(
+        capped.len(),
+        5,
+        "limit above the pagination ceiling should be clamped"
+    );
+
+    let mut collected = SorobanVec::new(&env);
+    for page in [page1.clone(), page2.clone(), page3.clone()] {
+        for i in 0..page.len() {
+            collected.push_back(page.get(i).unwrap());
+        }
+    }
+
+    assert_eq!(
+        collected.len(),
+        5,
+        "pagination should not skip or duplicate tiers across pages"
+    );
+}
+
 // ---------------------------------------------------------------------------
 
 // preview_yield_tier vs fund_with_commitment equivalence tests (issue #562)


### PR DESCRIPTION
## Summary

- Added `get_yield_tiers_page(env, start, limit)` as a read-only paginated view over the immutable yield-tier table.
- Reused the shared pagination ceiling through `MAX_INVESTOR_READ_BATCH`.
- Added safe handling for empty storage, zero limits, and out-of-range start values.
- Preserved deterministic tier ordering.
- Added documentation for the new read API.
- Added tests for empty results, full and partial pages, continuation, limit clamping, and no gaps or duplicates.

Closes #810

## Verification

```text
cargo fmt --check
Passed

cargo clippy --all-targets -- -D warnings
Passed

cargo test
842 passed; 0 failed; 54 ignored; 0 measured; 0 filtered out

Doc-tests liquifact_escrow
0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out.




Closes #810