### PR TITLE
test(attestation): cover auth negative paths

### DIFF
--- a/escrow/src/tests/admin.rs
+++ b/escrow/src/tests/admin.rs
@@ -1918,6 +1918,44 @@ fn auth_audit_append_attestation_requires_admin() {
 
 #[test]
 #[should_panic]
+fn auth_audit_revoke_attestation_digest_requires_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.append_attestation_digest(&soroban_sdk::BytesN::from_array(&env, &[0u8; 32]));
+    env.mock_auths(&[]);
+    client.revoke_attestation_digest(&0);
+}
+
+#[test]
+#[should_panic]
+fn auth_audit_revoke_attestation_digests_requires_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.append_attestation_digest(&soroban_sdk::BytesN::from_array(&env, &[0u8; 32]));
+    let indices = soroban_sdk::vec![&env, 0u32];
+    env.mock_auths(&[]);
+    client.revoke_attestation_digests(&indices);
+}
+
+#[test]
+#[should_panic]
+fn auth_audit_unrevoke_attestation_digest_requires_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+    client.append_attestation_digest(&soroban_sdk::BytesN::from_array(&env, &[0u8; 32]));
+    client.revoke_attestation_digest(&0);
+    env.mock_auths(&[]);
+    client.unrevoke_attestation_digest(&0);
+}
+
+#[test]
+#[should_panic]
 fn auth_audit_set_allowlist_active_requires_admin() {
     let env = Env::default();
     env.mock_all_auths();

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -268,6 +268,17 @@ fn test_append_non_admin_panics() {
     client.append_attestation_digest(&digest(&env, 0x01));
 }
 
+/// Non-admin `try_append_attestation_digest` returns an authorization error.
+#[test]
+fn test_append_non_admin_returns_error() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    env.mock_auths(&[]);
+    assert!(client
+        .try_append_attestation_digest(&digest(&env, 0x01))
+        .is_err());
+}
+
 // ---------------------------------------------------------------------------
 // Interaction: primary hash and append log are independent
 // ---------------------------------------------------------------------------
@@ -398,6 +409,33 @@ fn test_revoke_non_admin_returns_error() {
     env.mock_auths(&[]);
     // Any error (not Ok) satisfies the auth-rejection requirement.
     assert!(client.try_revoke_attestation_digest(&0).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// revoke_attestation_digests — batch revocation auth
+// ---------------------------------------------------------------------------
+
+/// Non-admin caller must not be able to batch-revoke.
+#[test]
+#[should_panic]
+fn test_revoke_digests_non_admin_panics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0xFF));
+    let indices = soroban_sdk::vec![&env, 0u32];
+    env.mock_auths(&[]);
+    client.revoke_attestation_digests(&indices);
+}
+
+/// Non-admin `try_revoke_attestation_digests` returns an error.
+#[test]
+fn test_revoke_digests_non_admin_returns_error() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0xFF));
+    let indices = soroban_sdk::vec![&env, 0u32];
+    env.mock_auths(&[]);
+    assert!(client.try_revoke_attestation_digests(&indices).is_err());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Overview
This PR adds negative-path authorization tests for the attestation module, ensuring each guarded entrypoint rejects unauthorized callers with typed errors.

## Related Issue
Closes #921

## Changes

### Auth Negative-Path Tests
- [ADD] Typed-error auth test for append_attestation_digest via try_append_attestation_digest
- [ADD] Panic + typed-error auth tests for revoke_attestation_digests (previously had zero auth coverage)
- [ADD] Panic-style auth-audit tests for revoke_attestation_digest, revoke_attestation_digests, and unrevoke_attestation_digest in the admin audit suite

### Verification
- cargo fmt - completed
- cargo clippy --all-targets -- -D warnings - passed
- cargo test - passed

### Coverage
All 5 guarded attestation entrypoints now have both panic-style (admin.rs) and typed-error (attestations.rs) auth rejection tests.
