### PR TITLE
[928] Emit an event on collateral state changes

### DIFF
--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -47,7 +47,7 @@ The current contract defines 38 event structs.
 | `AttestationDigestUnrevoked` | `att_unrev` | `unrevoke_attestation_digest` |
 | `BeneficiaryRotated` | `ben_rot` | `rotate_beneficiary` |
 | `BenChange` | `ben_chg` | `rotate_beneficiary` |
-| `CollateralClearedEvt` | — | `clear_sme_collateral_commitment` |
+| `CollateralClearedEvt` | `coll_clr` | `clear_sme_collateral_commitment` |
 | `CollateralRecordedEvt` | `coll_rec` | `record_sme_collateral_commitment` |
 | `ContractUpgraded` | `upgrade` | `upgrade` |
 | `DeprecatedTransferAdminUsed` | `depr_xfer` | `transfer_admin` |
@@ -343,6 +343,30 @@ Data:
 
 Note: this event records SME-reported collateral metadata only. It is not proof
 of custody, token movement, lien, or enforceable on-chain collateral.
+
+### `CollateralClearedEvt`
+
+Emitted after successful `clear_sme_collateral_commitment`. Exactly one event is
+published per successful clear (no duplicate `coll_clr` emission).
+
+Topics:
+
+| Index | Field | Type | Value |
+|---:|---|---|---|
+| 0 | fixed event topic | `Symbol` | `collateral_cleared_evt` |
+| 1 | `name` | `Symbol` | `coll_clr` |
+| 2 | `invoice_id` | `Symbol` | Escrow invoice id |
+
+Data:
+
+| Field | Type |
+|---|---|
+| `asset` | `Symbol` |
+| `amount` | `i128` |
+| `recorded_at` | `u64` |
+
+Note: this event retires SME-reported collateral metadata only. It is not proof
+of custody release, token movement, or enforceable on-chain collateral.
 
 ### `SmeWithdrew`
 

--- a/docs/escrow-sme-collateral.md
+++ b/docs/escrow-sme-collateral.md
@@ -2,40 +2,49 @@
 
 ## Overview
 
-The LiquiFact escrow contract supports **metadata-only** collateral pledge recording.
-No tokens are moved or reserved by these operations; they exist solely for indexers
-and dashboards to surface off-chain pledge intent alongside an invoice's on-chain state.
+The LiquiFact escrow contract supports **metadata-only** collateral commitment recording.
+No tokens are moved, reserved, or locked by these operations. The stored
+`SmeCollateralCommitment` and emitted collateral events are **not proof of custody**,
+lien, encumbrance, or asset control — they exist solely for indexers and off-chain risk
+teams to surface reported collateral intent alongside an invoice's on-chain state. Risk
+teams must verify supporting evidence outside this contract.
 
 ---
 
 ## Entrypoints
 
-### `record_sme_collateral_commitment(env, amount) -> Result<(), EscrowError>`
+### `record_sme_collateral_commitment(env, asset: Symbol, amount: i128) -> SmeCollateralCommitment`
 
-Records an off-chain collateral pledge against the escrow's invoice.
+Records (or replaces) an off-chain collateral commitment against the escrow's invoice.
 
 - **Auth**: SME address (`sme_address` from the escrow record).
-- **Storage**: writes `DataKey::SmeCollateralPledge` (instance storage).
-- **Event**: emits `CollateralRecordedEvt { invoice_id, amount }` under topic
-  `(col_rec, sme_address)`.
-- **Idempotency**: calling again overwrites the previous amount.
+- **Storage**: writes `DataKey::SmeCollateralPledge` (instance storage) as an
+  `SmeCollateralCommitment { asset, amount, recorded_at }`.
+- **Event**: emits exactly one `CollateralRecordedEvt` with
+  `{ name: "coll_rec", invoice_id, amount, prior_amount }`.
+- **Idempotency**: calling again replaces the previous commitment; `prior_amount` on the
+  event carries the amount that was overwritten (`0` on the first call).
+- **Ordering guard**: a replacement's ledger timestamp must be `>=` the prior commitment's
+  `recorded_at`, or the call is rejected with `CollateralTimestampBackwards`.
 - **Token movement**: none.
 
-### `get_sme_collateral_commitment(env) -> Option<CollateralPledge>`
+### `get_sme_collateral_commitment(env) -> Option<SmeCollateralCommitment>`
 
-Returns the current pledge record, or `None` if none has been recorded (or it was cleared).
+Returns the current commitment, or `None` if none has been recorded (or it was cleared).
 
 - **Auth**: none required (read-only).
 
-### `clear_sme_collateral_commitment(env) -> Result<(), EscrowError>`
+### `clear_sme_collateral_commitment(env)`
 
-Retires a previously recorded pledge, removing it from storage.
+Retires a previously recorded commitment, removing it from storage.
 
 - **Auth**: SME address (`sme_address` from the escrow record).
 - **Storage**: removes `DataKey::SmeCollateralPledge` (instance storage).
-- **Event**: emits `CollateralClearedEvt { name, invoice_id, asset, amount, recorded_at }`
-  under topic `(coll_clr, invoice_id)`.
+- **Event**: emits exactly one `CollateralClearedEvt`
+  `{ name: "coll_clr", invoice_id, asset, amount, recorded_at }` under topics
+  `(coll_clr, invoice_id)`.
 - **Token movement**: none.
+- **Absent commitment**: returns `NoCollateralToClear` (no event).
 
 ## Test Coverage
 
@@ -54,12 +63,20 @@ The scenarios below are covered by the focused collateral suite in
 | `test_collateral_empty_asset_rejected` | Empty asset symbol is rejected with `CollateralAssetEmpty`. |
 | `test_collateral_non_sme_caller_rejected` | A caller that is not the SME address is rejected (auth failure). |
 | `test_collateral_record_does_not_change_token_balances` | No token balances change on the escrow contract, SME, or admin after recording. |
+| `test_clear_emits_exactly_one_coll_clr_event` | Clear emits exactly one `coll_clr` event with the cleared commitment payload. |
+| `test_collateral_state_change_topics_are_distinct` | `coll_rec` and `coll_clr` routing symbols do not collide. |
 
 Additional collateral scenarios (happy-path and validation) are also exercised in:
 - [`escrow/src/tests/admin.rs`](../escrow/src/tests/admin.rs) — collateral record in admin-flow baselines.
-- [`escrow/src/tests/integration.rs`](../escrow/src/tests/integration.rs) — `test_collateral_record_event_payload_is_metadata_only` and `test_collateral_replacement_event_contains_prior_amount` for full event-payload verification.
+- [`escrow/src/tests/integration.rs`](../escrow/src/tests/integration.rs) — `test_collateral_record_event_payload_is_metadata_only`, `test_collateral_replacement_event_contains_prior_amount`, and `test_collateral_clear_emits_one_dedicated_event_with_cleared_payload` for full event-payload verification.
 
 ## Off-chain Risk-Team Handling
+
+Risk teams and indexers must treat `SmeCollateralCommitment`, `CollateralRecordedEvt`,
+and `CollateralClearedEvt` as **reported metadata only**. They are not proof of custody,
+lien, encumbrance, or asset control, and do not alter funding, settlement, withdrawal,
+investor-claim, compliance-hold, or treasury-sweep behavior. Supporting evidence must be
+verified off-chain.
 
 ---
 
@@ -71,37 +88,32 @@ checks from masking informative errors:
 1. **Read-only existence check** — return `NoCollateralToClear` immediately if
    `DataKey::SmeCollateralPledge` is absent (no auth consumed).
 2. **`require_auth`** — assert the caller is the SME address.
-3. **Mutation** — remove the storage entry and emit `CollateralClearedEvt`.
+3. **Mutation** — remove the storage entry and emit exactly one `CollateralClearedEvt`.
 
 ---
 
 ## Data types
 
 ```rust
-pub struct CollateralPledge {
-    pub invoice_id: Symbol,
-    pub amount: i128,
-}
-
-pub struct CollateralRecordedEvt {
-    pub invoice_id: Symbol,
-    pub amount: i128,
-}
-
-pub struct CollateralClearedEvt {
-    pub name: Symbol,     // hardcoded coll_clr topic
-    pub invoice_id: Symbol,
-    pub asset: Symbol,    // carried from the pledge at the time of removal
-    pub amount: i128,   // carried from the pledge at the time of removal
-    pub recorded_at: u64, // original pledge ledger timestamp
-}
-
-pub struct CollateralCommitmentCleared {
-    pub name: Symbol,   // coll_clr
-    pub invoice_id: Symbol,
+pub struct SmeCollateralCommitment {
     pub asset: Symbol,
     pub amount: i128,
     pub recorded_at: u64,
+}
+
+pub struct CollateralRecordedEvt {
+    pub name: Symbol,       // "coll_rec"
+    pub invoice_id: Symbol,
+    pub amount: i128,
+    pub prior_amount: i128, // 0 on the first record
+}
+
+pub struct CollateralClearedEvt {
+    pub name: Symbol,       // hardcoded coll_clr topic
+    pub invoice_id: Symbol,
+    pub asset: Symbol,      // carried from the pledge at the time of removal
+    pub amount: i128,       // carried from the pledge at the time of removal
+    pub recorded_at: u64,   // original pledge ledger timestamp
 }
 ```
 
@@ -109,12 +121,12 @@ pub struct CollateralCommitmentCleared {
 
 ## Error codes
 
-| Code | Variant              | Trigger                                            |
-|------|----------------------|----------------------------------------------------|
-| 1    | `NotInitialized`     | Escrow not yet created via `init`                  |
-| 2    | `NotOpen`            | Reserved for future status guards                  |
-| 3    | `NotFunded`          | Reserved for future status guards                  |
-| 4    | `NoCollateralToClear`| `clear_sme_collateral_commitment` with no pledge   |
+| Code | Variant                        | Trigger                                                |
+|------|--------------------------------|---------------------------------------------------------|
+| 60   | `CollateralAmountNotPositive`  | `record_sme_collateral_commitment` with `amount <= 0`    |
+| 61   | `CollateralAssetEmpty`         | `record_sme_collateral_commitment` with empty asset symbol |
+| 62   | `CollateralTimestampBackwards` | Replacement timestamp precedes the stored `recorded_at`  |
+| 63   | `NoCollateralToClear`          | `clear_sme_collateral_commitment` with no commitment recorded |
 
 ---
 
@@ -124,21 +136,23 @@ pub struct CollateralCommitmentCleared {
   `clear_sme_collateral_commitment` transfers or locks tokens. This is
   **not proof of custody** — the contract does not verify off-chain asset control.
 - **SME-only writes**: all mutating operations require `sme_address.require_auth()`.
-- **No status dependency**: collateral metadata can be cleared regardless of escrow
-  status (open / funded / settled), allowing clean-up after settlement or cancellation.
+- **No status dependency**: collateral metadata can be recorded or cleared regardless of
+  escrow status (open / funded / settled), allowing clean-up after settlement or cancellation.
 - **No double-clear risk**: the existence check on entry ensures a second clear call
   returns `NoCollateralToClear` rather than silently succeeding.
+- **No duplicate emissions**: each successful record or clear publishes exactly one
+  dedicated event (`coll_rec` or `coll_clr`).
 
 ---
 
 ## Example flow
 
 ```
-SME calls record_sme_collateral_commitment(5_000_0000000)
-  → DataKey::SmeCollateralPledge stored
-  → CollateralRecordedEvt emitted
+SME calls record_sme_collateral_commitment("USDC", 5_000_0000000)
+  → DataKey::SmeCollateralPledge stored as SmeCollateralCommitment
+  → CollateralRecordedEvt { amount: 5_000_0000000, prior_amount: 0 } emitted
 
-[invoice settled off-chain; pledge released]
+[invoice settled off-chain; commitment released]
 
 SME calls clear_sme_collateral_commitment()
   → DataKey::SmeCollateralPledge removed

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1339,7 +1339,8 @@ pub struct CollateralRecordedEvt {
 /// This event is the removal-side counterpart to [`CollateralRecordedEvt`]. It
 /// copies the stored commitment fields before deletion so off-chain indexers can
 /// reconstruct which SME-reported asset record was retired without polling
-/// storage after the mutation.
+/// storage after the mutation. Exactly one `coll_clr` event is published per
+/// successful clear — do not emit a second event with the same topic.
 ///
 /// # Fields
 /// - `name`: Hardcoded `coll_clr` symbol.
@@ -1358,23 +1359,6 @@ pub struct CollateralClearedEvt {
     /// SME-reported amount that was cleared from storage.
     pub amount: i128,
     /// Ledger timestamp from the original recorded commitment.
-    pub recorded_at: u64,
-}
-
-/// Emitted after [`LiquifactEscrow::clear_sme_collateral_commitment`] removes
-/// the SME-reported collateral metadata.
-///
-/// This supplements [`CollateralClearedEvt`] with a short event name and the
-/// full cleared commitment identity so indexers can reconstruct the
-/// record-to-clear lifecycle without a storage read after removal.
-#[contractevent]
-pub struct CollateralCommitmentCleared {
-    #[topic]
-    pub name: Symbol,
-    #[topic]
-    pub invoice_id: Symbol,
-    pub asset: Symbol,
-    pub amount: i128,
     pub recorded_at: u64,
 }
 
@@ -2765,15 +2749,6 @@ impl LiquifactEscrow {
             .remove(&DataKey::SmeCollateralPledge);
 
         CollateralClearedEvt {
-            name: symbol_short!("coll_clr"),
-            invoice_id: escrow.invoice_id.clone(),
-            asset: commitment.asset.clone(),
-            amount: commitment.amount,
-            recorded_at: commitment.recorded_at,
-        }
-        .publish(&env);
-
-        CollateralCommitmentCleared {
             name: symbol_short!("coll_clr"),
             invoice_id: escrow.invoice_id.clone(),
             asset: commitment.asset.clone(),

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -12,7 +12,7 @@ use crate::{
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events as _, Ledger},
-    Address, BytesN, Env, Error, InvokeError, Vec as SorobanVec,
+    Address, BytesN, Env, Error, Event, InvokeError, Vec as SorobanVec,
 };
 
 const AMOUNT: i128 = 100_000_000_000;
@@ -1092,7 +1092,54 @@ fn test_overwrite_then_clear() {
     assert!(client.get_sme_collateral_commitment().is_none());
 }
 
-// ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+#[test]
+fn test_clear_emits_exactly_one_coll_clr_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+
+    let asset = symbol_short!("USDC");
+    client.record_sme_collateral_commitment(&asset, &PLEDGE);
+
+    // Drain the record event so we only measure the clear transition.
+    let _ = env.events().all();
+    client.clear_sme_collateral_commitment();
+
+    let contract_events = env.events().all().filter_by_contract(&contract_id);
+    let events = contract_events.events();
+    assert_eq!(
+        events.len(),
+        1,
+        "clear_sme_collateral_commitment must emit exactly one event"
+    );
+
+    let invoice_id = client.get_escrow().invoice_id;
+    assert_eq!(
+        events.last().unwrap().clone(),
+        CollateralClearedEvt {
+            name: symbol_short!("coll_clr"),
+            invoice_id,
+            asset,
+            amount: PLEDGE,
+            recorded_at: env.ledger().timestamp(),
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+#[test]
+fn test_collateral_state_change_topics_are_distinct() {
+    // Indexers key on the short routing symbols; record and clear must not collide.
+    assert_ne!(
+        symbol_short!("coll_rec"),
+        symbol_short!("coll_clr"),
+        "collateral record and clear topics must be distinct"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // Anchoring tests: read-view default/absent return values (docs/escrow-read-api.md)
 //
 // Each test asserts the default or absent-key return value documented in the

--- a/escrow/src/tests/integration.rs
+++ b/escrow/src/tests/integration.rs
@@ -1,6 +1,8 @@
 use super::super::external_calls::transfer_funding_token_with_balance_checks;
 use super::*;
-use crate::{CollateralRecordedEvt, DataKey, InvoiceEscrow, LegalHoldChanged};
+use crate::{
+    CollateralClearedEvt, CollateralRecordedEvt, DataKey, InvoiceEscrow, LegalHoldChanged,
+};
 use soroban_sdk::{
     contract, contractimpl, symbol_short, vec, IntoVal, Map, MuxedAddress, Symbol, TryFromVal, Val,
 };
@@ -666,6 +668,58 @@ fn test_collateral_replacement_event_contains_prior_amount() {
         expected_second.to_xdr(&env, &contract_id),
         "Second event should have prior_amount = 5000"
     );
+}
+
+#[test]
+fn test_collateral_clear_emits_one_dedicated_event_with_cleared_payload() {
+    use soroban_sdk::testutils::Events as _;
+    use soroban_sdk::Event;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = deploy_with_id(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let invoice_id = Symbol::new(&env, "COLEV003");
+
+    env.as_contract(&contract_id, || {
+        env.storage().instance().set(
+            &DataKey::Escrow,
+            &InvoiceEscrow {
+                invoice_id: invoice_id.clone(),
+                admin,
+                sme_address: sme,
+                amount: 10_000i128,
+                funding_target: 10_000i128,
+                funded_amount: 0i128,
+                yield_bps: 800i64,
+                maturity: 0u64,
+                status: 0u32,
+            },
+        );
+    });
+
+    let commitment = client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+    // Drain the record event before exercising the separate clear transition.
+    let _ = env.events().all();
+
+    client.clear_sme_collateral_commitment();
+    // Capture immediately: subsequent contract calls can replace the test event buffer.
+    let events = env.events().all().filter_by_contract(&contract_id);
+
+    assert_eq!(
+        events.events().len(),
+        1,
+        "clear must emit exactly one event"
+    );
+    let expected = CollateralClearedEvt {
+        name: symbol_short!("coll_clr"),
+        invoice_id,
+        asset: symbol_short!("USDC"),
+        amount: 5_000i128,
+        recorded_at: commitment.recorded_at,
+    };
+    assert_eq!(events.events()[0], expected.to_xdr(&env, &contract_id));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Ensure collateral state changes emit a documented event: `coll_rec` on record/replace and exactly one `coll_clr` on clear.
- Remove the duplicate `CollateralCommitmentCleared` emission that reused the same `coll_clr` topic, so indexers no longer see two equivalent clear events.
- Document topic/payload in `docs/escrow-sme-collateral.md` and `docs/EVENT_SCHEMA.md`, and cover one-shot emission + payload + topic distinctness in tests.

Closes #928

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy -p liquifact_escrow --all-targets -- -D warnings`
- [x] `cargo test -p liquifact_escrow` (851 passed, 0 failed, 54 ignored)
- [x] `test_clear_emits_exactly_one_coll_clr_event`
- [x] `test_collateral_clear_emits_one_dedicated_event_with_cleared_payload`
- [x] `test_collateral_state_change_topics_are_distinct`

### Security notes
- No fund-movement paths changed; collateral remains metadata-only.
- Auth and absent-commitment behavior for clear are unchanged.
- Duplicate `coll_clr` emission removed to keep a single authoritative clear signal for indexers.


Made with [Cursor](https://cursor.com)