### PR TITLE
feat(storage): admin-configurable limit #829

### DIFF
--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -152,6 +152,7 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 203 | `FundingDeadlineNotExtended` | `extend_funding_deadline` | `new_deadline <= current` | Pass a strictly later deadline | typed |
 | 204 | `FundingDeadlineBeyondMaturity` | `init`, `extend_funding_deadline` | deadline at or beyond maturity | Keep deadline before maturity | typed |
 | 205 | `FundingDeadlineNotSet` | `extend_funding_deadline` | no deadline configured | Set deadline at init first | typed |
+| 223 | `StorageLimitOutOfRange` | `set_storage_limit` | `limit` outside `MIN_STORAGE_LIMIT_LEDGERS..=MAX_STORAGE_LIMIT_LEDGERS` | Pass a ledger count within the documented bounds | typed |
 
 ### Legacy panic strings (migration aid)
 
@@ -247,6 +248,7 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 162 | `New SME address must differ from current beneficiary` |
 | 163 | `Funding deadline has passed` |
 | 164 | `Contract balance below funded amount` |
+| 223 | `storage limit out of range` |
 
 ## Client Guidance
 

--- a/docs/escrow-gas-storage-notes.md
+++ b/docs/escrow-gas-storage-notes.md
@@ -87,8 +87,20 @@ Key properties (invariant):
 
 Thresholds are defined as **named constants** in `escrow/src/lib.rs`:
 
-- `INSTANCE_TTL_MIN_EXTENSION_SECS`
-- `PERSISTENT_TTL_MIN_EXTENSION_SECS`
+- `INSTANCE_TTL_MIN_EXTENSION_LEDGERS` (default ≈ 1h)
+- `PERSISTENT_TTL_MIN_EXTENSION_LEDGERS` (default ≈ 1h; kept equal to the instance default)
+
+### Admin-configurable storage limit
+
+Operators may override the TTL extension horizon via:
+
+- `get_storage_limit` — returns the configured ledger count, or the compile-time default when unset
+- `set_storage_limit` — admin-only; accepts values in `MIN_STORAGE_LIMIT_LEDGERS..=MAX_STORAGE_LIMIT_LEDGERS`
+
+Unset storage preserves historical behaviour (`INSTANCE_TTL_MIN_EXTENSION_LEDGERS`). Out-of-range
+values revert with typed `EscrowError::StorageLimitOutOfRange` (223). The configured limit is
+applied uniformly to instance and persistent `extend_ttl` calls inside `bump_ttl` and funding-
+deadline TTL top-ups.
 
 ### Why permissionless is acceptable
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -263,13 +263,33 @@ pub const DEFAULT_ADMIN_PROPOSAL_VALIDITY_SECS: u64 = 604_800; // 7 days
 /// maturity/claim locks are far in the future.
 ///
 /// Named as a constant so operators can reason about and audit the threshold.
+/// Also the **default** for [`LiquifactEscrow::get_storage_limit`] when
+/// [`DataKey::StorageLimit`] is unset — preserving pre-configurable behaviour.
 pub const INSTANCE_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 ledger/sec.
 
 /// Minimum persistent storage TTL extension horizon for per-investor allowlist entries.
 ///
 /// When the escrow uses the allowlist gate, investor funding depends on persistent entries.
 /// Extending persistent allowlist TTL reduces the risk of silent allowlist disablement.
+///
+/// When [`DataKey::StorageLimit`] is unset, persistent extensions also fall back to
+/// [`INSTANCE_TTL_MIN_EXTENSION_LEDGERS`] (equal to this constant today).
 pub const PERSISTENT_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 ledger/sec.
+
+/// Inclusive lower bound for [`LiquifactEscrow::set_storage_limit`].
+///
+/// `0` is rejected: a zero ledger extension is a no-op that wastes the call budget.
+pub const MIN_STORAGE_LIMIT_LEDGERS: u32 = 1;
+
+/// Inclusive upper bound for [`LiquifactEscrow::set_storage_limit`].
+///
+/// Caps rent cost from an accidentally huge TTL extension (~30 days at the contract's
+/// "1 ledger/sec" model used elsewhere for TTL constants).
+pub const MAX_STORAGE_LIMIT_LEDGERS: u32 = 2_592_000;
+
+// Instance and persistent defaults stay equal so a single [`DataKey::StorageLimit`]
+// override applies uniformly to both storage kinds.
+const _: () = assert!(INSTANCE_TTL_MIN_EXTENSION_LEDGERS == PERSISTENT_TTL_MIN_EXTENSION_LEDGERS);
 
 /// Stable typed errors emitted by LiquiFact escrow entrypoints.
 ///
@@ -576,6 +596,10 @@ pub enum EscrowError {
     /// [`LiquifactEscrow::unfund`] blocked because a compliance/legal hold is active.
     /// No fund movement is permitted until the hold is cleared by the admin.
     UnfundLegalHoldActive = 222,
+
+    /// [`LiquifactEscrow::set_storage_limit`] received a value outside
+    /// [`MIN_STORAGE_LIMIT_LEDGERS`]..=[`MAX_STORAGE_LIMIT_LEDGERS`].
+    StorageLimitOutOfRange = 223,
 }
 
 #[inline(always)]
@@ -875,6 +899,11 @@ pub enum DataKey {
     /// **Additive key (ADR-007):** absent on instances predating this key ⇒ read as `0`
     /// (no fee), preserving legacy full-principal disbursement semantics.
     ProtocolFeeBps,
+    /// Admin-configured storage TTL extension horizon in ledgers, applied by
+    /// [`LiquifactEscrow::bump_ttl`] and funding-deadline TTL top-ups.
+    /// Absent ⇒ falls back to [`INSTANCE_TTL_MIN_EXTENSION_LEDGERS`] (preserves
+    /// pre-configurable behaviour). Updated via [`LiquifactEscrow::set_storage_limit`].
+    StorageLimit,
 }
 
 // --- Data types ---
@@ -4856,10 +4885,8 @@ impl LiquifactEscrow {
         env.storage()
             .instance()
             .set(&DataKey::FundingDeadline, &new_deadline);
-        env.storage().instance().extend_ttl(
-            INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
-            INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
-        );
+        let ttl = Self::get_storage_limit(env.clone());
+        env.storage().instance().extend_ttl(ttl, ttl);
 
         FundingDeadlineExtended {
             name: symbol_short!("fund_ext"),
@@ -4971,6 +4998,43 @@ impl LiquifactEscrow {
         new_horizon
     }
 
+    /// Return the admin-configured storage TTL extension horizon in ledgers.
+    ///
+    /// Falls back to [`INSTANCE_TTL_MIN_EXTENSION_LEDGERS`] when [`DataKey::StorageLimit`]
+    /// is unset, preserving the historical hard-coded bump amount.
+    pub fn get_storage_limit(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::StorageLimit)
+            .unwrap_or(INSTANCE_TTL_MIN_EXTENSION_LEDGERS)
+    }
+
+    /// Set the storage TTL extension horizon used by [`LiquifactEscrow::bump_ttl`]
+    /// and funding-deadline TTL top-ups.
+    ///
+    /// # Authorization
+    /// Requires the signature of the current [`InvoiceEscrow::admin`].
+    ///
+    /// # Errors
+    /// - [`EscrowError::StorageLimitOutOfRange`] if `limit` is outside
+    ///   [`MIN_STORAGE_LIMIT_LEDGERS`]..=[`MAX_STORAGE_LIMIT_LEDGERS`].
+    ///
+    /// # Returns
+    /// The newly stored limit.
+    pub fn set_storage_limit(env: Env, limit: u32) -> u32 {
+        let _escrow = Self::load_escrow_require_admin(&env);
+
+        ensure(
+            &env,
+            (MIN_STORAGE_LIMIT_LEDGERS..=MAX_STORAGE_LIMIT_LEDGERS).contains(&limit),
+            EscrowError::StorageLimitOutOfRange,
+        );
+
+        env.storage().instance().set(&DataKey::StorageLimit, &limit);
+
+        limit
+    }
+
     pub fn bump_ttl(env: Env, allowlisted: Vec<Address>) {
         // Permissionless TTL extension.
         //
@@ -4986,19 +5050,19 @@ impl LiquifactEscrow {
         // - ADR-007: storage key evolution policy (additive changes / key semantics).
         // - docs/escrow-ledger-time.md: all gating uses `Env::ledger().timestamp()` with `>=`.
 
+        // Admin-configurable horizon (default = INSTANCE_TTL_MIN_EXTENSION_LEDGERS).
+        let ttl = Self::get_storage_limit(env.clone());
+
         // Extend persistent TTL for allowlisted investor entries.
         for addr in allowlisted.iter() {
             // Persistent allowlist entry.
             env.storage().persistent().extend_ttl(
                 &DataKey::InvestorAllowlisted(addr.clone()),
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                ttl,
+                ttl,
             );
             // Instance keys that may be per‑investor (contribution & claim lock).
-            env.storage().instance().extend_ttl(
-                INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
-                INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
-            );
+            env.storage().instance().extend_ttl(ttl, ttl);
         }
 
         // Instance storage TTL is contract-wide under Soroban SDK 25. The call above covers
@@ -5007,31 +5071,27 @@ impl LiquifactEscrow {
         // Persistent per-investor keys and allowlist entries (independent TTL per address).
         for addr in allowlisted.iter() {
             let k = DataKey::InvestorAllowlisted(addr.clone());
-            env.storage().persistent().extend_ttl(
-                &k,
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
-            );
+            env.storage().persistent().extend_ttl(&k, ttl, ttl);
             // Extend persistent TTL for per-investor persistent keys used by this contract.
             env.storage().persistent().extend_ttl(
                 &DataKey::InvestorContribution(addr.clone()),
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                ttl,
+                ttl,
             );
             env.storage().persistent().extend_ttl(
                 &DataKey::InvestorEffectiveYield(addr.clone()),
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                ttl,
+                ttl,
             );
             env.storage().persistent().extend_ttl(
                 &DataKey::InvestorClaimNotBefore(addr.clone()),
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                ttl,
+                ttl,
             );
             env.storage().persistent().extend_ttl(
                 &DataKey::InvestorClaimed(addr.clone()),
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
-                PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
+                ttl,
+                ttl,
             );
         }
     }

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -3112,3 +3112,114 @@ fn test_pending_admin_remaining_consistent_with_accept_admin() {
     assert_eq!(client.get_pending_admin_remaining_secs(), Some(0));
     assert_contract_error(client.try_accept_admin(), EscrowError::AdminProposalExpired);
 }
+
+// ── set_storage_limit / get_storage_limit (GitHub Issue #829) ─────────────────
+
+/// Unconfigured escrows expose the historical hard-coded TTL extension (3600 ledgers).
+#[test]
+fn test_get_storage_limit_defaults_to_compile_time_constant() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    assert_eq!(
+        client.get_storage_limit(),
+        crate::INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
+        "unset StorageLimit must preserve the hard-coded TTL extension"
+    );
+    assert_eq!(client.get_storage_limit(), 3_600u32);
+}
+
+/// Admin may set an in-bounds storage limit; getter reflects the new value.
+#[test]
+fn test_set_storage_limit_success() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let new_limit = 7_200u32;
+    assert_eq!(client.set_storage_limit(&new_limit), new_limit);
+    assert_eq!(client.get_storage_limit(), new_limit);
+
+    // Boundary values are accepted.
+    assert_eq!(
+        client.set_storage_limit(&crate::MIN_STORAGE_LIMIT_LEDGERS),
+        crate::MIN_STORAGE_LIMIT_LEDGERS
+    );
+    assert_eq!(client.get_storage_limit(), crate::MIN_STORAGE_LIMIT_LEDGERS);
+    assert_eq!(
+        client.set_storage_limit(&crate::MAX_STORAGE_LIMIT_LEDGERS),
+        crate::MAX_STORAGE_LIMIT_LEDGERS
+    );
+    assert_eq!(client.get_storage_limit(), crate::MAX_STORAGE_LIMIT_LEDGERS);
+}
+
+/// Zero and above-max limits are rejected with `StorageLimitOutOfRange`.
+#[test]
+fn test_set_storage_limit_out_of_range() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    assert_contract_error(
+        client.try_set_storage_limit(&0u32),
+        EscrowError::StorageLimitOutOfRange,
+    );
+    assert_contract_error(
+        client.try_set_storage_limit(&(crate::MAX_STORAGE_LIMIT_LEDGERS + 1)),
+        EscrowError::StorageLimitOutOfRange,
+    );
+    // Rejected sets must not mutate the stored (default) limit.
+    assert_eq!(
+        client.get_storage_limit(),
+        crate::INSTANCE_TTL_MIN_EXTENSION_LEDGERS
+    );
+}
+
+/// Non-admin callers cannot set the storage limit.
+#[test]
+#[should_panic]
+fn test_set_storage_limit_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let client = deploy(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "STOR_U"),
+        &sme,
+        &1_000i128,
+        &500i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    env.mock_auths(&[]);
+    client.set_storage_limit(&7_200u32);
+}
+
+/// `bump_ttl` remains callable after an admin override (uses the configured horizon).
+#[test]
+fn test_bump_ttl_succeeds_after_storage_limit_override() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    client.set_storage_limit(&1_800u32);
+    assert_eq!(client.get_storage_limit(), 1_800u32);
+
+    // Empty allowlist still exercises the path that loads the configured storage limit.
+    let addrs = soroban_sdk::Vec::<Address>::new(&env);
+    client.bump_ttl(&addrs);
+}


### PR DESCRIPTION
## Overview

This PR makes the **storage TTL extension horizon** an admin-configurable parameter. The previous hard-coded `3600`-ledger bump amount remains the default when unset, and admins can override it within safe bounds so rent/archival policy can be tuned without redeploying.

## Related Issue

Closes #829

## Changes

### Storage Limit Configuration

* **[ADD]** `DataKey::StorageLimit` (additive, ADR-007)
  * Persists the admin-configured TTL extension horizon in ledgers.

* **[ADD]** `get_storage_limit` / `set_storage_limit`
  * Getter falls back to `INSTANCE_TTL_MIN_EXTENSION_LEDGERS` (`3600`) when unset — preserves current behaviour.
  * Setter requires admin auth and accepts `MIN_STORAGE_LIMIT_LEDGERS..=MAX_STORAGE_LIMIT_LEDGERS` (`1..=2_592_000`).
  * Out-of-range values revert with typed `EscrowError::StorageLimitOutOfRange` (223).

* **[MODIFY]** `bump_ttl` + funding-deadline TTL top-up
  * Both paths now extend TTL using the configured storage limit (instance + persistent).

* **[ADD]** Bounds constants
  * `MIN_STORAGE_LIMIT_LEDGERS`, `MAX_STORAGE_LIMIT_LEDGERS`, plus a compile-time assert that instance/persistent defaults stay equal.

* **[MODIFY]** Docs
  * `docs/escrow-gas-storage-notes.md` — document override + bounds (and fix `*_SECS` → `*_LEDGERS`).
  * `docs/escrow-error-messages.md` — register code `223`.

* **[ADD]** Tests in `escrow/src/tests/admin.rs`
  * Default, in-bounds set (incl. min/max), over-bounds rejection, non-admin rejection, and `bump_ttl` after override.

## Verification Results

```
cargo fmt -p liquifact_escrow
cargo clippy -p liquifact_escrow --all-targets -- -D warnings
✅ clean

cargo test -p liquifact_escrow -- test_get_storage_limit test_set_storage_limit test_bump_ttl_succeeds_after_storage
✅ 5/5 passed

cargo test -p liquifact_escrow -- bump_ttl
✅ 2/2 passed (incl. existing coverage test)
```

| Acceptance Criteria | Status |
| --- | --- |
| Admin entrypoint to set storage limit within safe bounds | ✅ `set_storage_limit` with `1..=2_592_000` |
| Default preserves current behaviour | ✅ Unset ⇒ `3600` (`INSTANCE_TTL_MIN_EXTENSION_LEDGERS`) |
| Require admin auth | ✅ Via `load_escrow_require_admin` |
| Reject out-of-range with typed error | ✅ `StorageLimitOutOfRange` (223) |
| Cover set/get and rejection in tests | ✅ Default, success, out-of-range, unauthorized, bump path |