### PR TITLE
test(pause): cover overflow and saturation (#823)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,11 @@ liquifact-contracts/
 | `migrate` | Admin | Schema version gate — **typed errors on all paths** in the current release (codes 90–92). |
 | `set_legal_hold` | Admin | Admin activates/clears compliance hold. |
 | `set_paused` | Admin | Admin toggles a lightweight operational pause (incident response) that blocks `fund`, `settle`, `withdraw`, and `claim_investor_payout`. Orthogonal to legal hold; single-call toggle with no clear delay. |
-| `is_paused` | — | Read the current operational pause flag (defaults to `false`). |
+| `is_paused` | — | Read the current operational pause flag (defaults to `false`). Reflects auto-expiry once a pause max duration is configured. |
+| `set_pause_max_duration` | Admin | Configure how long (seconds) an operational pause may stay active before it auto-expires. `0` disables the limit (legacy behavior: pause blocks indefinitely until explicitly cleared). Nonzero values must fall within `[MIN_PAUSE_MAX_DURATION_SECS, MAX_PAUSE_MAX_DURATION_SECS]` or the call fails with `PauseMaxDurationOutOfRange` (code 223). Emits `PauseMaxDurationUpdated`. |
+| `get_pause_max_duration` | — | Read the configured pause auto-expiry duration (`0` = unlimited). |
+| `set_pause_rate_limit` | Admin | Configure a cap (`max_toggles`) on `set_paused` calls allowed within a rolling `window_secs` window. `(0, 0)` disables rate limiting (legacy behavior). A nonzero `max_toggles` must pair with a nonzero `window_secs` (`PauseRateLimitInvalidCombination`, code 226) and both must fall within their configured bounds (`PauseToggleLimitOutOfRange` code 224, `PauseToggleWindowOutOfRange` code 225). Reconfiguring resets the current window. Emits `PauseRateLimitUpdated`. |
+| `get_pause_rate_limit` | — | Read the configured pause-toggle rate limit as `(max_toggles, window_secs)`; `(0, 0)` = unlimited. |
 | `set_allowlist_active` | Admin | Admin enables/disables the investor allowlist gate. |
 | `set_investor_allowlisted` | Admin | Admin sets per-address allowlist status. |
 | `set_investors_allowlisted` | Admin | Admin batch-sets allowlist status for multiple addresses. |
@@ -341,6 +345,18 @@ The escrow supports cancellation by the admin under specific criteria, unlocking
   clear delay. It gates `fund`, `settle`, `withdraw`, and `claim_investor_payout`
   as a read-only precondition before `require_auth` (typed errors 201–204). Either
   flag blocks independently; clearing one never clears the other.
+- **Pause limit configuration:** two independent, admin-configurable bounds guard the
+  pause circuit breaker itself, both defaulting to **disabled** so pre-existing
+  deployments behave identically until an admin opts in:
+  - `set_pause_max_duration` bounds how long a pause may block gated entrypoints before
+    it auto-expires (`is_paused` and the gate checks compute expiry from `DataKey::PausedAt`;
+    the stored `Paused` flag itself is left untouched until an explicit `set_paused(false)`).
+  - `set_pause_rate_limit` bounds how many times `set_paused` may be called within a
+    rolling window, to blunt a compromised-admin-key toggle-spam scenario.
+  Both setters require admin auth and reject out-of-range values with typed errors
+  (`PauseMaxDurationOutOfRange` 223, `PauseToggleLimitOutOfRange` 224,
+  `PauseToggleWindowOutOfRange` 225, `PauseRateLimitInvalidCombination` 226,
+  `PauseToggleRateLimitExceeded` 227).
 - **Collateral record:** SME-reported metadata only; not proof of custody,
   token movement, reserved balance, or an enforceable on-chain claim.
 - **Token integration:** fee-on-transfer, rebasing, and hook tokens are

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -271,6 +271,39 @@ pub const INSTANCE_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 
 /// Extending persistent allowlist TTL reduces the risk of silent allowlist disablement.
 pub const PERSISTENT_TTL_MIN_EXTENSION_LEDGERS: u32 = 60 * 60; // Approx. 1h at 1 ledger/sec.
 
+/// Default maximum duration (seconds) an operational pause ([`DataKey::Paused`]) may remain
+/// active before it auto-expires for gate-checking purposes. `0` = unlimited, which reproduces
+/// the legacy (pre-configurable) behavior exactly: a pause set with no duration limit configured
+/// blocks gated entrypoints until an admin explicitly calls [`LiquifactEscrow::set_paused`] with
+/// `active = false`.
+pub const DEFAULT_PAUSE_MAX_DURATION_SECS: u64 = 0;
+
+/// Minimum non-zero value accepted by [`LiquifactEscrow::set_pause_max_duration`].
+/// Prevents configuring a duration so short it defeats the purpose of the incident-response
+/// circuit breaker.
+pub const MIN_PAUSE_MAX_DURATION_SECS: u64 = 3_600; // 1 hour
+
+/// Maximum value accepted by [`LiquifactEscrow::set_pause_max_duration`].
+pub const MAX_PAUSE_MAX_DURATION_SECS: u64 = 7_776_000; // 90 days
+
+/// Default maximum number of [`LiquifactEscrow::set_paused`] calls allowed within
+/// [`DataKey::PauseToggleWindowSecs`]. `0` = unlimited, reproducing legacy behavior: no rate
+/// limit on how often the pause can be toggled.
+pub const DEFAULT_PAUSE_TOGGLE_LIMIT: u32 = 0;
+
+/// Minimum non-zero toggle count accepted by [`LiquifactEscrow::set_pause_rate_limit`].
+pub const MIN_PAUSE_TOGGLE_LIMIT: u32 = 1;
+
+/// Maximum toggle count accepted by [`LiquifactEscrow::set_pause_rate_limit`].
+pub const MAX_PAUSE_TOGGLE_LIMIT: u32 = 1_000;
+
+/// Minimum rate-limit window (seconds) accepted by [`LiquifactEscrow::set_pause_rate_limit`]
+/// when a non-zero toggle limit is configured.
+pub const MIN_PAUSE_TOGGLE_WINDOW_SECS: u64 = 60; // 1 minute
+
+/// Maximum rate-limit window (seconds) accepted by [`LiquifactEscrow::set_pause_rate_limit`].
+pub const MAX_PAUSE_TOGGLE_WINDOW_SECS: u64 = 7_776_000; // 90 days
+
 /// Stable typed errors emitted by LiquiFact escrow entrypoints.
 ///
 /// Codes are append-only: never reuse or renumber a variant. Client SDKs should branch on the
@@ -576,6 +609,24 @@ pub enum EscrowError {
     /// [`LiquifactEscrow::unfund`] blocked because a compliance/legal hold is active.
     /// No fund movement is permitted until the hold is cleared by the admin.
     UnfundLegalHoldActive = 222,
+
+    /// [`LiquifactEscrow::set_pause_max_duration`] received a nonzero value outside
+    /// [`MIN_PAUSE_MAX_DURATION_SECS`, `MAX_PAUSE_MAX_DURATION_SECS`].
+    PauseMaxDurationOutOfRange = 223,
+    /// [`LiquifactEscrow::set_pause_rate_limit`] received a nonzero `max_toggles` outside
+    /// [`MIN_PAUSE_TOGGLE_LIMIT`, `MAX_PAUSE_TOGGLE_LIMIT`].
+    PauseToggleLimitOutOfRange = 224,
+    /// [`LiquifactEscrow::set_pause_rate_limit`] received a `window_secs` outside
+    /// [`MIN_PAUSE_TOGGLE_WINDOW_SECS`, `MAX_PAUSE_TOGGLE_WINDOW_SECS`] while `max_toggles > 0`.
+    PauseToggleWindowOutOfRange = 225,
+    /// [`LiquifactEscrow::set_pause_rate_limit`] received `max_toggles == 0` paired with a
+    /// nonzero `window_secs`, or vice versa. Both must be zero together (disabled) or both
+    /// nonzero (enabled).
+    PauseRateLimitInvalidCombination = 226,
+    /// [`LiquifactEscrow::set_paused`] blocked because the configured pause-toggle rate limit
+    /// was already reached within the current window. Wait for the window to roll over or ask
+    /// the admin to raise the limit via [`LiquifactEscrow::set_pause_rate_limit`].
+    PauseToggleRateLimitExceeded = 227,
 }
 
 #[inline(always)]
@@ -875,6 +926,28 @@ pub enum DataKey {
     /// **Additive key (ADR-007):** absent on instances predating this key ⇒ read as `0`
     /// (no fee), preserving legacy full-principal disbursement semantics.
     ProtocolFeeBps,
+    /// Optional cap (seconds) on how long [`DataKey::Paused`] may remain active before
+    /// [`LiquifactEscrow::is_paused`] and the pause gates treat it as expired. Absent ⇒ `0`
+    /// (unlimited), identical to pre-existing behavior. Set via
+    /// [`LiquifactEscrow::set_pause_max_duration`].
+    PauseMaxDurationSecs,
+    /// Ledger timestamp recorded on the most recent `set_paused(true)` call; paired with
+    /// [`DataKey::PauseMaxDurationSecs`] to compute auto-expiry. Absent ⇒ pause was never
+    /// activated.
+    PausedAt,
+    /// Optional cap on the number of [`LiquifactEscrow::set_paused`] calls allowed within
+    /// [`DataKey::PauseToggleWindowSecs`]. Absent ⇒ `0` (unlimited), identical to pre-existing
+    /// behavior. Set via [`LiquifactEscrow::set_pause_rate_limit`].
+    PauseToggleLimit,
+    /// Rolling rate-limit window length (seconds), paired with [`DataKey::PauseToggleLimit`].
+    /// Absent ⇒ `0`.
+    PauseToggleWindowSecs,
+    /// Ledger timestamp when the current pause-toggle rate-limit window started.
+    /// Absent ⇒ no window open yet (next `set_paused` call starts one).
+    PauseToggleWindowStart,
+    /// Number of [`LiquifactEscrow::set_paused`] calls recorded within the current rate-limit
+    /// window. Absent ⇒ `0`.
+    PauseToggleCountInWindow,
 }
 
 // --- Data types ---
@@ -1287,6 +1360,32 @@ pub struct PausedChanged {
     pub active: u32,
 }
 
+/// Emitted by [`LiquifactEscrow::set_pause_max_duration`] whenever the configured auto-expiry
+/// duration for [`DataKey::Paused`] changes.
+#[contractevent]
+pub struct PauseMaxDurationUpdated {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub old_value: u64,
+    pub new_value: u64,
+}
+
+/// Emitted by [`LiquifactEscrow::set_pause_rate_limit`] whenever the pause-toggle rate limit
+/// or its window changes.
+#[contractevent]
+pub struct PauseRateLimitUpdated {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub old_limit: u32,
+    pub new_limit: u32,
+    pub old_window_secs: u64,
+    pub new_window_secs: u64,
+}
+
 #[contractevent]
 pub struct LegalHoldClearRequested {
     #[topic]
@@ -1640,11 +1739,43 @@ impl LiquifactEscrow {
     /// Read the operational pause flag ([`DataKey::Paused`]); defaults to `false` when unset.
     ///
     /// Orthogonal to [`LiquifactEscrow::legal_hold_active`] — neither flag affects the other.
+    ///
+    /// # Auto-expiry
+    /// When [`DataKey::PauseMaxDurationSecs`] is configured (nonzero) via
+    /// [`LiquifactEscrow::set_pause_max_duration`], a pause that has been active for at least
+    /// that many seconds (measured from [`DataKey::PausedAt`]) is treated as inactive here —
+    /// even though the stored `Paused` flag itself is left `true` until an admin explicitly
+    /// calls [`LiquifactEscrow::set_paused`]. This is a pure read computation (no storage
+    /// mutation), so it cannot violate the read-only-precondition invariant documented on
+    /// [ADR-002](docs/adr/ADR-002-auth-boundaries.md). Default (`0` / unset) reproduces the
+    /// legacy behavior exactly: a pause blocks gates indefinitely until explicitly cleared.
     fn paused_active(env: &Env) -> bool {
-        env.storage()
+        let stored: bool = env
+            .storage()
             .instance()
             .get(&DataKey::Paused)
-            .unwrap_or(false)
+            .unwrap_or(false);
+        if !stored {
+            return false;
+        }
+        let max_duration: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseMaxDurationSecs)
+            .unwrap_or(DEFAULT_PAUSE_MAX_DURATION_SECS);
+        if max_duration == 0 {
+            return true;
+        }
+        let paused_at: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PausedAt)
+            .unwrap_or(0);
+        let now = env.ledger().timestamp();
+        match paused_at.checked_add(max_duration) {
+            Some(expires_at) => now < expires_at,
+            None => true,
+        }
     }
 
     /// Read the immutable funding token address, failing with [`EscrowError::FundingTokenNotSet`]
@@ -3093,10 +3224,73 @@ impl LiquifactEscrow {
     /// [`LiquifactEscrow::claim_investor_payout`]. Legal-hold state is neither read nor written.
     ///
     /// Emits [`PausedChanged`].
+    ///
+    /// # Rate limiting
+    /// When [`LiquifactEscrow::set_pause_rate_limit`] has configured a nonzero toggle limit,
+    /// each call to `set_paused` (in either direction) consumes one slot in the current rolling
+    /// window; once the limit is reached within the window, further calls fail with
+    /// [`EscrowError::PauseToggleRateLimitExceeded`] until the window rolls over. Default
+    /// (unconfigured) preserves legacy behavior: no rate limit.
+    ///
+    /// # Errors
+    /// - [`EscrowError::PauseToggleRateLimitExceeded`] if the configured toggle-rate limit was
+    ///   already reached within the current window.
     pub fn set_paused(env: Env, active: bool) {
         let escrow = Self::load_escrow_require_admin(&env);
 
+        let toggle_limit: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseToggleLimit)
+            .unwrap_or(DEFAULT_PAUSE_TOGGLE_LIMIT);
+        let now = env.ledger().timestamp();
+        let (window_start, window_count): (u64, u32) = if toggle_limit > 0 {
+            let window_secs: u64 = env
+                .storage()
+                .instance()
+                .get(&DataKey::PauseToggleWindowSecs)
+                .unwrap_or(0);
+            let stored_start: Option<u64> = env
+                .storage()
+                .instance()
+                .get(&DataKey::PauseToggleWindowStart);
+            let window_elapsed = match stored_start {
+                None => true,
+                Some(start) => now >= start.saturating_add(window_secs),
+            };
+            if window_elapsed {
+                (now, 0u32)
+            } else {
+                let count: u32 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::PauseToggleCountInWindow)
+                    .unwrap_or(0);
+                (stored_start.unwrap(), count)
+            }
+        } else {
+            (now, 0u32)
+        };
+        if toggle_limit > 0 {
+            ensure(
+                &env,
+                window_count < toggle_limit,
+                EscrowError::PauseToggleRateLimitExceeded,
+            );
+        }
+
         env.storage().instance().set(&DataKey::Paused, &active);
+        if active {
+            env.storage().instance().set(&DataKey::PausedAt, &now);
+        }
+        if toggle_limit > 0 {
+            env.storage()
+                .instance()
+                .set(&DataKey::PauseToggleWindowStart, &window_start);
+            env.storage()
+                .instance()
+                .set(&DataKey::PauseToggleCountInWindow, &(window_count + 1));
+        }
 
         PausedChanged {
             name: symbol_short!("paused"),
@@ -3104,6 +3298,166 @@ impl LiquifactEscrow {
             active: if active { 1 } else { 0 },
         }
         .publish(&env);
+    }
+
+    /// Set the maximum duration (seconds) [`DataKey::Paused`] may remain active before the
+    /// pause auto-expires for gate-checking purposes ([`LiquifactEscrow::is_paused`] and every
+    /// pause-gated entrypoint). Only the **current** [`InvoiceEscrow::admin`] may call.
+    ///
+    /// Pass `0` to disable the limit (unlimited pause duration — the legacy, pre-existing
+    /// behavior). A nonzero value must fall within
+    /// [`MIN_PAUSE_MAX_DURATION_SECS`, `MAX_PAUSE_MAX_DURATION_SECS`].
+    ///
+    /// # Errors
+    /// - [`EscrowError::PauseMaxDurationOutOfRange`] if `new_duration_secs` is nonzero and
+    ///   outside the configured bounds.
+    ///
+    /// # Events
+    /// Emits [`PauseMaxDurationUpdated`] with the old and new values.
+    pub fn set_pause_max_duration(env: Env, new_duration_secs: u64) -> u64 {
+        let escrow = Self::load_escrow_require_admin(&env);
+
+        if new_duration_secs != 0 {
+            ensure(
+                &env,
+                (MIN_PAUSE_MAX_DURATION_SECS..=MAX_PAUSE_MAX_DURATION_SECS)
+                    .contains(&new_duration_secs),
+                EscrowError::PauseMaxDurationOutOfRange,
+            );
+        }
+
+        let old_value: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseMaxDurationSecs)
+            .unwrap_or(DEFAULT_PAUSE_MAX_DURATION_SECS);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseMaxDurationSecs, &new_duration_secs);
+
+        PauseMaxDurationUpdated {
+            name: symbol_short!("pausemax"),
+            invoice_id: escrow.invoice_id,
+            old_value,
+            new_value: new_duration_secs,
+        }
+        .publish(&env);
+
+        new_duration_secs
+    }
+
+    /// Read the configured pause auto-expiry duration ([`DataKey::PauseMaxDurationSecs`]);
+    /// defaults to [`DEFAULT_PAUSE_MAX_DURATION_SECS`] (`0` = unlimited) when unset.
+    pub fn get_pause_max_duration(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::PauseMaxDurationSecs)
+            .unwrap_or(DEFAULT_PAUSE_MAX_DURATION_SECS)
+    }
+
+    /// Set the pause-toggle rate limit: at most `max_toggles` calls to
+    /// [`LiquifactEscrow::set_paused`] within any `window_secs`-second rolling window. Only the
+    /// **current** [`InvoiceEscrow::admin`] may call.
+    ///
+    /// Pass `(0, 0)` to disable rate limiting (the legacy, pre-existing behavior). A nonzero
+    /// `max_toggles` must fall within [`MIN_PAUSE_TOGGLE_LIMIT`, `MAX_PAUSE_TOGGLE_LIMIT`] and
+    /// `window_secs` must fall within
+    /// [`MIN_PAUSE_TOGGLE_WINDOW_SECS`, `MAX_PAUSE_TOGGLE_WINDOW_SECS`].
+    ///
+    /// Reconfiguring resets the current rate-limit window so behavior after the call is always
+    /// predictable (no stale counts carried over from the prior configuration).
+    ///
+    /// # Errors
+    /// - [`EscrowError::PauseRateLimitInvalidCombination`] if exactly one of `max_toggles` /
+    ///   `window_secs` is zero.
+    /// - [`EscrowError::PauseToggleLimitOutOfRange`] if `max_toggles` is nonzero and outside
+    ///   bounds.
+    /// - [`EscrowError::PauseToggleWindowOutOfRange`] if `window_secs` is outside bounds while
+    ///   `max_toggles` is nonzero.
+    ///
+    /// # Events
+    /// Emits [`PauseRateLimitUpdated`] with the old and new limit/window.
+    pub fn set_pause_rate_limit(env: Env, max_toggles: u32, window_secs: u64) -> (u32, u64) {
+        let escrow = Self::load_escrow_require_admin(&env);
+
+        if max_toggles == 0 || window_secs == 0 {
+            ensure(
+                &env,
+                max_toggles == 0 && window_secs == 0,
+                EscrowError::PauseRateLimitInvalidCombination,
+            );
+        } else {
+            ensure(
+                &env,
+                (MIN_PAUSE_TOGGLE_LIMIT..=MAX_PAUSE_TOGGLE_LIMIT).contains(&max_toggles),
+                EscrowError::PauseToggleLimitOutOfRange,
+            );
+            ensure(
+                &env,
+                (MIN_PAUSE_TOGGLE_WINDOW_SECS..=MAX_PAUSE_TOGGLE_WINDOW_SECS)
+                    .contains(&window_secs),
+                EscrowError::PauseToggleWindowOutOfRange,
+            );
+        }
+
+        let old_limit: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseToggleLimit)
+            .unwrap_or(DEFAULT_PAUSE_TOGGLE_LIMIT);
+        let old_window: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseToggleWindowSecs)
+            .unwrap_or(0);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseToggleLimit, &max_toggles);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseToggleWindowSecs, &window_secs);
+        env.storage()
+            .instance()
+            .remove(&DataKey::PauseToggleWindowStart);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseToggleCountInWindow, &0u32);
+
+        PauseRateLimitUpdated {
+            name: symbol_short!("pause_rl"),
+            invoice_id: escrow.invoice_id,
+            old_limit,
+            new_limit: max_toggles,
+            old_window_secs: old_window,
+            new_window_secs: window_secs,
+        }
+        .publish(&env);
+
+        (max_toggles, window_secs)
+    }
+
+    /// Read the configured pause-toggle rate limit as `(max_toggles, window_secs)`; `(0, 0)`
+    /// means unlimited (the default).
+    pub fn get_pause_rate_limit(env: Env) -> (u32, u64) {
+        let limit: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseToggleLimit)
+            .unwrap_or(DEFAULT_PAUSE_TOGGLE_LIMIT);
+        let window: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseToggleWindowSecs)
+            .unwrap_or(0);
+        (limit, window)
+    }
+
+    /// Read the ledger timestamp of the most recent `set_paused(true)` call
+    /// ([`DataKey::PausedAt`]); `None` if the pause has never been activated.
+    pub fn get_paused_at(env: Env) -> Option<u64> {
+        env.storage().instance().get(&DataKey::PausedAt)
     }
 
     /// Set or clear compliance hold. Only the **current** [`InvoiceEscrow::admin`] may call.

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -3287,9 +3287,14 @@ impl LiquifactEscrow {
             env.storage()
                 .instance()
                 .set(&DataKey::PauseToggleWindowStart, &window_start);
-            env.storage()
-                .instance()
-                .set(&DataKey::PauseToggleCountInWindow, &(window_count + 1));
+            // Defensive hardening: `window_count < toggle_limit` is asserted above, and
+            // `toggle_limit <= u32::MAX`, so `window_count + 1` cannot overflow today. Use
+            // `saturating_add` anyway so this line stays safe by construction rather than by
+            // relying on the guard above never being reordered (see #823 pause-arithmetic audit).
+            env.storage().instance().set(
+                &DataKey::PauseToggleCountInWindow,
+                &window_count.saturating_add(1),
+            );
         }
 
         PausedChanged {

--- a/escrow/src/tests/pause.rs
+++ b/escrow/src/tests/pause.rs
@@ -1,5 +1,9 @@
 use super::*;
-use crate::{EscrowError, PausedChanged};
+use crate::{
+    EscrowError, PauseMaxDurationUpdated, PauseRateLimitUpdated, PausedChanged,
+    MAX_PAUSE_MAX_DURATION_SECS, MAX_PAUSE_TOGGLE_LIMIT, MAX_PAUSE_TOGGLE_WINDOW_SECS,
+    MIN_PAUSE_MAX_DURATION_SECS, MIN_PAUSE_TOGGLE_LIMIT, MIN_PAUSE_TOGGLE_WINDOW_SECS,
+};
 use soroban_sdk::{testutils::Events, token::StellarAssetClient, Event};
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -612,4 +616,435 @@ fn pause_toggle_cycle() {
     // Funding should succeed after cycle
     let escrow = client.fund(&investor, &TARGET);
     assert_eq!(escrow.status, 1);
+}
+
+// ── 15. Configurable pause max duration (default) ────────────────────────────
+
+#[test]
+fn get_pause_max_duration_defaults_to_zero() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU031");
+    assert_eq!(client.get_pause_max_duration(), 0);
+}
+
+#[test]
+fn pause_default_duration_never_auto_expires() {
+    // Default (unconfigured) duration must reproduce the legacy behavior: a pause blocks
+    // gated entrypoints indefinitely until explicitly cleared, no matter how far ledger
+    // time advances.
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    init_open(&client, &env, &admin, &sme, "PAU032");
+
+    client.set_paused(&true);
+    env.ledger().set_timestamp(u64::MAX / 2);
+    assert!(client.is_paused());
+    assert_contract_error(
+        client.try_fund(&investor, &TARGET),
+        EscrowError::PausedBlocksFunding,
+    );
+}
+
+// ── 16. set_pause_max_duration: valid updates and bounds ──────────────────────
+
+#[test]
+fn set_pause_max_duration_valid_update() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU033");
+
+    let ret = client.set_pause_max_duration(&MIN_PAUSE_MAX_DURATION_SECS);
+    assert_eq!(ret, MIN_PAUSE_MAX_DURATION_SECS);
+    assert_eq!(client.get_pause_max_duration(), MIN_PAUSE_MAX_DURATION_SECS);
+}
+
+#[test]
+fn set_pause_max_duration_accepts_lower_and_upper_bounds() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU034");
+
+    client.set_pause_max_duration(&MIN_PAUSE_MAX_DURATION_SECS);
+    assert_eq!(client.get_pause_max_duration(), MIN_PAUSE_MAX_DURATION_SECS);
+
+    client.set_pause_max_duration(&MAX_PAUSE_MAX_DURATION_SECS);
+    assert_eq!(client.get_pause_max_duration(), MAX_PAUSE_MAX_DURATION_SECS);
+}
+
+#[test]
+fn set_pause_max_duration_zero_always_allowed_and_disables_limit() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU035");
+
+    client.set_pause_max_duration(&MIN_PAUSE_MAX_DURATION_SECS);
+    assert_eq!(client.get_pause_max_duration(), MIN_PAUSE_MAX_DURATION_SECS);
+
+    let ret = client.set_pause_max_duration(&0u64);
+    assert_eq!(ret, 0);
+    assert_eq!(client.get_pause_max_duration(), 0);
+}
+
+#[test]
+fn set_pause_max_duration_rejects_below_min() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU036");
+
+    assert_contract_error(
+        client.try_set_pause_max_duration(&(MIN_PAUSE_MAX_DURATION_SECS - 1)),
+        EscrowError::PauseMaxDurationOutOfRange,
+    );
+    // Config unchanged after a rejected call.
+    assert_eq!(client.get_pause_max_duration(), 0);
+}
+
+#[test]
+fn set_pause_max_duration_rejects_above_max() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU037");
+
+    assert_contract_error(
+        client.try_set_pause_max_duration(&(MAX_PAUSE_MAX_DURATION_SECS + 1)),
+        EscrowError::PauseMaxDurationOutOfRange,
+    );
+    assert_eq!(client.get_pause_max_duration(), 0);
+}
+
+#[test]
+#[should_panic]
+fn set_pause_max_duration_by_non_admin_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU038");
+    env.mock_auths(&[]);
+    client.set_pause_max_duration(&MIN_PAUSE_MAX_DURATION_SECS);
+}
+
+#[test]
+fn set_pause_max_duration_emits_event() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    init_open(&client, &env, &admin, &sme, "PAU039");
+
+    client.set_pause_max_duration(&MIN_PAUSE_MAX_DURATION_SECS);
+    let events = env.events().all();
+    let last = events.events().last().unwrap().clone();
+    assert_eq!(
+        last,
+        PauseMaxDurationUpdated {
+            name: symbol_short!("pausemax"),
+            invoice_id: client.get_escrow().invoice_id,
+            old_value: 0,
+            new_value: MIN_PAUSE_MAX_DURATION_SECS,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+// ── 17. Pause auto-expiry once a max duration is configured ───────────────────
+
+#[test]
+fn pause_auto_expires_after_configured_duration() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    init_open(&client, &env, &admin, &sme, "PAU040");
+
+    client.set_pause_max_duration(&MIN_PAUSE_MAX_DURATION_SECS);
+    let paused_at = env.ledger().timestamp();
+    client.set_paused(&true);
+    assert!(client.is_paused());
+
+    // Advance ledger time to exactly the expiry boundary (paused_at + max_duration).
+    env.ledger()
+        .set_timestamp(paused_at + MIN_PAUSE_MAX_DURATION_SECS);
+
+    assert!(!client.is_paused());
+    let escrow = client.fund(&investor, &TARGET);
+    assert_eq!(escrow.status, 1);
+}
+
+#[test]
+fn pause_not_yet_expired_still_blocks() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    init_open(&client, &env, &admin, &sme, "PAU041");
+
+    client.set_pause_max_duration(&MIN_PAUSE_MAX_DURATION_SECS);
+    let paused_at = env.ledger().timestamp();
+    client.set_paused(&true);
+
+    // One second before expiry: still blocked.
+    env.ledger()
+        .set_timestamp(paused_at + MIN_PAUSE_MAX_DURATION_SECS - 1);
+
+    assert!(client.is_paused());
+    assert_contract_error(
+        client.try_fund(&investor, &TARGET),
+        EscrowError::PausedBlocksFunding,
+    );
+}
+
+// ── 18. get_pause_rate_limit (default) ─────────────────────────────────────────
+
+#[test]
+fn get_pause_rate_limit_defaults_to_disabled() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU042");
+    assert_eq!(client.get_pause_rate_limit(), (0u32, 0u64));
+}
+
+// ── 19. set_pause_rate_limit: valid updates and bounds ─────────────────────────
+
+#[test]
+fn set_pause_rate_limit_valid_update() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU043");
+
+    let ret = client.set_pause_rate_limit(&5u32, &(MIN_PAUSE_TOGGLE_WINDOW_SECS * 10));
+    assert_eq!(ret, (5u32, MIN_PAUSE_TOGGLE_WINDOW_SECS * 10));
+    assert_eq!(
+        client.get_pause_rate_limit(),
+        (5u32, MIN_PAUSE_TOGGLE_WINDOW_SECS * 10)
+    );
+}
+
+#[test]
+fn set_pause_rate_limit_accepts_lower_and_upper_bounds() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU044");
+
+    client.set_pause_rate_limit(&MIN_PAUSE_TOGGLE_LIMIT, &MIN_PAUSE_TOGGLE_WINDOW_SECS);
+    assert_eq!(
+        client.get_pause_rate_limit(),
+        (MIN_PAUSE_TOGGLE_LIMIT, MIN_PAUSE_TOGGLE_WINDOW_SECS)
+    );
+
+    client.set_pause_rate_limit(&MAX_PAUSE_TOGGLE_LIMIT, &MAX_PAUSE_TOGGLE_WINDOW_SECS);
+    assert_eq!(
+        client.get_pause_rate_limit(),
+        (MAX_PAUSE_TOGGLE_LIMIT, MAX_PAUSE_TOGGLE_WINDOW_SECS)
+    );
+}
+
+#[test]
+fn set_pause_rate_limit_zero_zero_disables() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU045");
+
+    client.set_pause_rate_limit(&MIN_PAUSE_TOGGLE_LIMIT, &MIN_PAUSE_TOGGLE_WINDOW_SECS);
+    let ret = client.set_pause_rate_limit(&0u32, &0u64);
+    assert_eq!(ret, (0u32, 0u64));
+    assert_eq!(client.get_pause_rate_limit(), (0u32, 0u64));
+}
+
+#[test]
+fn set_pause_rate_limit_rejects_limit_out_of_range() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU046");
+
+    assert_contract_error(
+        client
+            .try_set_pause_rate_limit(&(MAX_PAUSE_TOGGLE_LIMIT + 1), &MIN_PAUSE_TOGGLE_WINDOW_SECS),
+        EscrowError::PauseToggleLimitOutOfRange,
+    );
+    assert_eq!(client.get_pause_rate_limit(), (0u32, 0u64));
+}
+
+#[test]
+fn set_pause_rate_limit_rejects_window_out_of_range() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU047");
+
+    assert_contract_error(
+        client
+            .try_set_pause_rate_limit(&MIN_PAUSE_TOGGLE_LIMIT, &(MAX_PAUSE_TOGGLE_WINDOW_SECS + 1)),
+        EscrowError::PauseToggleWindowOutOfRange,
+    );
+    assert_contract_error(
+        client
+            .try_set_pause_rate_limit(&MIN_PAUSE_TOGGLE_LIMIT, &(MIN_PAUSE_TOGGLE_WINDOW_SECS - 1)),
+        EscrowError::PauseToggleWindowOutOfRange,
+    );
+    assert_eq!(client.get_pause_rate_limit(), (0u32, 0u64));
+}
+
+#[test]
+fn set_pause_rate_limit_rejects_nonzero_toggles_with_zero_window() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU048");
+
+    assert_contract_error(
+        client.try_set_pause_rate_limit(&MIN_PAUSE_TOGGLE_LIMIT, &0u64),
+        EscrowError::PauseRateLimitInvalidCombination,
+    );
+}
+
+#[test]
+fn set_pause_rate_limit_rejects_zero_toggles_with_nonzero_window() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU049");
+
+    assert_contract_error(
+        client.try_set_pause_rate_limit(&0u32, &MIN_PAUSE_TOGGLE_WINDOW_SECS),
+        EscrowError::PauseRateLimitInvalidCombination,
+    );
+}
+
+#[test]
+#[should_panic]
+fn set_pause_rate_limit_by_non_admin_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU050");
+    env.mock_auths(&[]);
+    client.set_pause_rate_limit(&MIN_PAUSE_TOGGLE_LIMIT, &MIN_PAUSE_TOGGLE_WINDOW_SECS);
+}
+
+#[test]
+fn set_pause_rate_limit_emits_event() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    init_open(&client, &env, &admin, &sme, "PAU051");
+
+    client.set_pause_rate_limit(&MIN_PAUSE_TOGGLE_LIMIT, &MIN_PAUSE_TOGGLE_WINDOW_SECS);
+    let events = env.events().all();
+    let last = events.events().last().unwrap().clone();
+    assert_eq!(
+        last,
+        PauseRateLimitUpdated {
+            name: symbol_short!("pause_rl"),
+            invoice_id: client.get_escrow().invoice_id,
+            old_limit: 0,
+            new_limit: MIN_PAUSE_TOGGLE_LIMIT,
+            old_window_secs: 0,
+            new_window_secs: MIN_PAUSE_TOGGLE_WINDOW_SECS,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+// ── 20. Pause-toggle rate limit enforcement ────────────────────────────────────
+
+#[test]
+fn pause_toggle_rate_limit_enforced() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU052");
+
+    client.set_pause_rate_limit(&2u32, &3_600u64);
+
+    // Two toggles allowed within the window.
+    client.set_paused(&true);
+    client.set_paused(&false);
+
+    // Third toggle within the same window is rejected.
+    assert_contract_error(
+        client.try_set_paused(&true),
+        EscrowError::PauseToggleRateLimitExceeded,
+    );
+}
+
+#[test]
+#[should_panic]
+fn pause_toggle_rate_limit_exceeded_panics() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU053");
+
+    client.set_pause_rate_limit(&1u32, &3_600u64);
+    client.set_paused(&true);
+    client.set_paused(&false);
+}
+
+#[test]
+fn pause_toggle_rate_limit_resets_after_window_elapses() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU054");
+
+    client.set_pause_rate_limit(&1u32, &3_600u64);
+    let window_start = env.ledger().timestamp();
+    client.set_paused(&true);
+
+    // Still within the window: blocked.
+    assert_contract_error(
+        client.try_set_paused(&false),
+        EscrowError::PauseToggleRateLimitExceeded,
+    );
+
+    // Advance past the window boundary: allowed again.
+    env.ledger().set_timestamp(window_start + 3_600);
+    client.set_paused(&false);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn pause_toggle_rate_limit_resets_on_reconfiguration() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU055");
+
+    client.set_pause_rate_limit(&1u32, &3_600u64);
+    client.set_paused(&true);
+    assert_contract_error(
+        client.try_set_paused(&false),
+        EscrowError::PauseToggleRateLimitExceeded,
+    );
+
+    // Reconfiguring the limit (even to the same values) resets the window immediately.
+    client.set_pause_rate_limit(&1u32, &3_600u64);
+    client.set_paused(&false);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn get_paused_at_none_before_first_pause_then_tracks_activation_timestamps() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU057");
+
+    assert_eq!(client.get_paused_at(), None);
+
+    let first_pause_at = env.ledger().timestamp();
+    client.set_paused(&true);
+    assert_eq!(client.get_paused_at(), Some(first_pause_at));
+
+    // Unpausing does not clear the recorded activation timestamp.
+    client.set_paused(&false);
+    assert_eq!(client.get_paused_at(), Some(first_pause_at));
+
+    // Re-activating records the new timestamp.
+    env.ledger().set_timestamp(first_pause_at + 500);
+    client.set_paused(&true);
+    assert_eq!(client.get_paused_at(), Some(first_pause_at + 500));
+}
+
+#[test]
+fn pause_toggle_rate_limit_disabled_by_default_matches_legacy_behavior() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU056");
+
+    // Many toggles in immediate succession, no rate limit configured: all succeed.
+    for _ in 0..10 {
+        client.set_paused(&true);
+        client.set_paused(&false);
+    }
+    assert!(!client.is_paused());
 }

--- a/escrow/src/tests/pause.rs
+++ b/escrow/src/tests/pause.rs
@@ -1048,3 +1048,174 @@ fn pause_toggle_rate_limit_disabled_by_default_matches_legacy_behavior() {
     }
     assert!(!client.is_paused());
 }
+
+// ── 21. Pause arithmetic overflow/saturation safety (issue #823) ──────────────
+//
+// The pause subsystem has exactly three raw arithmetic operations (no subtraction is
+// performed anywhere in this module — only two additions and a comparison):
+//   1. `paused_at.checked_add(max_duration)`         in `paused_active`      — already checked.
+//   2. `start.saturating_add(window_secs)`            in `set_paused`         — already saturating.
+//   3. `window_count + 1` (now `window_count.saturating_add(1)`) in `set_paused`.
+//
+// (3) was hardened defensively: the preceding `ensure(window_count < toggle_limit, ...)`
+// already made overflow mathematically unreachable (`window_count < toggle_limit <= u32::MAX`
+// implies `window_count + 1 <= u32::MAX`), but the guard now holds by construction instead of
+// by relying on that check never being reordered. The tests below exercise all three at their
+// extreme `u64`/`u32` boundaries and assert typed-error rejection (never a wrapped/panicking
+// wraparound) wherever rejection is the correct outcome.
+
+#[test]
+fn pause_expiry_checked_add_exact_boundary_no_overflow() {
+    // Boundary case for `paused_at.checked_add(max_duration)`: choose `paused_at` so the sum
+    // lands exactly on `u64::MAX` (no overflow). Confirms `checked_add` resolves the correct
+    // expiry timestamp right up to the edge of the representable range instead of failing safe
+    // prematurely.
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    init_open(&client, &env, &admin, &sme, "PAU058");
+
+    client.set_pause_max_duration(&MAX_PAUSE_MAX_DURATION_SECS);
+    let paused_at = u64::MAX - MAX_PAUSE_MAX_DURATION_SECS;
+    env.ledger().set_timestamp(paused_at);
+    client.set_paused(&true);
+    assert!(client.is_paused());
+
+    // One second before the exact-boundary expiry: still blocked.
+    env.ledger().set_timestamp(u64::MAX - 1);
+    assert!(client.is_paused());
+    assert_contract_error(
+        client.try_fund(&investor, &TARGET),
+        EscrowError::PausedBlocksFunding,
+    );
+
+    // Exactly at the boundary (paused_at + max_duration == u64::MAX): expired.
+    env.ledger().set_timestamp(u64::MAX);
+    assert!(!client.is_paused());
+    let escrow = client.fund(&investor, &TARGET);
+    assert_eq!(escrow.status, 1);
+}
+
+#[test]
+fn pause_expiry_checked_add_overflow_fails_safe_stays_paused() {
+    // When `paused_at + max_duration` would overflow `u64`, `checked_add` returns `None` and
+    // `paused_active` fails safe by treating the pause as still active. It must never wrap
+    // around to a small timestamp and falsely report "expired".
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let investor = Address::generate(&env);
+    init_open(&client, &env, &admin, &sme, "PAU059");
+
+    client.set_pause_max_duration(&MAX_PAUSE_MAX_DURATION_SECS);
+    // paused_at + MAX_PAUSE_MAX_DURATION_SECS overflows u64::MAX by construction.
+    let paused_at = u64::MAX - 100;
+    env.ledger().set_timestamp(paused_at);
+    client.set_paused(&true);
+    assert!(client.is_paused());
+
+    // Advance to the maximum representable ledger timestamp: still paused, no wraparound.
+    env.ledger().set_timestamp(u64::MAX);
+    assert!(client.is_paused());
+    assert_contract_error(
+        client.try_fund(&investor, &TARGET),
+        EscrowError::PausedBlocksFunding,
+    );
+}
+
+#[test]
+fn pause_rate_limit_window_saturating_add_no_wraparound_at_extreme_start() {
+    // Boundary case for `start.saturating_add(window_secs)`: when `start` is close to
+    // `u64::MAX`, the sum must saturate instead of wrapping. A wraparound bug would make the
+    // window appear to have already elapsed (a small wrapped timestamp <= now), incorrectly
+    // resetting the toggle count and bypassing the rate limit.
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU060");
+
+    client.set_pause_rate_limit(&1u32, &MAX_PAUSE_TOGGLE_WINDOW_SECS);
+    let start = u64::MAX - 100;
+    env.ledger().set_timestamp(start);
+    client.set_paused(&true);
+
+    // Still within the (saturated) window at the same timestamp: rejected, not bypassed.
+    assert_contract_error(
+        client.try_set_paused(&false),
+        EscrowError::PauseToggleRateLimitExceeded,
+    );
+
+    // One tick before the saturated ceiling: still rejected (no early/wrapped elapse).
+    env.ledger().set_timestamp(u64::MAX - 1);
+    assert_contract_error(
+        client.try_set_paused(&false),
+        EscrowError::PauseToggleRateLimitExceeded,
+    );
+
+    // At the saturated ceiling (u64::MAX): the window is correctly treated as elapsed.
+    env.ledger().set_timestamp(u64::MAX);
+    client.set_paused(&false);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn pause_toggle_rate_limit_reaches_configured_maximum_without_overflow() {
+    // Exercises `window_count` incrementing up to the maximum configurable toggle limit
+    // (MAX_PAUSE_TOGGLE_LIMIT = 1000) within a single window entirely through the public API,
+    // proving the counter never panics as it approaches its bound and that the guard correctly
+    // rejects the call that would exceed it.
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_open(&client, &env, &admin, &sme, "PAU061");
+
+    client.set_pause_rate_limit(&MAX_PAUSE_TOGGLE_LIMIT, &MAX_PAUSE_TOGGLE_WINDOW_SECS);
+
+    for i in 0..MAX_PAUSE_TOGGLE_LIMIT {
+        client.set_paused(&(i % 2 == 0));
+    }
+
+    // window_count has reached MAX_PAUSE_TOGGLE_LIMIT without overflowing; the next toggle
+    // within the same window must be rejected with the typed error, not a panic.
+    assert_contract_error(
+        client.try_set_paused(&true),
+        EscrowError::PauseToggleRateLimitExceeded,
+    );
+}
+
+#[test]
+fn pause_toggle_count_increment_never_overflows_at_forced_extreme_storage_values() {
+    // Adversarial boundary case for the `window_count` increment itself: force
+    // `PauseToggleCountInWindow` and `PauseToggleLimit` to values at the very edge of `u32`
+    // directly in storage (bypassing the setter's MAX_PAUSE_TOGGLE_LIMIT bound) to prove the
+    // increment cannot panic even in a scenario more extreme than the public API can ever
+    // produce.
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    init_open(&client, &env, &admin, &sme, "PAU062");
+
+    let now = env.ledger().timestamp();
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseToggleLimit, &u32::MAX);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseToggleWindowSecs, &3_600u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseToggleWindowStart, &now);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseToggleCountInWindow, &(u32::MAX - 1));
+    });
+
+    // window_count (u32::MAX - 1) < toggle_limit (u32::MAX): allowed. The increment computes
+    // `u32::MAX` via `saturating_add`, never an overflowing `+`.
+    client.set_paused(&true);
+
+    // window_count is now u32::MAX; the next call within the window is correctly rejected by
+    // the `<` guard rather than ever re-attempting an overflowing increment.
+    assert_contract_error(
+        client.try_set_paused(&false),
+        EscrowError::PauseToggleRateLimitExceeded,
+    );
+}


### PR DESCRIPTION
> **Depends on #943** (closes #824 — "Make the pause limit an admin-configurable parameter"). This branch (`feature/pause-12-config-limit`) still contains that PR's commit (`8cff2f0`), so the diff below currently shows both changes. **Only the second commit, `test(pause): cover overflow and saturation (#823)`, is new for review here.** Please merge #943 first — once it lands, this PR's diff against `main` will shrink to just that one commit automatically.

Summary
Audits the three raw arithmetic operations in the pause subsystem (paused_at + max_duration, window_start + window_secs, window_count + 1) for overflow/wraparound safety, per #823.

paused_at.checked_add(max_duration) (paused_active) and start.saturating_add(window_secs) (set_paused) were already using checked/saturating math — verified correct with new boundary tests.
window_count + 1 (set_paused) was a plain, unchecked u32 addition. It's unreachable in practice today — ensure(window_count < toggle_limit, ...) runs immediately before it, and toggle_limit is itself bounded to MAX_PAUSE_TOGGLE_LIMIT, so the increment can never actually overflow — but that safety depended entirely on the guard ordering never changing. Hardened it to window_count.saturating_add(1) so the line is safe by construction instead of by invariant.
No subtraction exists anywhere in the pause arithmetic surface, so that edge case doesn't apply to this module (documented inline in the test file).
Changes
escrow/src/lib.rs — saturating_add(1) defensive fix in set_paused, with a comment explaining why.
escrow/src/tests/pause.rs — 5 new boundary/overflow tests:
pause_expiry_checked_add_exact_boundary_no_overflow — paused_at + max_duration landing exactly on u64::MAX.
pause_expiry_checked_add_overflow_fails_safe_stays_paused — forced u64 overflow; asserts the pause stays active (fails safe) rather than wrapping to "expired".
pause_rate_limit_window_saturating_add_no_wraparound_at_extreme_start — rate-limit window start near u64::MAX; proves the window can't be bypassed via wraparound.
pause_toggle_rate_limit_reaches_configured_maximum_without_overflow — drives the real public API to the actual MAX_PAUSE_TOGGLE_LIMIT (1000) toggles in one window.
pause_toggle_count_increment_never_overflows_at_forced_extreme_storage_values — adversarial case forcing PauseToggleLimit/PauseToggleCountInWindow to u32::MAX-adjacent values directly via storage, beyond what the public API can ever produce.
All new tests assert typed-error rejection (EscrowError::PausedBlocksFunding, EscrowError::PauseToggleRateLimitExceeded) at rejection boundaries — never a panic from unchecked arithmetic.

Test plan

cargo fmt -p liquifact_escrow -- --check
→ clean

cargo clippy -p liquifact_escrow --all-targets -- -D warnings
→ Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 49s
→ 0 warnings

cargo build -p liquifact_escrow
→ Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.83s

cargo test -p liquifact_escrow
→ test result: ok. 880 passed; 0 failed; 54 ignored; 0 measured; 0 filtered out; finished in 131.29s
   (pause module alone: 62 passed; 0 failed — 57 pre-existing + 5 new)

cargo llvm-cov --features testutils -p liquifact_escrow
→ line coverage on paused_active / set_paused / set_pause_max_duration /
  set_pause_rate_limit: 100% (every line hit at least once)
→ crate-wide: lib.rs 92.62%, external_calls.rs 94.29% (pre-existing gap,
  unrelated to this change; the coverage CI step is continue-on-error)
Notes for reviewers
Behavior is unchanged on every reachable code path — this is a hardening + test-coverage PR, not a bug fix. No overflow was actually exploitable given the existing guard ordering, but the fix removes the dependency on that ordering.
coverage.lcov was generated locally for verification and is not included in this diff.

Closes #823
