### PR TITLE
refactor(funding): centralize storage keys (#912)

### DIFF
--- a/escrow/src/keys.rs
+++ b/escrow/src/keys.rs
@@ -1,0 +1,75 @@
+//! Centralized constructors for funding-related storage keys.
+//!
+//! Funding logic (`fund`/`fund_with_commitment`/`fund_batch`/`fund_impl`, the cap and
+//! funding-deadline admin setters, `update_funding_target`, `partial_settle`, `unfund`, and
+//! `bump_ttl`) previously constructed the [`DataKey`] variants below inline at each call site.
+//! Two call sites agreeing on a key's shape by convention (rather than by construction) is
+//! exactly the drift risk this module removes: every caller now obtains a given key through one
+//! function instead of re-typing `DataKey::Variant(...)`.
+//!
+//! This is a pure indirection layer. No key's on-chain shape or `DataKey` discriminant changes —
+//! that contract still belongs solely to [`DataKey`] (see ADR-007) — so no migration or
+//! `SCHEMA_VERSION` bump is needed (issue #912).
+
+use crate::DataKey;
+use soroban_sdk::Address;
+
+/// Per-investor persistent principal recorded by `fund` / `fund_with_commitment` / `fund_batch`.
+pub(crate) fn investor_contribution(investor: Address) -> DataKey {
+    DataKey::InvestorContribution(investor)
+}
+
+/// Per-investor persistent effective yield (bps) selected on the investor's first deposit.
+pub(crate) fn investor_effective_yield(investor: Address) -> DataKey {
+    DataKey::InvestorEffectiveYield(investor)
+}
+
+/// Per-investor persistent claim-not-before ledger timestamp (`0` = no extra claim gate).
+pub(crate) fn investor_claim_not_before(investor: Address) -> DataKey {
+    DataKey::InvestorClaimNotBefore(investor)
+}
+
+/// Per-investor persistent claimed-payout marker.
+pub(crate) fn investor_claimed(investor: Address) -> DataKey {
+    DataKey::InvestorClaimed(investor)
+}
+
+/// Instance-storage minimum per-call contribution floor (`0` = no floor).
+pub(crate) fn min_contribution_floor() -> DataKey {
+    DataKey::MinContributionFloor
+}
+
+/// Instance-storage cap on distinct investor addresses (absent = unlimited).
+pub(crate) fn max_unique_investors_cap() -> DataKey {
+    DataKey::MaxUniqueInvestorsCap
+}
+
+/// Instance-storage cap on total principal for a single investor address (absent = unlimited).
+pub(crate) fn max_per_investor_cap() -> DataKey {
+    DataKey::MaxPerInvestorCap
+}
+
+/// Instance-storage count of distinct investor addresses that have funded so far.
+pub(crate) fn unique_funder_count() -> DataKey {
+    DataKey::UniqueFunderCount
+}
+
+/// Instance-storage ordered list of investor addresses backing paginated enumeration.
+pub(crate) fn investor_index() -> DataKey {
+    DataKey::InvestorIndex
+}
+
+/// Instance-storage optional funding deadline timestamp (absent = no deadline).
+pub(crate) fn funding_deadline() -> DataKey {
+    DataKey::FundingDeadline
+}
+
+/// Instance-storage write-once pro-rata snapshot captured at the first funded transition.
+pub(crate) fn funding_close_snapshot() -> DataKey {
+    DataKey::FundingCloseSnapshot
+}
+
+/// Instance-storage immutable SEP-41 funding token address, set once at `init`.
+pub(crate) fn funding_token() -> DataKey {
+    DataKey::FundingToken
+}

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -146,6 +146,7 @@ use soroban_sdk::{
 };
 
 pub mod external_calls;
+mod keys;
 
 /// Current storage schema version written to [`DataKey::Version`] by [`LiquifactEscrow::init`].
 ///
@@ -1652,7 +1653,7 @@ impl LiquifactEscrow {
     fn funding_token_or_fail(env: &Env) -> Address {
         env.storage()
             .instance()
-            .get(&DataKey::FundingToken)
+            .get(&keys::funding_token())
             .unwrap_or_else(|| fail(env, EscrowError::FundingTokenNotSet))
     }
 
@@ -1863,7 +1864,7 @@ impl LiquifactEscrow {
 
         env.storage()
             .instance()
-            .set(&DataKey::FundingToken, &funding_token);
+            .set(&keys::funding_token(), &funding_token);
         env.storage().instance().set(&DataKey::Treasury, &treasury);
         env.storage()
             .instance()
@@ -1890,27 +1891,27 @@ impl LiquifactEscrow {
         let floor = min_contribution.unwrap_or(0);
         env.storage()
             .instance()
-            .set(&DataKey::MinContributionFloor, &floor);
+            .set(&keys::min_contribution_floor(), &floor);
         // Always persist the fee (even the `0` default) so `withdraw` reads never branch on absence.
         env.storage()
             .instance()
             .set(&DataKey::ProtocolFeeBps, &protocol_fee_bps);
         env.storage()
             .instance()
-            .set(&DataKey::UniqueFunderCount, &0u32);
+            .set(&keys::unique_funder_count(), &0u32);
 
         if let Some(cap) = max_per_investor {
             ensure(&env, cap > 0, EscrowError::MaxPerInvestorNotPositive);
             env.storage()
                 .instance()
-                .set(&DataKey::MaxPerInvestorCap, &cap);
+                .set(&keys::max_per_investor_cap(), &cap);
         }
 
         if let Some(cap) = max_unique_investors {
             ensure(&env, cap > 0, EscrowError::MaxUniqueInvestorsNotPositive);
             env.storage()
                 .instance()
-                .set(&DataKey::MaxUniqueInvestorsCap, &cap);
+                .set(&keys::max_unique_investors_cap(), &cap);
         }
 
         let delay = legal_hold_clear_delay.unwrap_or(0);
@@ -1938,7 +1939,7 @@ impl LiquifactEscrow {
             }
             env.storage()
                 .instance()
-                .set(&DataKey::FundingDeadline, &deadline);
+                .set(&keys::funding_deadline(), &deadline);
         }
 
         let invoice_sym = validate_invoice_id_string(&env, &invoice_id);
@@ -2337,12 +2338,12 @@ impl LiquifactEscrow {
 
     /// Get the optional funding deadline (ledger timestamp), returns None if not set.
     pub fn get_funding_deadline(env: Env) -> Option<u64> {
-        env.storage().instance().get(&DataKey::FundingDeadline)
+        env.storage().instance().get(&keys::funding_deadline())
     }
 
     /// Check if funding has expired (deadline set and now > deadline).
     pub fn is_funding_expired(env: Env) -> bool {
-        if let Some(deadline) = env.storage().instance().get(&DataKey::FundingDeadline) {
+        if let Some(deadline) = env.storage().instance().get(&keys::funding_deadline()) {
             env.ledger().timestamp() > deadline
         } else {
             false
@@ -2385,7 +2386,7 @@ impl LiquifactEscrow {
     pub fn get_min_contribution_floor(env: Env) -> i128 {
         env.storage()
             .instance()
-            .get(&DataKey::MinContributionFloor)
+            .get(&keys::min_contribution_floor())
             .unwrap_or(0)
     }
 
@@ -2408,13 +2409,13 @@ impl LiquifactEscrow {
     pub fn get_max_unique_investors_cap(env: Env) -> Option<u32> {
         env.storage()
             .instance()
-            .get(&DataKey::MaxUniqueInvestorsCap)
+            .get(&keys::max_unique_investors_cap())
     }
 
     /// Optional cap on total principal for a single investor address.
     /// Absent ⇒ unlimited. Enforced on every deposit.
     pub fn get_max_per_investor_cap(env: Env) -> Option<i128> {
-        env.storage().instance().get(&DataKey::MaxPerInvestorCap)
+        env.storage().instance().get(&keys::max_per_investor_cap())
     }
 
     /// Distinct funders counted so far (each address counted once when it first receives principal).
@@ -2424,7 +2425,7 @@ impl LiquifactEscrow {
     pub fn get_unique_funder_count(env: Env) -> u32 {
         env.storage()
             .instance()
-            .get(&DataKey::UniqueFunderCount)
+            .get(&keys::unique_funder_count())
             .unwrap_or(0)
     }
 
@@ -2554,52 +2555,52 @@ impl LiquifactEscrow {
     fn get_persistent_investor_contribution(env: &Env, investor: Address) -> i128 {
         env.storage()
             .persistent()
-            .get(&DataKey::InvestorContribution(investor))
+            .get(&keys::investor_contribution(investor))
             .unwrap_or(0)
     }
 
     fn set_persistent_investor_contribution(env: &Env, investor: Address, amount: i128) {
         env.storage()
             .persistent()
-            .set(&DataKey::InvestorContribution(investor), &amount);
+            .set(&keys::investor_contribution(investor), &amount);
     }
 
     fn get_persistent_investor_effective_yield(env: &Env, investor: Address) -> Option<i64> {
         env.storage()
             .persistent()
-            .get(&DataKey::InvestorEffectiveYield(investor))
+            .get(&keys::investor_effective_yield(investor))
     }
 
     fn set_persistent_investor_effective_yield(env: &Env, investor: Address, value: i64) {
         env.storage()
             .persistent()
-            .set(&DataKey::InvestorEffectiveYield(investor), &value);
+            .set(&keys::investor_effective_yield(investor), &value);
     }
 
     fn get_persistent_investor_claim_not_before(env: &Env, investor: Address) -> u64 {
         env.storage()
             .persistent()
-            .get(&DataKey::InvestorClaimNotBefore(investor))
+            .get(&keys::investor_claim_not_before(investor))
             .unwrap_or(0)
     }
 
     fn set_persistent_investor_claim_not_before(env: &Env, investor: Address, value: u64) {
         env.storage()
             .persistent()
-            .set(&DataKey::InvestorClaimNotBefore(investor), &value);
+            .set(&keys::investor_claim_not_before(investor), &value);
     }
 
     fn get_persistent_investor_claimed(env: &Env, investor: Address) -> bool {
         env.storage()
             .persistent()
-            .get(&DataKey::InvestorClaimed(investor))
+            .get(&keys::investor_claimed(investor))
             .unwrap_or(false)
     }
 
     fn set_persistent_investor_claimed(env: &Env, investor: Address, value: bool) {
         env.storage()
             .persistent()
-            .set(&DataKey::InvestorClaimed(investor), &value);
+            .set(&keys::investor_claimed(investor), &value);
     }
 
     /// Public API: contribution recorded for `investor` (persistent storage).
@@ -2645,7 +2646,7 @@ impl LiquifactEscrow {
         let index: Vec<Address> = env
             .storage()
             .instance()
-            .get(&DataKey::InvestorIndex)
+            .get(&keys::investor_index())
             .unwrap_or_else(|| Vec::new(&env));
 
         let len = index.len();
@@ -2669,7 +2670,9 @@ impl LiquifactEscrow {
     /// funding call, including any over-funding past `funding_target`, plus the close ledger time
     /// and sequence used by off-chain auditors.
     pub fn get_funding_close_snapshot(env: Env) -> Option<FundingCloseSnapshot> {
-        env.storage().instance().get(&DataKey::FundingCloseSnapshot)
+        env.storage()
+            .instance()
+            .get(&keys::funding_close_snapshot())
     }
 
     /// Returns the ledger timestamp (seconds since Unix epoch) at which [`LiquifactEscrow::settle`]
@@ -3496,11 +3499,14 @@ impl LiquifactEscrow {
         // exactly once — mirroring the promotion logic in `fund`/`fund_with_commitment`.
         if escrow.funded_amount > 0
             && escrow.funded_amount >= new_target
-            && !env.storage().instance().has(&DataKey::FundingCloseSnapshot)
+            && !env
+                .storage()
+                .instance()
+                .has(&keys::funding_close_snapshot())
         {
             escrow.status = 1;
             env.storage().instance().set(
-                &DataKey::FundingCloseSnapshot,
+                &keys::funding_close_snapshot(),
                 &FundingCloseSnapshot {
                     total_principal: escrow.funded_amount,
                     funding_target: new_target,
@@ -3542,7 +3548,7 @@ impl LiquifactEscrow {
         let old_cap: Option<u32> = env
             .storage()
             .instance()
-            .get(&DataKey::MaxUniqueInvestorsCap);
+            .get(&keys::max_unique_investors_cap());
         ensure(
             &env,
             old_cap.is_some(),
@@ -3560,7 +3566,7 @@ impl LiquifactEscrow {
 
         env.storage()
             .instance()
-            .set(&DataKey::MaxUniqueInvestorsCap, &new_cap);
+            .set(&keys::max_unique_investors_cap(), &new_cap);
 
         MaxUniqueInvestorsCapLowered {
             name: symbol_short!("inv_cap"),
@@ -3590,7 +3596,7 @@ impl LiquifactEscrow {
         let old_cap: Option<u32> = env
             .storage()
             .instance()
-            .get(&DataKey::MaxUniqueInvestorsCap);
+            .get(&keys::max_unique_investors_cap());
         ensure(
             &env,
             old_cap.is_some(),
@@ -3602,7 +3608,7 @@ impl LiquifactEscrow {
 
         env.storage()
             .instance()
-            .set(&DataKey::MaxUniqueInvestorsCap, &new_cap);
+            .set(&keys::max_unique_investors_cap(), &new_cap);
 
         MaxUniqueInvestorsCapRaised {
             name: symbol_short!("raise_cap"),
@@ -3635,13 +3641,13 @@ impl LiquifactEscrow {
         let old_floor: i128 = env
             .storage()
             .instance()
-            .get(&DataKey::MinContributionFloor)
+            .get(&keys::min_contribution_floor())
             .unwrap_or(0);
         ensure(&env, new_floor < old_floor, EscrowError::NewFloorNotLower);
 
         env.storage()
             .instance()
-            .set(&DataKey::MinContributionFloor, &new_floor);
+            .set(&keys::min_contribution_floor(), &new_floor);
 
         MinContributionFloorLowered {
             name: symbol_short!("floor_lo"),
@@ -3680,7 +3686,7 @@ impl LiquifactEscrow {
 
         guard_status_eq(&env, escrow.status, 0, EscrowError::CapLowerNotOpen);
 
-        let old_cap: Option<i128> = env.storage().instance().get(&DataKey::MaxPerInvestorCap);
+        let old_cap: Option<i128> = env.storage().instance().get(&keys::max_per_investor_cap());
         ensure(
             &env,
             old_cap.is_some(),
@@ -3696,7 +3702,7 @@ impl LiquifactEscrow {
 
         env.storage()
             .instance()
-            .set(&DataKey::MaxPerInvestorCap, &new_cap);
+            .set(&keys::max_per_investor_cap(), &new_cap);
 
         MaxPerInvestorCapRaised {
             name: symbol_short!("inv_cap"),
@@ -3954,7 +3960,7 @@ impl LiquifactEscrow {
         let floor: i128 = env
             .storage()
             .instance()
-            .get(&DataKey::MinContributionFloor)
+            .get(&keys::min_contribution_floor())
             .unwrap_or(0);
         for i in 0..n {
             let (_, amount) = entries.get(i).unwrap();
@@ -4015,7 +4021,7 @@ impl LiquifactEscrow {
         let floor: i128 = env
             .storage()
             .instance()
-            .get(&DataKey::MinContributionFloor)
+            .get(&keys::min_contribution_floor())
             .unwrap_or(0);
         if floor > 0 {
             ensure(
@@ -4040,7 +4046,7 @@ impl LiquifactEscrow {
         require_funding_open(&env, escrow.status);
 
         // Check funding deadline
-        if let Some(deadline) = env.storage().instance().get(&DataKey::FundingDeadline) {
+        if let Some(deadline) = env.storage().instance().get(&keys::funding_deadline()) {
             ensure(
                 &env,
                 env.ledger().timestamp() <= deadline,
@@ -4064,7 +4070,7 @@ impl LiquifactEscrow {
         if let Some(cap) = env
             .storage()
             .instance()
-            .get::<DataKey, i128>(&DataKey::MaxPerInvestorCap)
+            .get::<DataKey, i128>(&keys::max_per_investor_cap())
         {
             ensure(
                 &env,
@@ -4079,7 +4085,7 @@ impl LiquifactEscrow {
         let cur_funder_count: u32 = if prev == 0 {
             env.storage()
                 .instance()
-                .get(&DataKey::UniqueFunderCount)
+                .get(&keys::unique_funder_count())
                 .unwrap_or(0)
         } else {
             0 // prev != 0: count is not needed; skip the read entirely.
@@ -4089,7 +4095,7 @@ impl LiquifactEscrow {
             if let Some(cap) = env
                 .storage()
                 .instance()
-                .get::<DataKey, u32>(&DataKey::MaxUniqueInvestorsCap)
+                .get::<DataKey, u32>(&keys::max_unique_investors_cap())
             {
                 ensure(
                     &env,
@@ -4153,7 +4159,11 @@ impl LiquifactEscrow {
 
         if escrow.status == 0 && escrow.funded_amount >= escrow.funding_target {
             escrow.status = 1;
-            if !env.storage().instance().has(&DataKey::FundingCloseSnapshot) {
+            if !env
+                .storage()
+                .instance()
+                .has(&keys::funding_close_snapshot())
+            {
                 let snap = FundingCloseSnapshot {
                     total_principal: escrow.funded_amount,
                     funding_target: escrow.funding_target,
@@ -4162,7 +4172,7 @@ impl LiquifactEscrow {
                 };
                 env.storage()
                     .instance()
-                    .set(&DataKey::FundingCloseSnapshot, &snap);
+                    .set(&keys::funding_close_snapshot(), &snap);
             }
         }
 
@@ -4171,27 +4181,23 @@ impl LiquifactEscrow {
         if prev == 0 {
             env.storage()
                 .instance()
-                .set(&DataKey::UniqueFunderCount, &(cur_funder_count + 1));
+                .set(&keys::unique_funder_count(), &(cur_funder_count + 1));
 
             let mut index: Vec<Address> = env
                 .storage()
                 .instance()
-                .get(&DataKey::InvestorIndex)
+                .get(&keys::investor_index())
                 .unwrap_or_else(|| Vec::new(&env));
             index.push_back(investor.clone());
             env.storage()
                 .instance()
-                .set(&DataKey::InvestorIndex, &index);
+                .set(&keys::investor_index(), &index);
         }
 
         env.storage().instance().set(&DataKey::Escrow, &escrow);
 
         // 4. Token transfer
-        let token_addr = env
-            .storage()
-            .instance()
-            .get(&DataKey::FundingToken)
-            .unwrap_or_else(|| fail(&env, EscrowError::FundingTokenNotSet));
+        let token_addr = Self::funding_token_or_fail(&env);
         let this = env.current_contract_address();
 
         #[cfg(any(test, feature = "testutils"))]
@@ -4252,7 +4258,11 @@ impl LiquifactEscrow {
         escrow.status = 1;
 
         // Write FundingCloseSnapshot if not already present.
-        if !env.storage().instance().has(&DataKey::FundingCloseSnapshot) {
+        if !env
+            .storage()
+            .instance()
+            .has(&keys::funding_close_snapshot())
+        {
             let snap = FundingCloseSnapshot {
                 total_principal: escrow.funded_amount,
                 funding_target: escrow.funding_target,
@@ -4261,7 +4271,7 @@ impl LiquifactEscrow {
             };
             env.storage()
                 .instance()
-                .set(&DataKey::FundingCloseSnapshot, &snap);
+                .set(&keys::funding_close_snapshot(), &snap);
         }
 
         env.storage().instance().set(&DataKey::Escrow, &escrow);
@@ -4401,11 +4411,7 @@ impl LiquifactEscrow {
             .checked_sub(fee)
             .unwrap_or_else(|| fail(&env, EscrowError::WithdrawNetArithmeticUnderflow));
 
-        let token_addr: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::FundingToken)
-            .unwrap_or_else(|| fail(&env, EscrowError::FundingTokenNotSet));
+        let token_addr: Address = Self::funding_token_or_fail(&env);
 
         // Verify the contract holds enough before mutating state. The check uses the gross
         // `funded_amount` because the contract must fund both the SME payout and the treasury fee.
@@ -4652,7 +4658,7 @@ impl LiquifactEscrow {
         let Some(snap) = env
             .storage()
             .instance()
-            .get::<DataKey, FundingCloseSnapshot>(&DataKey::FundingCloseSnapshot)
+            .get::<DataKey, FundingCloseSnapshot>(&keys::funding_close_snapshot())
         else {
             return 0;
         };
@@ -4735,7 +4741,7 @@ impl LiquifactEscrow {
         let Some(snap) = env
             .storage()
             .instance()
-            .get::<DataKey, FundingCloseSnapshot>(&DataKey::FundingCloseSnapshot)
+            .get::<DataKey, FundingCloseSnapshot>(&keys::funding_close_snapshot())
         else {
             return 0;
         };
@@ -4832,7 +4838,7 @@ impl LiquifactEscrow {
         let old_deadline = env
             .storage()
             .instance()
-            .get::<DataKey, u64>(&DataKey::FundingDeadline)
+            .get::<DataKey, u64>(&keys::funding_deadline())
             .unwrap_or_else(|| fail(&env, EscrowError::FundingDeadlineNotExtended));
 
         ensure(
@@ -4855,7 +4861,7 @@ impl LiquifactEscrow {
 
         env.storage()
             .instance()
-            .set(&DataKey::FundingDeadline, &new_deadline);
+            .set(&keys::funding_deadline(), &new_deadline);
         env.storage().instance().extend_ttl(
             INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
             INSTANCE_TTL_MIN_EXTENSION_LEDGERS,
@@ -5014,22 +5020,22 @@ impl LiquifactEscrow {
             );
             // Extend persistent TTL for per-investor persistent keys used by this contract.
             env.storage().persistent().extend_ttl(
-                &DataKey::InvestorContribution(addr.clone()),
+                &keys::investor_contribution(addr.clone()),
                 PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
                 PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
             );
             env.storage().persistent().extend_ttl(
-                &DataKey::InvestorEffectiveYield(addr.clone()),
+                &keys::investor_effective_yield(addr.clone()),
                 PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
                 PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
             );
             env.storage().persistent().extend_ttl(
-                &DataKey::InvestorClaimNotBefore(addr.clone()),
+                &keys::investor_claim_not_before(addr.clone()),
                 PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
                 PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
             );
             env.storage().persistent().extend_ttl(
-                &DataKey::InvestorClaimed(addr.clone()),
+                &keys::investor_claimed(addr.clone()),
                 PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
                 PERSISTENT_TTL_MIN_EXTENSION_LEDGERS,
             );
@@ -5461,11 +5467,11 @@ impl LiquifactEscrow {
             let cur: u32 = env
                 .storage()
                 .instance()
-                .get(&DataKey::UniqueFunderCount)
+                .get(&keys::unique_funder_count())
                 .unwrap_or(0);
             env.storage()
                 .instance()
-                .set(&DataKey::UniqueFunderCount, &cur.saturating_sub(1));
+                .set(&keys::unique_funder_count(), &cur.saturating_sub(1));
         }
 
         // 8. Persist updated escrow.

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -69,6 +69,7 @@ mod funding;
 mod init;
 mod integration;
 mod integration_status_guards;
+mod keys;
 mod legal_hold;
 mod migration_errors;
 mod pause;

--- a/escrow/src/tests/keys.rs
+++ b/escrow/src/tests/keys.rs
@@ -1,0 +1,277 @@
+use super::*;
+use crate::{keys, FundingCloseSnapshot};
+
+// Regression tests for issue #912: the centralized `keys` module must produce byte-for-byte
+// identical storage keys to the raw `DataKey` variants it replaces, since the refactor promises
+// "identical key layout; no migration needed". Each test writes a value under one construction
+// (`keys::x(...)` or the raw `DataKey::X(...)`) and reads it back under the other — a typo or
+// shape mismatch in the new module would surface as a defaulted/missing read, not a silent pass.
+
+#[test]
+fn investor_contribution_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+    let investor = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&keys::investor_contribution(investor.clone()), &777i128);
+    });
+    let read_back: i128 = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::InvestorContribution(investor.clone()))
+            .unwrap()
+    });
+    assert_eq!(read_back, 777i128);
+}
+
+#[test]
+fn investor_effective_yield_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+    let investor = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::InvestorEffectiveYield(investor.clone()), &950i64);
+    });
+    let read_back: i64 = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&keys::investor_effective_yield(investor.clone()))
+            .unwrap()
+    });
+    assert_eq!(read_back, 950i64);
+}
+
+#[test]
+fn investor_claim_not_before_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+    let investor = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(
+            &keys::investor_claim_not_before(investor.clone()),
+            &123_456u64,
+        );
+    });
+    let read_back: u64 = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::InvestorClaimNotBefore(investor.clone()))
+            .unwrap()
+    });
+    assert_eq!(read_back, 123_456u64);
+}
+
+#[test]
+fn investor_claimed_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+    let investor = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::InvestorClaimed(investor.clone()), &true);
+    });
+    let read_back: bool = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&keys::investor_claimed(investor.clone()))
+            .unwrap()
+    });
+    assert!(read_back);
+}
+
+#[test]
+fn min_contribution_floor_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&keys::min_contribution_floor(), &42i128);
+    });
+    let read_back: i128 = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinContributionFloor)
+            .unwrap()
+    });
+    assert_eq!(read_back, 42i128);
+}
+
+#[test]
+fn max_unique_investors_cap_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxUniqueInvestorsCap, &7u32);
+    });
+    let read_back: u32 = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&keys::max_unique_investors_cap())
+            .unwrap()
+    });
+    assert_eq!(read_back, 7u32);
+}
+
+#[test]
+fn max_per_investor_cap_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&keys::max_per_investor_cap(), &555i128);
+    });
+    let read_back: i128 = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxPerInvestorCap)
+            .unwrap()
+    });
+    assert_eq!(read_back, 555i128);
+}
+
+#[test]
+fn unique_funder_count_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::UniqueFunderCount, &3u32);
+    });
+    let read_back: u32 = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&keys::unique_funder_count())
+            .unwrap()
+    });
+    assert_eq!(read_back, 3u32);
+}
+
+#[test]
+fn investor_index_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+    let investor = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        let mut index: SorobanVec<Address> = SorobanVec::new(&env);
+        index.push_back(investor.clone());
+        env.storage()
+            .instance()
+            .set(&keys::investor_index(), &index);
+    });
+    let read_back: SorobanVec<Address> = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&DataKey::InvestorIndex)
+            .unwrap()
+    });
+    assert_eq!(read_back.len(), 1);
+    assert_eq!(read_back.get(0).unwrap(), investor);
+}
+
+#[test]
+fn funding_deadline_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::FundingDeadline, &999_999u64);
+    });
+    let read_back: u64 = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&keys::funding_deadline())
+            .unwrap()
+    });
+    assert_eq!(read_back, 999_999u64);
+}
+
+#[test]
+fn funding_close_snapshot_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+
+    let snap = FundingCloseSnapshot {
+        total_principal: 100i128,
+        funding_target: 100i128,
+        closed_at_ledger_timestamp: 0,
+        closed_at_ledger_sequence: 100,
+    };
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&keys::funding_close_snapshot(), &snap);
+    });
+    let read_back: FundingCloseSnapshot = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&DataKey::FundingCloseSnapshot)
+            .unwrap()
+    });
+    assert_eq!(read_back, snap);
+}
+
+#[test]
+fn funding_token_key_matches_raw_datakey() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+    default_init(&client, &env, &admin, &sme);
+    let other_token = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::FundingToken, &other_token);
+    });
+    let read_back: Address = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&keys::funding_token())
+            .unwrap()
+    });
+    assert_eq!(read_back, other_token);
+}


### PR DESCRIPTION
Summary
Funding logic constructed DataKey variants inline at each call site — fund_impl, fund_batch, update_funding_target, the cap/floor/deadline admin setters, partial_settle, unfund, bump_ttl, and their read-only getters — risking two sites drifting apart on a key's shape. This adds escrow/src/keys.rs with one constructor function per funding-related DataKey variant and routes every real construction site through it.

Covered variants: InvestorContribution, InvestorEffectiveYield, InvestorClaimNotBefore, InvestorClaimed, MinContributionFloor, MaxUniqueInvestorsCap, MaxPerInvestorCap, UniqueFunderCount, InvestorIndex, FundingDeadline, FundingCloseSnapshot, FundingToken.

Bonus fix found while sweeping FundingToken's construction sites: fund_impl and withdraw each reimplemented the existing funding_token_or_fail helper's get-with-fallback logic inline instead of calling it — the exact same drift risk this issue is about. Both now call the helper directly, removing the duplicate.

No migration needed: this is a pure indirection layer. No key's on-chain shape or DataKey discriminant changes — that contract still belongs solely to DataKey (ADR-007) — so SCHEMA_VERSION is unchanged.

Changes
escrow/src/keys.rs (new) — 12 constructor functions, pub(crate), each returning the corresponding DataKey variant.
escrow/src/lib.rs — every real (non-doc-comment) construction of the 12 variants above now goes through keys::; fund_impl/withdraw's duplicate FundingToken lookups now call Self::funding_token_or_fail(&env).
escrow/src/tests/keys.rs (new) — 12 regression tests. Each writes a value under one construction (keys::x(...) or the raw DataKey::X(...)) and reads it back under the other, proving byte-for-byte key equivalence — the strongest direct evidence that key layout is unchanged. A typo or shape mismatch in the new module would surface as a defaulted/missing read, not a silent pass.
escrow/src/tests.rs — registers the new keys test module.
Test plan

cargo fmt -p liquifact_escrow -- --check
→ clean

cargo clippy -p liquifact_escrow --all-targets -- -D warnings
→ Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.00s
→ 0 warnings

cargo build -p liquifact_escrow
→ Finished `dev` profile [unoptimized + debuginfo] target(s) in 26.53s

cargo test -p liquifact_escrow
→ test result: ok. 860 passed; 0 failed; 54 ignored; 0 measured; 0 filtered out; finished in 106.25s
   (848 pre-existing + 12 new; all pre-existing tests pass unchanged, proving no
   behavioral or storage-compatibility regression)

cargo llvm-cov --features testutils --summary-only -p liquifact_escrow
→ keys.rs:  100.00% lines, 100.00% functions, 100.00% regions
→ lib.rs:    90.87% lines (unchanged from pre-refactor baseline; no new gaps introduced)
Notes for reviewers
This branch is based directly on main at e2eaacd, independent of any other open PR — no unrelated diff.
Scope is intentionally limited to funding-domain keys (not allowlist, attestation, or legal-hold keys), matching the issue title; those are separate concerns with their own admin entrypoints.
keys is a private module (mod keys;, pub(crate) functions) — pure internal plumbing, not part of the contract's public interface.

Closes #912