### PR TITLE
docs(collateral): document error codes and resolve outdated reference tables Closes #889

### DIFF
--- a/docs/collateral-errors.md
+++ b/docs/collateral-errors.md
@@ -1,0 +1,68 @@
+# Liquifact Escrow Collateral Error Codes
+
+This document details the typed Soroban contract errors associated with the **SME Collateral Commitment** feature in the `Liquifact` escrow contract. Client SDKs and integration libraries can use these codes to branch programmatically on specific failure states.
+
+For a complete list of all escrow error codes, see [`docs/escrow-error-messages.md`](escrow-error-messages.md). For details on how the collateral system operates, see [`docs/escrow-sme-collateral.md`](escrow-sme-collateral.md).
+
+---
+
+## Stability and Category Mapping
+
+Collateral-specific errors are grouped under the **SME Collateral** range (codes `60–62`) and the general **Funding deadline / balance / state** range (code `169`).
+
+All errors in this contract are defined in [`escrow/src/lib.rs`](../escrow/src/lib.rs) inside the `EscrowError` enum. They are stable, append-only, and represented as `u32` values.
+
+---
+
+## Collateral Error Codes Reference
+
+### 1. `EscrowNotInitialized` (Code `20`)
+* **Variant:** `EscrowError::EscrowNotInitialized`
+* **Entrypoints:** 
+  * `record_sme_collateral_commitment`
+  * `clear_sme_collateral_commitment`
+* **Trigger Condition:** The contract instance storage does not contain the core escrow configuration (`DataKey::Escrow`). This check is performed via `load_escrow_require_sme`.
+* **How to Avoid:** Ensure the escrow contract instance has been initialized by calling `init` before attempting any collateral-related operations.
+
+---
+
+### 2. `CollateralAmountNotPositive` (Code `60`)
+* **Variant:** `EscrowError::CollateralAmountNotPositive`
+* **Entrypoint:** `record_sme_collateral_commitment`
+* **Trigger Condition:** The `amount` parameter passed to the function is less than or equal to zero (`amount <= 0`).
+* **How to Avoid:** Provide a strictly positive metadata amount (e.g. `amount > 0`).
+
+---
+
+### 3. `CollateralAssetEmpty` (Code `61`)
+* **Variant:** `EscrowError::CollateralAssetEmpty`
+* **Entrypoint:** `record_sme_collateral_commitment`
+* **Trigger Condition:** The `asset` Symbol parameter passed to the function is empty (i.e. `Symbol::new(&env, "")`).
+* **How to Avoid:** Provide a non-empty symbol representing the asset identifier (e.g. `USDC`).
+
+---
+
+### 4. `CollateralTimestampBackwards` (Code `62`)
+* **Variant:** `EscrowError::CollateralTimestampBackwards`
+* **Entrypoint:** `record_sme_collateral_commitment`
+* **Trigger Condition:** A prior commitment pledge exists in storage, and the current ledger timestamp (`env.ledger().timestamp()`) is strictly less than the stored commitment's `recorded_at` timestamp.
+* **How to Avoid:** When updating/replacing an existing collateral commitment, ensure that the transaction is submitted with a monotonic ledger time that is greater than or equal to the timestamp of the prior commitment.
+
+---
+
+### 5. `NoCollateralToClear` (Code `169`)
+* **Variant:** `EscrowError::NoCollateralToClear`
+* **Entrypoint:** `clear_sme_collateral_commitment`
+* **Trigger Condition:** The function attempts to clear the SME collateral commitment but no commitment pledge (`DataKey::SmeCollateralPledge`) is currently stored in the contract instance.
+* **How to Avoid:** Check the status of the collateral commitment using `get_sme_collateral_commitment` before attempting to clear it. Do not invoke the clear entrypoint if no commitment exists.
+
+---
+
+## Authorization Failures vs Typed Errors
+
+All collateral-mutating entrypoints require authorization from the configured SME address (`InvoiceEscrow::sme_address`):
+
+- `record_sme_collateral_commitment` enforces authorization by invoking `sme_address.require_auth()`.
+- `clear_sme_collateral_commitment` enforces authorization by invoking `sme_address.require_auth()`.
+
+If an unauthorized address invokes these functions, Soroban's native authentication framework will reject the invocation with a standard host authorization failure rather than returning a custom `EscrowError` code.

--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -44,8 +44,10 @@ Codes are grouped by domain so SDKs can map coarse categories without parsing va
 | Funding deadline / balance | 163–164 | Post-deadline funding and contract balance sufficiency | 163, 164 |
 
 See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
-[`docs/ESCROW_BENEFICIARY_ROTATION.md`](ESCROW_BENEFICIARY_ROTATION.md), and
+[`docs/ESCROW_BENEFICIARY_ROTATION.md`](ESCROW_BENEFICIARY_ROTATION.md),
+[`docs/collateral-errors.md`](collateral-errors.md), and
 [`docs/adr/ADR-006-dust-sweep-and-token-safety.md`](adr/ADR-006-dust-sweep-and-token-safety.md).
+
 
 ## Canonical Reference Table
 
@@ -146,6 +148,7 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 165 | `ClaimBatchEmpty` | `claim_payouts_batch` | `investors` vec is empty | Pass at least one investor | typed |
 | 166 | `ClaimBatchTooLarge` | `claim_payouts_batch` | `investors` vec exceeds `MAX_CLAIM_BATCH` (32) | Split into smaller batches | typed |
 | 167 | `FundingDeadlinePassed` | `init`, `fund`, `fund_with_commitment`, `fund_batch` | `funding_deadline` configured and `ledger.timestamp()` past deadline | Funding window closed; do not retry deposits | typed |
+| 169 | `NoCollateralToClear` | `clear_sme_collateral_commitment` | `DataKey::SmeCollateralPledge` is missing | Check if collateral is recorded first | typed |
 | 200 | `PartialSettleUnauthorizedCaller` | `partial_settle` | `caller` is neither `sme_address` nor `admin` | Call as the SME or admin | typed |
 | 201 | `LegalHoldBlocksPartialSettle` | `partial_settle` | legal hold active | Complete legal-hold clear workflow | typed |
 | 202 | `PartialSettleNotOpen` | `partial_settle` | escrow status `!= 0` (open) | Partial settle only while open | typed |
@@ -247,6 +250,7 @@ See also [`docs/escrow-legal-hold.md`](escrow-legal-hold.md),
 | 162 | `New SME address must differ from current beneficiary` |
 | 163 | `Funding deadline has passed` |
 | 164 | `Contract balance below funded amount` |
+| 169 | `n/a — clear_sme_collateral_commitment with no pledge` |
 
 ## Client Guidance
 

--- a/docs/escrow-sme-collateral.md
+++ b/docs/escrow-sme-collateral.md
@@ -109,12 +109,16 @@ pub struct CollateralCommitmentCleared {
 
 ## Error codes
 
-| Code | Variant              | Trigger                                            |
-|------|----------------------|----------------------------------------------------|
-| 1    | `NotInitialized`     | Escrow not yet created via `init`                  |
-| 2    | `NotOpen`            | Reserved for future status guards                  |
-| 3    | `NotFunded`          | Reserved for future status guards                  |
-| 4    | `NoCollateralToClear`| `clear_sme_collateral_commitment` with no pledge   |
+For the full details of all collateral-related error codes, see [`docs/collateral-errors.md`](collateral-errors.md).
+
+| Code | Variant | Trigger | Recommended client action |
+| ---: | --- | --- | --- |
+| 20 | `EscrowNotInitialized` | `record_sme_collateral_commitment` / `clear_sme_collateral_commitment` called before `init` | Call `init` first |
+| 60 | `CollateralAmountNotPositive` | `record_sme_collateral_commitment` with `amount <= 0` | Provide positive metadata amount |
+| 61 | `CollateralAssetEmpty` | `record_sme_collateral_commitment` with empty asset symbol | Provide non-empty asset label |
+| 62 | `CollateralTimestampBackwards` | `record_sme_collateral_commitment` with timestamp `<` stored timestamp | Use monotonic timestamps |
+| 169 | `NoCollateralToClear` | `clear_sme_collateral_commitment` with no pledge active | Check if collateral is recorded first |
+
 
 ---
 


### PR DESCRIPTION
Closes #889

---

## Description
This PR addresses issue #889 by fully documenting the typed Soroban contract error codes associated with the SME Collateral Commitment feature in the `Liquifact-contracts` repository. 

Previously, these collateral error codes were undocumented or documented incorrectly (with fictional placeholder codes 1-4 in the collateral guide), which made integrating client SDKs and backend indexers difficult.

## Changes Made
- **Created [`docs/collateral-errors.md`](docs/collateral-errors.md)**: A dedicated guide explaining every collateral-related `EscrowError` code, its variant name, triggers, recommended client resolutions, and authorization requirements:
  - `EscrowNotInitialized` (Code `20`)
  - `CollateralAmountNotPositive` (Code `60`)
  - `CollateralAssetEmpty` (Code `61`)
  - `CollateralTimestampBackwards` (Code `62`)
  - `NoCollateralToClear` (Code `169`)
- **Updated [`docs/escrow-error-messages.md`](docs/escrow-error-messages.md)**:
  - Linked to the new `collateral-errors.md` documentation in the "See Also" section.
  - Registered `NoCollateralToClear` (Code `169`) in both the Canonical Reference Table and the Legacy Panic table.
- **Updated [`docs/escrow-sme-collateral.md`](docs/escrow-sme-collateral.md)**:
  - Replaced outdated placeholder error codes with actual Soroban contract error codes and linked to the new `collateral-errors.md` guide.

## Verification & Testing
- Ran `cargo fmt --all -- --check` in the `escrow` directory to verify code formatting (passed).
- Verified the numeric error codes and their exact trigger conditions manually against the Rust contract source code in [`escrow/src/lib.rs`](escrow/src/lib.rs):
  - `CollateralAmountNotPositive = 60` (checked at line 3042)
  - `CollateralAssetEmpty = 61` (checked at line 3043)
  - `CollateralTimestampBackwards = 62` (checked at line 3058)
  - `NoCollateralToClear = 169` (checked at line 2759)
  - `EscrowNotInitialized = 20` (checked at line 2304)

*Note: MSVC Build Tools (`link.exe`) are not available on the current host system, so cargo check/test execution was skipped, but all changes are strictly Markdown documentation files.*
