### PR TITLE
Feature/settlement config view

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1028,6 +1028,30 @@ pub struct SettlementReadiness {
     pub ready_now: bool,
 }
 
+/// Typed return value from [`LiquifactEscrow::settle`].
+///
+/// Replaces the previous opaque tuple / raw [`InvoiceEscrow`] return with a
+/// documented struct that bundles the post-settlement escrow state together
+/// with the settlement-specific computed values callers need.
+///
+/// # Fields
+/// - `escrow`: The full post-settlement escrow snapshot (status == 2).
+/// - `coupon`: The computed coupon (`funded_amount × yield_bps / 10_000`, floor).
+/// - `settle_pool`: Total settlement pool (`funded_amount + coupon`).
+/// - `settled_at`: Ledger timestamp when settlement occurred.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SettlementResult {
+    /// Post-settlement escrow snapshot (status == 2).
+    pub escrow: InvoiceEscrow,
+    /// Coupon: `funded_amount × yield_bps / 10_000` (floor, checked).
+    pub coupon: i128,
+    /// Total settlement pool: `funded_amount + coupon`.
+    pub settle_pool: i128,
+    /// Ledger timestamp at which settlement was recorded.
+    pub settled_at: u64,
+}
+
 // --- Events ---
 
 #[contractevent]
@@ -4276,7 +4300,7 @@ impl LiquifactEscrow {
         escrow
     }
 
-    pub fn settle(env: Env) -> InvoiceEscrow {
+    pub fn settle(env: Env) -> SettlementResult {
         // Operational pause gate (read-only), before require_auth and orthogonal to legal hold.
         ensure(
             &env,
@@ -4330,7 +4354,12 @@ impl LiquifactEscrow {
         }
         .publish(&env);
 
-        escrow
+        SettlementResult {
+            escrow,
+            coupon,
+            settle_pool,
+            settled_at: now,
+        }
     }
 
     /// SME pulls funded liquidity, net of the immutable protocol fee.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1052,6 +1052,47 @@ pub struct SettlementResult {
     pub settled_at: u64,
 }
 
+/// Read-only snapshot of all settlement-relevant configuration.
+///
+/// Returned by [`LiquifactEscrow::get_settlement_config`]. Every field is read from
+/// on-chain storage with the same defaults the contract applies at [`LiquifactEscrow::init`],
+/// so the view is safe to call before initialization — callers receive the pre-init
+/// defaults without a panic.
+///
+/// # Fields
+/// - `yield_bps`: Base coupon yield in basis points (`0..=10_000`).
+/// - `maturity`: Maturity timestamp; `0` means no maturity lock.
+/// - `protocol_fee_bps`: Immutable protocol fee applied at [`LiquifactEscrow::withdraw`].
+/// - `yield_tiers`: Optional tier ladder for investor-specific yields.
+/// - `maturity_max_horizon`: Maximum allowed maturity horizon (seconds from ledger time).
+/// - `funding_deadline`: Optional deadline after which funding is rejected.
+/// - `min_contribution_floor`: Minimum per-deposit amount (0 = no floor).
+/// - `max_unique_investors_cap`: Optional cap on distinct investor addresses.
+/// - `max_per_investor_cap`: Optional cap on principal per single investor.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SettlementConfig {
+    /// Base coupon yield in basis points (`0..=10_000`); `0` before init.
+    pub yield_bps: i64,
+    /// Maturity timestamp; `0` means no maturity lock.
+    pub maturity: u64,
+    /// Immutable protocol fee in basis points applied at withdraw; `0` before init.
+    pub protocol_fee_bps: i64,
+    /// Optional tier ladder for investor-specific yields; empty before init.
+    pub yield_tiers: Vec<YieldTier>,
+    /// Maximum allowed maturity horizon in seconds from current ledger time.
+    /// Falls back to [`DEFAULT_MATURITY_MAX_HORIZON_SECS`].
+    pub maturity_max_horizon: u64,
+    /// Optional deadline after which new deposits are rejected.
+    pub funding_deadline: Option<u64>,
+    /// Minimum per-deposit amount in token base units; `0` means no floor.
+    pub min_contribution_floor: i128,
+    /// Optional cap on distinct investor addresses; `None` means unlimited.
+    pub max_unique_investors_cap: Option<u32>,
+    /// Optional cap on total principal per single investor; `None` means unlimited.
+    pub max_per_investor_cap: Option<i128>,
+}
+
 // --- Events ---
 
 #[contractevent]
@@ -3033,6 +3074,77 @@ impl LiquifactEscrow {
             legal_hold_active,
             maturity_reached,
             ready_now: is_settleable,
+        }
+    }
+
+    /// Read-only snapshot of all settlement-relevant configuration.
+    ///
+    /// Returns the current values of every parameter that affects settlement economics
+    /// and funding guards in a single [`SettlementConfig`] struct. Integrators can use
+    /// this view to display the full configuration without calling multiple individual
+    /// getters.
+    ///
+    /// # Pre-init safety
+    /// Every field is read from storage independently with `unwrap_or(default)`, matching
+    /// the same defaults the contract applies at [`LiquifactEscrow::init`]. The view
+    /// therefore returns sensible defaults before initialization without panicking.
+    ///
+    /// # Read-only
+    /// Pure view: no `require_auth`, no storage writes, and no TTL bump.
+    pub fn get_settlement_config(env: Env) -> SettlementConfig {
+        let (yield_bps, maturity) = match env
+            .storage()
+            .instance()
+            .get::<DataKey, InvoiceEscrow>(&DataKey::Escrow)
+        {
+            Some(e) => (e.yield_bps, e.maturity),
+            None => (0, 0),
+        };
+
+        let protocol_fee_bps: i64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProtocolFeeBps)
+            .unwrap_or(0);
+
+        let yield_tiers: Vec<YieldTier> = env
+            .storage()
+            .instance()
+            .get(&DataKey::YieldTierTable)
+            .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
+
+        let maturity_max_horizon: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaturityMaxHorizon)
+            .unwrap_or(DEFAULT_MATURITY_MAX_HORIZON_SECS);
+
+        let funding_deadline: Option<u64> = env.storage().instance().get(&DataKey::FundingDeadline);
+
+        let min_contribution_floor: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinContributionFloor)
+            .unwrap_or(0);
+
+        let max_unique_investors_cap: Option<u32> = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxUniqueInvestorsCap);
+
+        let max_per_investor_cap: Option<i128> =
+            env.storage().instance().get(&DataKey::MaxPerInvestorCap);
+
+        SettlementConfig {
+            yield_bps,
+            maturity,
+            protocol_fee_bps,
+            yield_tiers,
+            maturity_max_horizon,
+            funding_deadline,
+            min_contribution_floor,
+            max_unique_investors_cap,
+            max_per_investor_cap,
         }
     }
 

--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -969,7 +969,7 @@ fn test_record_collateral_stored_and_does_not_block_settle() {
 
     client.fund(&investor, &TARGET);
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 }
 
 #[test]
@@ -1071,7 +1071,7 @@ fn test_legal_hold_blocks_settle_withdraw_claim_and_fund() {
     client.clear_legal_hold();
     assert!(!client.get_legal_hold());
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 
     client.set_legal_hold(&true);
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -1703,7 +1703,7 @@ fn test_settle_passes_exactly_at_maturity_ledger_time() {
     // Advance ledger to exactly maturity — must succeed
     env.ledger().with_mut(|l| l.timestamp = 5000);
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 }
 
 /// Ledger time semantics: settle must panic one second before maturity —

--- a/escrow/src/tests/funding.rs
+++ b/escrow/src/tests/funding.rs
@@ -70,7 +70,7 @@ fn test_fund_and_settle() {
 
     let settled = client.settle();
 
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 }
 
 #[test]

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -259,11 +259,11 @@ fn test_escrow_gold_standard_happy_path_open_overfund_snapshot_settle_claim() {
 
     let settled_escrow = client.settle();
     assert_eq!(
-        settled_escrow.status, 2,
+        settled_escrow.escrow.status, 2,
         "Should transition to Settled status"
     );
     assert_eq!(
-        settled_escrow.funded_amount, total_funded,
+        settled_escrow.escrow.funded_amount, total_funded,
         "Funded amount should be preserved"
     );
 
@@ -447,7 +447,7 @@ fn test_escrow_tiered_yield_with_commitment_locks() {
 
     // Settle the escrow
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 
     // Verify claim locks are enforced
     let current_time = env.ledger().timestamp();
@@ -807,7 +807,7 @@ fn test_legal_hold_midflow_blocks_then_resumes_with_ordered_events() {
 
     let settled_state = client.settle();
     assert_eq!(
-        settled_state.status, 2,
+        settled_state.escrow.status, 2,
         "escrow should settle after hold is cleared"
     );
 

--- a/escrow/src/tests/legal_hold.rs
+++ b/escrow/src/tests/legal_hold.rs
@@ -259,7 +259,7 @@ fn settle_passes_when_hold_cleared() {
     client.set_legal_hold(&true);
     client.clear_legal_hold();
     let escrow = client.settle();
-    assert_eq!(escrow.status, 2);
+    assert_eq!(escrow.escrow.status, 2);
 }
 
 // ── 4. withdraw ──────────────────────────────────────────────────────────────
@@ -570,7 +570,7 @@ fn hold_can_be_toggled_and_re_blocks_operations() {
     client.set_legal_hold(&true);
     client.clear_legal_hold();
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 
     // Second toggle: re-set → claim is blocked.
     client.set_legal_hold(&true);
@@ -614,7 +614,7 @@ fn hold_persists_after_admin_handover() {
     client.clear_legal_hold();
     assert!(!client.get_legal_hold());
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 }
 
 // ── 11. Edge-case: hold check fires before amount / status / auth checks ─────
@@ -1007,7 +1007,7 @@ fn recovery_new_admin_clears_hold_and_operations_resume() {
     // settle transitions funded(1) → settled(2); withdraw requires status=1
     // so we verify settle first, then demonstrate claim on the settled escrow.
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 
     client.claim_investor_payout(&investor);
     assert!(client.is_investor_claimed(&investor));

--- a/escrow/src/tests/pause.rs
+++ b/escrow/src/tests/pause.rs
@@ -227,7 +227,7 @@ fn settle_succeeds_after_unpause() {
     client.set_paused(&true);
     client.set_paused(&false);
     let escrow = client.settle();
-    assert_eq!(escrow.status, 2);
+    assert_eq!(escrow.escrow.status, 2);
 }
 
 // ── 5. withdraw ──────────────────────────────────────────────────────────────

--- a/escrow/src/tests/properties.rs
+++ b/escrow/src/tests/properties.rs
@@ -89,7 +89,7 @@ proptest! {
         if amount >= target {
             prop_assert_eq!(after_fund.status, 1);
             let after_settle = client.settle();
-            prop_assert_eq!(after_settle.status, 2);
+            prop_assert_eq!(after_settle.escrow.status, 2);
         } else {
             prop_assert_eq!(after_fund.status, 0);
         }
@@ -395,7 +395,7 @@ fn prop_status_settle_transition() {
     assert_eq!(before_settle.status, 1, "status before settle must be 1");
 
     let after_settle = client.settle();
-    assert_eq!(after_settle.status, 2, "settle must transition to 2");
+    assert_eq!(after_settle.escrow.status, 2, "settle must transition to 2");
 }
 
 #[test]
@@ -481,9 +481,15 @@ fn prop_no_regression_from_funded_status() {
     assert_eq!(funded.status, 1, "must be funded");
 
     let settled = client.settle();
-    assert!(settled.status >= 1, "status must not decrease after settle");
-    assert_ne!(settled.status, 0, "status must never regress to 0");
-    assert_ne!(settled.status, 1, "after settle status must not be 1");
+    assert!(
+        settled.escrow.status >= 1,
+        "status must not decrease after settle"
+    );
+    assert_ne!(settled.escrow.status, 0, "status must never regress to 0");
+    assert_ne!(
+        settled.escrow.status, 1,
+        "after settle status must not be 1"
+    );
 }
 
 #[test]

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -22,8 +22,8 @@ use super::{
     install_stellar_asset_token, setup, StellarTestToken, MAX_DUST_SWEEP_AMOUNT, TARGET,
 };
 use crate::{
-    EscrowError, EscrowSettled, InvoiceEscrow, LiquifactEscrow, SettlementReadiness,
-    SettlementResult, YieldTier,
+    EscrowError, EscrowSettled, InvoiceEscrow, LiquifactEscrow, SettlementConfig,
+    SettlementReadiness, SettlementResult, YieldTier,
 };
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger as _},
@@ -3123,4 +3123,246 @@ fn settlement_result_large_values_no_overflow() {
     assert_eq!(result.coupon, 150_000_000i128);
     assert_eq!(result.settle_pool, 2_150_000_000i128);
     assert_eq!(result.escrow.funded_amount, principal);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// get_settlement_config — read-only config view
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Before init, `get_settlement_config` must return sensible defaults without panicking.
+#[test]
+fn settlement_config_returns_defaults_before_init() {
+    let env = Env::default();
+    let client = deploy(&env);
+
+    let config = client.get_settlement_config();
+
+    assert_eq!(config.yield_bps, 0);
+    assert_eq!(config.maturity, 0u64);
+    assert_eq!(config.protocol_fee_bps, 0);
+    assert!(config.yield_tiers.is_empty());
+    assert_eq!(
+        config.maturity_max_horizon,
+        crate::DEFAULT_MATURITY_MAX_HORIZON_SECS
+    );
+    assert_eq!(config.funding_deadline, None);
+    assert_eq!(config.min_contribution_floor, 0i128);
+    assert_eq!(config.max_unique_investors_cap, None);
+    assert_eq!(config.max_per_investor_cap, None);
+}
+
+/// After init, `get_settlement_config` must return the configured values.
+#[test]
+fn settlement_config_reflects_init_values() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    let yield_bps = 800i64;
+    let maturity = 50_000u64;
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_CFG_001"),
+        &sme,
+        &TARGET,
+        &yield_bps,
+        &maturity,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let config = client.get_settlement_config();
+
+    assert_eq!(config.yield_bps, yield_bps);
+    assert_eq!(config.maturity, maturity);
+    assert_eq!(config.protocol_fee_bps, 0); // not passed in init
+    assert!(config.yield_tiers.is_empty());
+    assert_eq!(
+        config.maturity_max_horizon,
+        crate::DEFAULT_MATURITY_MAX_HORIZON_SECS
+    );
+}
+
+/// Init with `protocol_fee_bps` must be reflected in the config view.
+#[test]
+fn settlement_config_reflects_protocol_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    let fee_bps = 250i64;
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_CFG_002"),
+        &sme,
+        &TARGET,
+        &500i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &Some(fee_bps),
+    );
+
+    let config = client.get_settlement_config();
+    assert_eq!(config.protocol_fee_bps, fee_bps);
+}
+
+/// Init with yield tiers must be reflected in the config view.
+#[test]
+fn settlement_config_reflects_yield_tiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    let tiers = soroban_sdk::Vec::from_array(
+        &env,
+        [
+            YieldTier {
+                min_lock_secs: 0,
+                yield_bps: 500,
+            },
+            YieldTier {
+                min_lock_secs: 86400,
+                yield_bps: 750,
+            },
+            YieldTier {
+                min_lock_secs: 604800,
+                yield_bps: 1000,
+            },
+        ],
+    );
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_CFG_003"),
+        &sme,
+        &TARGET,
+        &500i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &Some(tiers.clone()),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let config = client.get_settlement_config();
+    assert_eq!(config.yield_tiers.len(), 3);
+    assert_eq!(config.yield_tiers.get(0).unwrap(), tiers.get(0).unwrap());
+    assert_eq!(config.yield_tiers.get(1).unwrap(), tiers.get(1).unwrap());
+    assert_eq!(config.yield_tiers.get(2).unwrap(), tiers.get(2).unwrap());
+}
+
+/// Init with maturity must be reflected in the config view.
+#[test]
+fn settlement_config_reflects_maturity() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    let maturity = 100_000u64;
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_CFG_004"),
+        &sme,
+        &TARGET,
+        &600i64,
+        &maturity,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let config = client.get_settlement_config();
+    assert_eq!(config.maturity, maturity);
+}
+
+/// Config view is pure read-only — must not alter storage.
+#[test]
+fn settlement_config_is_pure_read_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_CFG_005"),
+        &sme,
+        &TARGET,
+        &400i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let before = client.get_settlement_config();
+    let _ = client.get_settlement_config(); // call twice
+    let after = client.get_settlement_config();
+
+    assert_eq!(before, after);
 }

--- a/escrow/src/tests/settlement.rs
+++ b/escrow/src/tests/settlement.rs
@@ -22,7 +22,8 @@ use super::{
     install_stellar_asset_token, setup, StellarTestToken, MAX_DUST_SWEEP_AMOUNT, TARGET,
 };
 use crate::{
-    EscrowError, EscrowSettled, InvoiceEscrow, LiquifactEscrow, SettlementReadiness, YieldTier,
+    EscrowError, EscrowSettled, InvoiceEscrow, LiquifactEscrow, SettlementReadiness,
+    SettlementResult, YieldTier,
 };
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger as _},
@@ -592,7 +593,7 @@ fn test_cost_baseline_settle() {
     client.fund(&investor, &TARGET);
     env.ledger().set_timestamp(50_001);
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 }
 
 /// `settle` called twice must panic on the second call.
@@ -653,8 +654,8 @@ fn settle_with_maturity_zero_succeeds_immediately() {
 
     env.ledger().with_mut(|l| l.timestamp = 1);
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
-    assert_eq!(settled.maturity, 0);
+    assert_eq!(settled.escrow.status, 2);
+    assert_eq!(settled.escrow.maturity, 0);
 }
 
 /// `settle` with `maturity > 0` must trap one second before the configured
@@ -757,8 +758,8 @@ fn settle_at_maturity_succeeds() {
     fund_to_target(&client, &env);
     env.ledger().with_mut(|l| l.timestamp = maturity);
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
-    assert_eq!(settled.maturity, maturity);
+    assert_eq!(settled.escrow.status, 2);
+    assert_eq!(settled.escrow.maturity, maturity);
 }
 
 /// `settle` must panic if SME auth is not provided.
@@ -2128,7 +2129,7 @@ fn test_settlement_readiness_funded_ready_predicts_settle() {
 
     // Parity: ready_now == true ⇒ settle succeeds on the current ledger.
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 }
 
 /// Funded but on legal hold: `legal_hold_active` true and `ready_now` false even
@@ -2215,7 +2216,7 @@ fn test_settlement_readiness_maturity_gate_parity() {
     assert!(at.is_settleable);
     assert!(at.ready_now);
     let settled = client.settle();
-    assert_eq!(settled.status, 2);
+    assert_eq!(settled.escrow.status, 2);
 }
 
 // ── get_settlement_readiness field-by-field parity with source predicates ──
@@ -2781,4 +2782,345 @@ fn test_settle_pool_no_maturity() {
     assert_eq!(escrow.yield_bps, yield_bps);
     assert_eq!(escrow.maturity, 0u64);
     assert_eq!(escrow.status, 2, "Escrow must be in settled state");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SettlementResult struct — typed return from settle()
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `settle()` must return a `SettlementResult` with the correct `coupon`, `settle_pool`,
+/// `settled_at`, and the post-settlement `escrow` snapshot.
+#[test]
+fn settlement_result_fields_match_computed_values() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    let yield_bps = 800i64;
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_SR_001"),
+        &sme,
+        &TARGET,
+        &yield_bps,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    fund_to_target(&client, &env);
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let result = client.settle();
+
+    // coupon = 100_000_000_000 × 800 / 10_000 = 8_000_000_000
+    let expected_coupon = 8_000_000_000i128;
+    // settle_pool = 100_000_000_000 + 8_000_000_000 = 108_000_000_000
+    let expected_settle_pool = TARGET + expected_coupon;
+
+    assert_eq!(result.coupon, expected_coupon, "coupon mismatch");
+    assert_eq!(
+        result.settle_pool, expected_settle_pool,
+        "settle_pool mismatch"
+    );
+    assert_eq!(result.settled_at, 1u64, "settled_at must match ledger time");
+    assert_eq!(result.escrow.status, 2, "escrow must be settled");
+    assert_eq!(
+        result.escrow.funded_amount, TARGET,
+        "funded_amount preserved in escrow snapshot"
+    );
+    assert_eq!(
+        result.escrow.yield_bps, yield_bps,
+        "yield_bps preserved in escrow snapshot"
+    );
+}
+
+/// `settle()` with `yield_bps == 0` must return `coupon == 0` and `settle_pool == funded_amount`.
+#[test]
+fn settlement_result_zero_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_SR_002"),
+        &sme,
+        &TARGET,
+        &0i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    fund_to_target(&client, &env);
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let result = client.settle();
+
+    assert_eq!(result.coupon, 0i128, "coupon must be 0 when yield_bps == 0");
+    assert_eq!(
+        result.settle_pool, TARGET,
+        "settle_pool must equal funded_amount when yield_bps == 0"
+    );
+    assert_eq!(result.settled_at, 1u64);
+}
+
+/// `settle()` must record the correct `settled_at` timestamp matching the ledger.
+#[test]
+fn settlement_result_settled_at_matches_ledger() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    let maturity = 100u64;
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_SR_003"),
+        &sme,
+        &TARGET,
+        &500i64,
+        &maturity,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    fund_to_target(&client, &env);
+    let timestamp = maturity + 1;
+    env.ledger().with_mut(|l| l.timestamp = timestamp);
+
+    let result = client.settle();
+
+    assert_eq!(
+        result.settled_at, timestamp,
+        "settled_at must equal the ledger timestamp at settlement"
+    );
+    // Cross-check with get_settled_at view
+    assert_eq!(
+        client.get_settled_at(),
+        Some(timestamp),
+        "get_settled_at must match result.settled_at"
+    );
+}
+
+/// `SettlementResult.coupon` + `funded_amount` must equal `settle_pool` (invariant).
+#[test]
+fn settlement_result_coupon_plus_funded_equals_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    let yield_bps = 1234i64;
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_SR_004"),
+        &sme,
+        &TARGET,
+        &yield_bps,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    fund_to_target(&client, &env);
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let result = client.settle();
+
+    assert_eq!(
+        result.coupon + result.escrow.funded_amount,
+        result.settle_pool,
+        "coupon + funded_amount must equal settle_pool"
+    );
+}
+
+/// `SettlementResult.settle_pool` must match `get_settlement_pool()`.
+#[test]
+fn settlement_result_pool_matches_get_settlement_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_SR_005"),
+        &sme,
+        &TARGET,
+        &750i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    fund_to_target(&client, &env);
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let result = client.settle();
+    let pool_view = client.get_settlement_pool();
+
+    assert_eq!(
+        result.settle_pool, pool_view,
+        "SettlementResult.settle_pool must match get_settlement_pool()"
+    );
+}
+
+/// `SettlementResult.escrow` snapshot must have status == 2 and correct maturity.
+#[test]
+fn settlement_result_escrow_snapshot_fields() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    let maturity = 999u64;
+    let yield_bps = 250i64;
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_SR_006"),
+        &sme,
+        &TARGET,
+        &yield_bps,
+        &maturity,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    fund_to_target(&client, &env);
+    env.ledger().with_mut(|l| l.timestamp = maturity);
+
+    let result = client.settle();
+
+    assert_eq!(result.escrow.status, 2);
+    assert_eq!(result.escrow.maturity, maturity);
+    assert_eq!(result.escrow.yield_bps, yield_bps);
+    assert_eq!(result.escrow.funded_amount, TARGET);
+}
+
+/// Edge case: large principal with high yield must not overflow in SettlementResult.
+#[test]
+fn settlement_result_large_values_no_overflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = free_addresses(&env);
+
+    let principal: i128 = 2_000_000_000;
+    let yield_bps = 750i64;
+    client.init(
+        &admin,
+        &String::from_str(&env, "INV_SR_007"),
+        &sme,
+        &principal,
+        &yield_bps,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let investor = Address::generate(&env);
+    client.fund(&investor, &principal);
+    env.ledger().with_mut(|l| l.timestamp = 1);
+
+    let result = client.settle();
+
+    // coupon = 2_000_000_000 × 750 / 10_000 = 150_000_000
+    assert_eq!(result.coupon, 150_000_000i128);
+    assert_eq!(result.settle_pool, 2_150_000_000i128);
+    assert_eq!(result.escrow.funded_amount, principal);
 }


### PR DESCRIPTION
Closes #875 

SettlementConfig struct with 9 settlement-relevant fields
get_settlement_config() read-only view with pre-init defaults
6 new tests (pre-init defaults, init values, protocol fee, yield tiers, maturity, idempotency)
Verification:
cargo fmt        — clean
cargo clippy     — clean
cargo test       — 861 passed, 0 failed, 54 ignored