### PR TITLE
docs(settlement): document error codes (#879)

### DIFF
--- a/docs/attestation-errors.md
+++ b/docs/attestation-errors.md
@@ -1,0 +1,144 @@
+# Attestation Error Codes
+
+This document lists every typed [`EscrowError`](../escrow/src/lib.rs) code that the
+attestation entrypoints can emit, the exact condition that triggers each one, and how to avoid it.
+
+All codes are **stable and append-only** — SDKs must branch on the numeric
+`ContractError(code)`, not on panic-string text.
+
+## Covered entrypoints
+
+| Entrypoint | Auth role | Description |
+| --- | --- | --- |
+| `bind_primary_attestation_hash(digest)` | Admin | Single-write 32-byte primary attestation digest. Once bound, cannot be overwritten. |
+| `append_attestation_digest(digest)` | Admin | Append a 32-byte digest to the bounded append log. |
+| `revoke_attestation_digest(index)` | Admin | Mark a single append-log entry as revoked. |
+| `revoke_attestation_digests(indices)` | Admin | Atomically revoke multiple entries by index. |
+| `unrevoke_attestation_digest(index)` | Admin | Clear the revocation flag on an append-log entry. |
+
+### Constants referenced by error codes
+
+| Constant | Value | Description |
+| --- | ---: | --- |
+| `MAX_ATTESTATION_APPEND_ENTRIES` | 32 | Maximum entries in the append log. |
+| `MAX_ATTESTATION_REVOKE_BATCH` | 32 | Maximum indices per `revoke_attestation_digests` call. |
+
+---
+
+## Error Reference
+
+### Pre-condition: escrow not initialised
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 20 | `EscrowNotInitialized` | all attestation entrypoints | `DataKey::Escrow` is absent from storage — the contract has not been initialised. | Call `init` before any attestation entrypoint. |
+
+### Primary attestation hash errors
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 50 | `PrimaryAttestationAlreadyBound` | `bind_primary_attestation_hash` | `DataKey::PrimaryAttestationHash` already exists in storage. The primary hash is **single-write**: once set it cannot be replaced. | Check `get_primary_attestation_hash()` before calling. If a value is returned, the primary digest is already final for this escrow instance. |
+
+### Append-log errors
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 51 | `AttestationAppendLogCapacityReached` | `append_attestation_digest` | The append log already contains `MAX_ATTESTATION_APPEND_ENTRIES` (32) entries. New digests cannot be appended once the cap is hit. | Query `get_attestation_append_log()` to check current log length before appending. If the log is full, no further appends are possible on this escrow instance. |
+
+### Index validation errors (single-index operations)
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 52 | `AttestationIndexOutOfRange` | `revoke_attestation_digest`, `unrevoke_attestation_digest` | `index >= log.len()` — the requested index is beyond the end of the current append log. | Read `get_attestation_append_log()` to determine valid indices (`0` to `log.len() - 1`). |
+| 53 | `AttestationAlreadyRevoked` | `revoke_attestation_digest` | The entry at `index` already has `DataKey::AttestationRevoked(index)` set to `true`. | Check `is_attestation_revoked(index)` before calling. If `true`, the entry is already revoked. |
+| 56 | `AttestationNotRevoked` | `unrevoke_attestation_digest` | The entry at `index` does not have a revocation flag (`DataKey::AttestationRevoked(index)` is absent). | Check `is_attestation_revoked(index)` before calling. If `false`, the entry is not revoked and cannot be unrevoked. |
+
+### Batch-revoke errors
+
+`revoke_attestation_digests` validates the entire batch before mutating any state. If **any**
+per-index check fails, the whole call is rolled back atomically — no partial revocation occurs.
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 54 | `AttestationBatchEmpty` | `revoke_attestation_digests` | `indices` vector has length 0. | Always pass at least one index. Guard the call client-side if your list may be empty. |
+| 55 | `AttestationBatchTooLarge` | `revoke_attestation_digests` | `indices.len() > MAX_ATTESTATION_REVOKE_BATCH` (32). | Split large index lists into chunks of ≤ 32 and call `revoke_attestation_digests` once per chunk. |
+| 52 | `AttestationIndexOutOfRange` | `revoke_attestation_digests` | Any entry in `indices` satisfies `index >= log.len()`. | Validate every index against the current log length before building the batch. |
+| 53 | `AttestationAlreadyRevoked` | `revoke_attestation_digests` | Any entry in `indices` is already revoked, **or** `indices` contains a duplicate (the second occurrence of a duplicate fails here because the first occurrence revoking that index makes it already-revoked). | Pre-check each index with `is_attestation_revoked`. De-duplicate the `indices` list before calling. |
+
+---
+
+## Guard-ordering summary
+
+### `bind_primary_attestation_hash(digest)`
+1. `load_escrow_require_admin` → `EscrowNotInitialized` (20) if storage missing; Soroban host auth failure if caller is not admin.
+2. Primary-hash existence check → `PrimaryAttestationAlreadyBound` (50)
+
+### `append_attestation_digest(digest)`
+1. `load_escrow_require_admin` → `EscrowNotInitialized` (20); Soroban host auth failure if not admin.
+2. Log-length check → `AttestationAppendLogCapacityReached` (51)
+
+### `revoke_attestation_digest(index)`
+1. `get_escrow` → `EscrowNotInitialized` (20)
+2. `admin.require_auth()` — Soroban host auth failure
+3. Index range check → `AttestationIndexOutOfRange` (52)
+4. Already-revoked check → `AttestationAlreadyRevoked` (53)
+
+### `revoke_attestation_digests(indices)`
+1. Batch-size guards → `AttestationBatchEmpty` (54) / `AttestationBatchTooLarge` (55)
+2. `get_escrow` → `EscrowNotInitialized` (20)
+3. `admin.require_auth()` — Soroban host auth failure
+4. Per-index (in order, all-or-nothing): `AttestationIndexOutOfRange` (52) then `AttestationAlreadyRevoked` (53)
+
+### `unrevoke_attestation_digest(index)`
+1. Index range check → `AttestationIndexOutOfRange` (52) _(note: precedes auth in this entrypoint)_
+2. Not-revoked check → `AttestationNotRevoked` (56)
+3. `get_escrow` + `admin.require_auth()` — `EscrowNotInitialized` (20) or Soroban host auth failure
+
+---
+
+## Authorization
+
+All attestation-mutating entrypoints require the current `InvoiceEscrow::admin` address. If an
+unauthorized caller invokes them, Soroban's native authentication framework rejects the
+invocation with a host auth failure — not a typed `EscrowError` code.
+
+Read-only attestation entrypoints require no authentication:
+
+| Entrypoint | Returns |
+| --- | --- |
+| `get_primary_attestation_hash()` | `Option<BytesN<32>>` — `None` when unbound. |
+| `get_attestation_append_log()` | `Vec<BytesN<32>>` — full log (active and revoked entries). |
+| `get_attestation_digest_at(index)` | `Option<AttestationDigestInfo>` — `None` when `index >= log.len()`. |
+| `is_attestation_revoked(index)` | `bool` — `false` when no revocation key exists. |
+| `get_revoked_attestation_digests(start, limit)` | Paginated list of revoked entries. Page size capped at `MAX_ATTESTATION_READ_PAGE` (20). |
+
+---
+
+## Lifecycle example
+
+```
+1. Admin calls init(...)                                    — escrow is initialised
+2. Admin calls bind_primary_attestation_hash(hash_a)       — primary hash bound; emits PrimaryAttestationBound
+3. Admin calls bind_primary_attestation_hash(hash_b)       — reverts: PrimaryAttestationAlreadyBound (50)
+4. Admin calls append_attestation_digest(hash_b)           — index 0 added to log
+5. Admin calls append_attestation_digest(hash_c)           — index 1 added to log
+6. Admin calls revoke_attestation_digest(0)                — index 0 marked revoked
+7. Admin calls revoke_attestation_digest(0)                — reverts: AttestationAlreadyRevoked (53)
+8. Admin calls revoke_attestation_digests([1, 99])         — reverts (atomically): AttestationIndexOutOfRange (52) for index 99
+9. Admin calls unrevoke_attestation_digest(1)              — reverts: AttestationNotRevoked (56) — index 1 was never revoked
+10. Admin calls unrevoke_attestation_digest(0)             — clears revocation on index 0
+```
+
+---
+
+## Stability policy
+
+All codes listed here are **append-only and will never be renumbered or reassigned**. New
+attestation-related failures will receive new codes at the end of the attestation range (50+). See
+[`docs/escrow-error-messages.md`](escrow-error-messages.md) for the full contract-wide code table.
+
+## See also
+
+- [`docs/escrow-error-messages.md`](escrow-error-messages.md) — full error code table
+- [`docs/escrow-attestations.md`](escrow-attestations.md) — attestation system overview and design
+- [`docs/attestation-invariants.md`](attestation-invariants.md) — invariant specification

--- a/docs/settlement-errors.md
+++ b/docs/settlement-errors.md
@@ -1,0 +1,169 @@
+# Settlement Error Codes
+
+This document lists every typed [`EscrowError`](../escrow/src/lib.rs) code that the
+settlement-family entrypoints can emit, the exact condition that triggers each one, and how to
+avoid it.
+
+All codes are **stable and append-only** — SDKs must branch on the numeric
+`ContractError(code)`, not on panic-string text.
+
+## Covered entrypoints
+
+| Entrypoint | Auth role | Description |
+| --- | --- | --- |
+| `partial_settle(caller)` | SME or Admin | Force-advances open escrow to funded status before the target is reached. |
+| `settle()` | SME | Marks a funded escrow as settled once maturity is reached. |
+| `withdraw()` | SME | SME pulls the funded principal (net of protocol fee). |
+| `claim_investor_payout(investor)` | Investor | Investor records a payout claim after settlement. |
+
+---
+
+## Error Reference
+
+### Legal-hold guards
+
+These errors are checked **before** `require_auth` as read-only pre-conditions, so they fire even
+if the caller's signature is valid.
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 201 | `LegalHoldBlocksPartialSettle` | `partial_settle` | A legal hold is active when `partial_settle` is called. | Wait for the admin to clear the legal hold before calling `partial_settle`. |
+| 120 | `LegalHoldBlocksSettlement` | `settle` | A legal hold is active when `settle` is called. | Wait for the admin to clear the legal hold before calling `settle`. |
+| 123 | `LegalHoldBlocksWithdrawal` | `withdraw` | A legal hold is active when `withdraw` is called. | Wait for the admin to clear the legal hold before calling `withdraw`. |
+| 125 | `LegalHoldBlocksInvestorClaims` | `claim_investor_payout` | A legal hold is active when `claim_investor_payout` is called. | Wait for the admin to clear the legal hold before claiming. |
+
+### Operational-pause guards
+
+Checked before `require_auth`, orthogonal to the legal hold. A pause auto-expires if
+`set_pause_max_duration` is configured; otherwise it persists until cleared explicitly.
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 211 | `PausedBlocksSettlement` | `settle` | The operational pause is active. | Wait for the pause to be cleared (`set_paused(false)`) or for the configured max duration to expire. |
+| 212 | `PausedBlocksWithdrawal` | `withdraw` | The operational pause is active. | Same as above. |
+| 213 | `PausedBlocksInvestorClaims` | `claim_investor_payout` | The operational pause is active. | Same as above. |
+
+### Authorization and caller guards
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 200 | `PartialSettleUnauthorizedCaller` | `partial_settle` | `caller` is neither `InvoiceEscrow::sme_address` nor `InvoiceEscrow::admin`. | Pass the SME address or the admin address as `caller` and sign with the matching key. |
+
+### Status guards
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 202 | `PartialSettleNotOpen` | `partial_settle` | `InvoiceEscrow::status != 0` (escrow is not open). | `partial_settle` is only valid while the escrow is still accepting contributions (`status = 0`). Check status before calling. |
+| 121 | `SettlementNotFunded` | `settle` | `InvoiceEscrow::status != 1` (escrow has not reached funded status). | `settle` requires `status = 1`. Fund the escrow to the target (or call `partial_settle`) first. |
+| 124 | `WithdrawalNotFunded` | `withdraw` | `InvoiceEscrow::status != 1`. | `withdraw` requires `status = 1`. Call `settle` before `withdraw` is not the correct sequence — the SME must call `withdraw` while the escrow is in the funded state (`status = 1`), after which `settle` transitions to `status = 2`. Wait for funding to complete first. |
+| 127 | `InvestorClaimNotSettled` | `claim_investor_payout` | `InvoiceEscrow::status != 2`. | Investors may only claim after the escrow has been fully settled. Check `get_escrow().status == 2` before calling. |
+
+### Maturity guard
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 122 | `MaturityNotReached` | `settle` | `InvoiceEscrow::maturity > 0` and the current ledger timestamp is strictly less than `maturity`. | Wait until `env.ledger().timestamp() >= maturity` before calling `settle`. When `maturity == 0` this guard is skipped entirely. |
+
+### Balance and arithmetic guards
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 165 | `InsufficientContractBalance` | `withdraw` | The contract's funding-token balance is less than `InvoiceEscrow::funded_amount`. | Ensure the funding token was transferred into the contract by investors before the SME calls `withdraw`. This check fires if tokens were drained externally or the escrow was never funded via `fund`/`fund_with_commitment`. |
+| 216 | `WithdrawFeeArithmeticOverflow` | `withdraw` | `funded_amount * fee_bps` overflowed `i128` during protocol-fee computation. | This is practically unreachable for compliant escrows: `funded_amount` is bounded by `MAX_INVOICE_AMOUNT` (≤ 2⁶³ − 1) and `fee_bps ∈ [0, 10_000]`, so the product fits in `i128`. If you encounter this, the escrow was initialised with an out-of-range amount or fee. |
+| 217 | `WithdrawNetArithmeticUnderflow` | `withdraw` | `funded_amount - fee` underflowed. | Unreachable for in-range `fee_bps` (0–10 000). Indicates a logic or storage corruption. |
+| 129 | `ComputePayoutArithmeticOverflow` | `settle`, `claim_investor_payout` | Checked arithmetic overflowed while computing `settle_pool` or the investor's gross payout. | Unreachable for compliant escrows whose `funded_amount` is within `MAX_INVOICE_AMOUNT`. Indicates a storage inconsistency. |
+
+### Investor-payout guards
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 126 | `NoContributionToClaim` | `claim_investor_payout` | The investor address has no recorded contribution (`DataKey::InvestorContribution == 0`). | Only investors who funded the escrow via `fund` or `fund_with_commitment` have a claimable payout. Verify contribution with `get_contribution(investor)` before calling. |
+| 128 | `InvestorCommitmentLockNotExpired` | `claim_investor_payout` | The current ledger timestamp is before the investor's `InvestorClaimNotBefore` timestamp (set when the investor used `fund_with_commitment` with a `committed_lock_secs > 0`). | Wait until `env.ledger().timestamp() >= InvestorClaimNotBefore`. Read the lock-expiry time off-chain via `get_investor_claim_not_before(investor)`. |
+| 170 | `PayoutZero` | `claim_investor_payout` | The computed on-chain payout for the investor is zero. | This can occur when `funded_amount` is tiny relative to `total_principal` and floor-rounding produces zero. If you encounter this, the investor's contribution was too small to generate a non-zero payout under the configured yield. |
+
+### SEP-41 token-safety guards (transfer wrapper)
+
+These codes fire inside the `transfer_funding_token_with_balance_checks` wrapper used by `withdraw`
+and `claim_investor_payout`. See [`docs/escrow-token-safety.md`](escrow-token-safety.md) for the
+full threat model.
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 36 | `TransferAmountNotPositive` | `withdraw`, `claim_investor_payout` | The amount passed to the transfer wrapper is ≤ 0. | Internal guard; only reachable via a logic error in the calling entrypoint. |
+| 37 | `InsufficientTokenBalanceBeforeTransfer` | `withdraw`, `claim_investor_payout` | The sender's balance is less than the requested transfer amount immediately before the `transfer` call. | Ensure the contract holds sufficient tokens. Pre-check with `TokenClient::balance`. |
+| 38 | `SenderBalanceUnderflow` | `withdraw`, `claim_investor_payout` | Post-transfer arithmetic detected that the sender's balance decreased by less than expected (underflow in delta). | The token contract behaved unexpectedly. Fee-on-transfer and rebasing tokens are explicitly unsupported. |
+| 39 | `RecipientBalanceUnderflow` | `withdraw`, `claim_investor_payout` | Post-transfer arithmetic detected that the recipient's balance increased by less than expected (underflow in delta). | Same as above. |
+| 40 | `SenderBalanceDeltaMismatch` | `withdraw`, `claim_investor_payout` | The sender spent a different amount than requested (fee-on-transfer token detected). | Use only standard SEP-41 compliant tokens. |
+| 41 | `RecipientBalanceDeltaMismatch` | `withdraw`, `claim_investor_payout` | The recipient received a different amount than requested. | Use only standard SEP-41 compliant tokens. |
+
+---
+
+## Guard-ordering summary
+
+Understanding the order in which guards are evaluated helps predict which code fires when multiple
+conditions are true simultaneously.
+
+### `partial_settle(caller)`
+1. Legal-hold gate → `LegalHoldBlocksPartialSettle` (201)
+2. `caller.require_auth()` — Soroban host auth failure (not a typed `EscrowError`)
+3. Caller identity check → `PartialSettleUnauthorizedCaller` (200)
+4. Status == 0 check → `PartialSettleNotOpen` (202)
+
+### `settle()`
+1. Operational-pause gate → `PausedBlocksSettlement` (211)
+2. Legal-hold gate → `LegalHoldBlocksSettlement` (120)
+3. `sme_address.require_auth()` — Soroban host auth failure
+4. Status == 1 check → `SettlementNotFunded` (121)
+5. Maturity check → `MaturityNotReached` (122)
+6. Payout arithmetic → `ComputePayoutArithmeticOverflow` (129)
+
+### `withdraw()`
+1. Operational-pause gate → `PausedBlocksWithdrawal` (212)
+2. Legal-hold gate → `LegalHoldBlocksWithdrawal` (123)
+3. `sme_address.require_auth()` — Soroban host auth failure
+4. Status == 1 check → `WithdrawalNotFunded` (124)
+5. Contract balance check → `InsufficientContractBalance` (165)
+6. Fee arithmetic → `WithdrawFeeArithmeticOverflow` (216) / `WithdrawNetArithmeticUnderflow` (217)
+7. Token transfers → codes 36–41
+
+### `claim_investor_payout(investor)`
+1. Operational-pause gate → `PausedBlocksInvestorClaims` (213)
+2. Legal-hold gate → `LegalHoldBlocksInvestorClaims` (125)
+3. `investor.require_auth()` — Soroban host auth failure
+4. Contribution > 0 check → `NoContributionToClaim` (126)
+5. Status == 2 check → `InvestorClaimNotSettled` (127)
+6. Commitment-lock check → `InvestorCommitmentLockNotExpired` (128)
+7. Idempotency check (silent no-op if already claimed — no error)
+8. Payout computation → `ComputePayoutArithmeticOverflow` (129)
+9. Payout > 0 check → `PayoutZero` (170)
+10. Token transfer → codes 36–41
+
+---
+
+## Escrow-status reference
+
+| Value | Name | Description |
+| ---: | --- | --- |
+| 0 | Open | Accepting contributions; `partial_settle` valid. |
+| 1 | Funded | Target reached or `partial_settle` called; `settle` and `withdraw` valid. |
+| 2 | Settled | SME called `settle`; investor claims valid. |
+| 3 | Withdrawn | SME called `withdraw`; terminal. |
+| 4 | Cancelled | Admin cancelled; refunds valid. |
+
+---
+
+## Stability policy
+
+All codes listed here are **append-only and will never be renumbered or reassigned**. New
+settlement-related failures will receive new codes at the end of the relevant range. See
+[`docs/escrow-error-messages.md`](escrow-error-messages.md) for the full contract-wide code table.
+
+## See also
+
+- [`docs/escrow-error-messages.md`](escrow-error-messages.md) — full error code table
+- [`docs/escrow-token-safety.md`](escrow-token-safety.md) — SEP-41 token-safety wrapper
+- [`docs/settlement-auth.md`](settlement-auth.md) — authorization boundaries for settlement
+- [`docs/escrow-legal-hold.md`](escrow-legal-hold.md) — legal hold lifecycle
+- [`docs/escrow-ledger-time.md`](escrow-ledger-time.md) — maturity and ledger-time model
+- [`docs/escrow-pro-rata.md`](escrow-pro-rata.md) — pro-rata payout arithmetic
+- [`docs/adr/ADR-003-settlement-flow.md`](adr/ADR-003-settlement-flow.md) — settlement design decisions

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1405,6 +1405,31 @@ pub struct AttestationDigestInfo {
     pub revoked: bool,
 }
 
+/// Read-only configuration snapshot for the attestation subsystem.
+///
+/// Returned by [`LiquifactEscrow::get_attestation_config`]. All fields reflect
+/// the current static constants plus the live runtime state. Returns sensible
+/// defaults (zero counts, `has_primary = false`) when called before `init`.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AttestationConfig {
+    /// Maximum number of entries the append log may hold.
+    /// Equals [`MAX_ATTESTATION_APPEND_ENTRIES`] (32).
+    pub max_append_entries: u32,
+    /// Maximum number of indices that can be revoked in a single batch call.
+    /// Equals [`MAX_ATTESTATION_REVOKE_BATCH`] (32).
+    pub max_revoke_batch: u32,
+    /// Maximum page size for [`LiquifactEscrow::get_revoked_attestation_digests`].
+    /// Equals [`MAX_ATTESTATION_READ_PAGE`] (20).
+    pub max_read_page: u32,
+    /// Number of entries currently in the append log (`0` before any append).
+    pub append_log_len: u32,
+    /// Free slots remaining before the append log hits `max_append_entries`.
+    pub append_log_remaining: u32,
+    /// `true` when [`DataKey::PrimaryAttestationHash`] is set.
+    pub has_primary_hash: bool,
+}
+
 #[contractevent]
 pub struct AllowlistEnabledChanged {
     #[topic]
@@ -2821,6 +2846,28 @@ impl LiquifactEscrow {
 
     pub fn get_attestation_append_log(env: Env) -> Vec<BytesN<32>> {
         Self::load_attestation_log(&env)
+    }
+
+    /// Pure read — no auth, no storage writes, safe for simulation.
+    ///
+    /// Returns an [`AttestationConfig`] snapshot combining the static capacity constants
+    /// with the current runtime state. Calling this before [`LiquifactEscrow::init`] is
+    /// valid and returns zero-count / `false` defaults for all runtime fields.
+    pub fn get_attestation_config(env: Env) -> AttestationConfig {
+        let log = Self::load_attestation_log(&env);
+        let append_log_len = log.len();
+        let has_primary_hash = env
+            .storage()
+            .instance()
+            .has(&DataKey::PrimaryAttestationHash);
+        AttestationConfig {
+            max_append_entries: MAX_ATTESTATION_APPEND_ENTRIES,
+            max_revoke_batch: MAX_ATTESTATION_REVOKE_BATCH,
+            max_read_page: MAX_ATTESTATION_READ_PAGE,
+            append_log_len,
+            append_log_remaining: MAX_ATTESTATION_APPEND_ENTRIES.saturating_sub(append_log_len),
+            has_primary_hash,
+        }
     }
 
     /// Returns the digest and revocation flag at `index`.

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -18,13 +18,14 @@
 )]
 #[allow(unused_imports)]
 use super::{
-    AttestationDigestAppended, AttestationDigestRevoked, AttestationDigestUnrevoked,
-    CollateralRecordedEvt, ContractUpgraded, DataKey, DeprecatedTransferAdminUsed, EscrowError,
-    EscrowFunded, EscrowInitialized, EscrowUnfunded, FundingCancelled, FundingTargetUpdated,
-    InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient, MaturityMaxHorizonUpdated,
-    MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept,
-    YieldResolution, YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT,
-    MAX_FUND_BATCH, SCHEMA_VERSION,
+    AttestationConfig, AttestationDigestAppended, AttestationDigestRevoked,
+    AttestationDigestUnrevoked, CollateralRecordedEvt, ContractUpgraded, DataKey,
+    DeprecatedTransferAdminUsed, EscrowError, EscrowFunded, EscrowInitialized, EscrowUnfunded,
+    FundingCancelled, FundingTargetUpdated, InvestorRefundedEvt, LiquifactEscrow,
+    LiquifactEscrowClient, MaturityMaxHorizonUpdated, MaxUniqueInvestorsCapLowered,
+    PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept, YieldResolution, YieldTier,
+    MAX_ATTESTATION_APPEND_ENTRIES, MAX_ATTESTATION_READ_PAGE, MAX_ATTESTATION_REVOKE_BATCH,
+    MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -1385,3 +1385,420 @@ fn test_double_revoke_no_event_emitted() {
     // Second revoke should panic before event emission
     client.revoke_attestation_digest(&0);
 }
+
+// ---------------------------------------------------------------------------
+// get_attestation_config — read-only config view (issue #880)
+// ---------------------------------------------------------------------------
+
+/// Before init, the config returns the static constants and zero runtime values.
+#[test]
+fn test_get_attestation_config_default_before_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = super::deploy(&env);
+
+    let cfg = client.get_attestation_config();
+    assert_eq!(cfg.max_append_entries, MAX_ATTESTATION_APPEND_ENTRIES);
+    assert_eq!(cfg.max_revoke_batch, MAX_ATTESTATION_REVOKE_BATCH);
+    assert_eq!(cfg.max_read_page, MAX_ATTESTATION_READ_PAGE);
+    assert_eq!(cfg.append_log_len, 0);
+    assert_eq!(cfg.append_log_remaining, MAX_ATTESTATION_APPEND_ENTRIES);
+    assert!(!cfg.has_primary_hash);
+}
+
+/// After init but before any attestation call, runtime fields are still zero.
+#[test]
+fn test_get_attestation_config_after_init_no_attestations() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+
+    let cfg = client.get_attestation_config();
+    assert_eq!(cfg.max_append_entries, MAX_ATTESTATION_APPEND_ENTRIES);
+    assert_eq!(cfg.max_revoke_batch, MAX_ATTESTATION_REVOKE_BATCH);
+    assert_eq!(cfg.max_read_page, MAX_ATTESTATION_READ_PAGE);
+    assert_eq!(cfg.append_log_len, 0);
+    assert_eq!(cfg.append_log_remaining, MAX_ATTESTATION_APPEND_ENTRIES);
+    assert!(!cfg.has_primary_hash);
+}
+
+/// Binding the primary hash flips `has_primary_hash` to `true`.
+#[test]
+fn test_get_attestation_config_has_primary_hash_after_bind() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+
+    assert!(!client.get_attestation_config().has_primary_hash);
+
+    client.bind_primary_attestation_hash(&digest(&env, 0xAA));
+
+    let cfg = client.get_attestation_config();
+    assert!(cfg.has_primary_hash);
+    // Append-log fields unaffected.
+    assert_eq!(cfg.append_log_len, 0);
+    assert_eq!(cfg.append_log_remaining, MAX_ATTESTATION_APPEND_ENTRIES);
+}
+
+/// `append_log_len` and `append_log_remaining` track appends correctly.
+#[test]
+fn test_get_attestation_config_tracks_append_log_length() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+
+    for n in 1u32..=5 {
+        client.append_attestation_digest(&digest(&env, n as u8));
+        let cfg = client.get_attestation_config();
+        assert_eq!(cfg.append_log_len, n);
+        assert_eq!(cfg.append_log_remaining, MAX_ATTESTATION_APPEND_ENTRIES - n);
+    }
+}
+
+/// When the log is full, `append_log_remaining` is zero.
+#[test]
+fn test_get_attestation_config_remaining_zero_when_full() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+
+    for i in 0u8..(MAX_ATTESTATION_APPEND_ENTRIES as u8) {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+
+    let cfg = client.get_attestation_config();
+    assert_eq!(cfg.append_log_len, MAX_ATTESTATION_APPEND_ENTRIES);
+    assert_eq!(cfg.append_log_remaining, 0);
+}
+
+/// Revocation does not alter `append_log_len` or `append_log_remaining`
+/// (revoked entries stay in the log).
+#[test]
+fn test_get_attestation_config_revocation_does_not_change_len() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+
+    client.append_attestation_digest(&digest(&env, 0x10));
+    client.append_attestation_digest(&digest(&env, 0x20));
+    client.revoke_attestation_digest(&0);
+
+    let cfg = client.get_attestation_config();
+    assert_eq!(cfg.append_log_len, 2);
+    assert_eq!(cfg.append_log_remaining, MAX_ATTESTATION_APPEND_ENTRIES - 2);
+}
+
+/// `get_attestation_config` is pure: does not mutate storage, so calling it
+/// multiple times returns identical results.
+#[test]
+fn test_get_attestation_config_idempotent() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+
+    let cfg1 = client.get_attestation_config();
+    let cfg2 = client.get_attestation_config();
+    assert_eq!(cfg1, cfg2);
+}
+
+/// All static-constant fields match the crate-level constants exactly.
+#[test]
+fn test_get_attestation_config_constants_match_crate_values() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+
+    let cfg = client.get_attestation_config();
+    assert_eq!(cfg.max_append_entries, MAX_ATTESTATION_APPEND_ENTRIES);
+    assert_eq!(cfg.max_revoke_batch, MAX_ATTESTATION_REVOKE_BATCH);
+    assert_eq!(cfg.max_read_page, MAX_ATTESTATION_READ_PAGE);
+}
+
+// ---------------------------------------------------------------------------
+// Event topics and payloads — attestation subsystem (issue #881)
+// ---------------------------------------------------------------------------
+//
+// Rules:
+//  - Events are captured from `env.events().all()` immediately after the
+//    emitting call (the buffer holds the latest invocation only).
+//  - Topics are asserted via `symbol_short!` literals.
+//  - Payload fields are asserted individually to catch any drift.
+//  - No two attestation events share a topic symbol.
+
+/// `bind_primary_attestation_hash` emits topic `att_bind` with correct payload.
+#[test]
+fn test_event_bind_primary_attestation_hash_topic_and_payload() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let d = digest(&env, 0xAB);
+    let invoice_id = client.get_escrow().invoice_id;
+
+    client.bind_primary_attestation_hash(&d);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1, "expected exactly one event");
+    let event = events.events().first().unwrap();
+
+    assert_eq!(
+        *event,
+        crate::PrimaryAttestationBound {
+            name: symbol_short!("att_bind"),
+            invoice_id,
+            digest: d,
+        }
+        .to_xdr(&env, &client.address)
+    );
+}
+
+/// `append_attestation_digest` emits topic `att_app` with index and digest.
+#[test]
+fn test_event_append_attestation_digest_topic_and_payload() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let d = digest(&env, 0x12);
+    let invoice_id = client.get_escrow().invoice_id;
+
+    client.append_attestation_digest(&d);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    assert_eq!(
+        *events.events().first().unwrap(),
+        crate::AttestationDigestAppended {
+            name: symbol_short!("att_app"),
+            invoice_id,
+            index: 0,
+            digest: d,
+        }
+        .to_xdr(&env, &client.address)
+    );
+}
+
+/// Index increments correctly across consecutive appends.
+#[test]
+fn test_event_append_index_increments() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let invoice_id = client.get_escrow().invoice_id;
+
+    for i in 0u8..3 {
+        let d = digest(&env, i);
+        client.append_attestation_digest(&d);
+
+        let events = env.events().all();
+        assert_eq!(
+            *events.events().first().unwrap(),
+            crate::AttestationDigestAppended {
+                name: symbol_short!("att_app"),
+                invoice_id: invoice_id.clone(),
+                index: i as u32,
+                digest: d,
+            }
+            .to_xdr(&env, &client.address),
+            "index mismatch at position {i}"
+        );
+    }
+}
+
+/// `revoke_attestation_digest` emits topic `att_rev` with the revoked index.
+#[test]
+fn test_event_revoke_attestation_digest_topic_and_payload() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let invoice_id = client.get_escrow().invoice_id;
+    client.append_attestation_digest(&digest(&env, 0xFF));
+
+    client.revoke_attestation_digest(&0);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    assert_eq!(
+        *events.events().first().unwrap(),
+        crate::AttestationDigestRevoked {
+            name: symbol_short!("att_rev"),
+            invoice_id,
+            index: 0,
+        }
+        .to_xdr(&env, &client.address)
+    );
+}
+
+/// `unrevoke_attestation_digest` emits topic `att_unrev` with the unrevoked index.
+#[test]
+fn test_event_unrevoke_attestation_digest_topic_and_payload() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let invoice_id = client.get_escrow().invoice_id;
+    client.append_attestation_digest(&digest(&env, 0xCC));
+    client.revoke_attestation_digest(&0);
+
+    client.unrevoke_attestation_digest(&0);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 1);
+    assert_eq!(
+        *events.events().first().unwrap(),
+        crate::AttestationDigestUnrevoked {
+            name: symbol_short!("att_unrev"),
+            invoice_id,
+            index: 0,
+        }
+        .to_xdr(&env, &client.address)
+    );
+}
+
+/// `revoke_attestation_digests` (batch) emits one `att_rev` event per index.
+#[test]
+fn test_event_batch_revoke_emits_one_event_per_index() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let invoice_id = client.get_escrow().invoice_id;
+    for i in 0u8..3 {
+        client.append_attestation_digest(&digest(&env, i));
+    }
+
+    let indices = soroban_sdk::vec![&env, 0u32, 1u32, 2u32];
+    client.revoke_attestation_digests(&indices);
+
+    let events = env.events().all();
+    assert_eq!(events.events().len(), 3, "one event per revoked index");
+
+    for (pos, expected_index) in [0u32, 1, 2].iter().enumerate() {
+        assert_eq!(
+            *events.events().get(pos as u32).unwrap(),
+            crate::AttestationDigestRevoked {
+                name: symbol_short!("att_rev"),
+                invoice_id: invoice_id.clone(),
+                index: *expected_index,
+            }
+            .to_xdr(&env, &client.address),
+            "event mismatch at position {pos}"
+        );
+    }
+}
+
+/// No two attestation event topic symbols collide with each other.
+#[test]
+fn test_attestation_event_topics_no_collision() {
+    // Static check: collect topic symbols from each event type and assert uniqueness.
+    // We use the known symbol strings from the contract source.
+    let topics = [
+        symbol_short!("att_bind"),  // PrimaryAttestationBound
+        symbol_short!("att_app"),   // AttestationDigestAppended
+        symbol_short!("att_rev"),   // AttestationDigestRevoked
+        symbol_short!("att_unrev"), // AttestationDigestUnrevoked
+    ];
+
+    // Verify all four are distinct.
+    for i in 0..topics.len() {
+        for j in (i + 1)..topics.len() {
+            assert_ne!(
+                topics[i], topics[j],
+                "topic collision between index {i} and {j}"
+            );
+        }
+    }
+}
+
+/// `bind_primary_attestation_hash` topic `att_bind` is distinct from `att_app`.
+#[test]
+fn test_bind_and_append_events_have_different_topics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let invoice_id = client.get_escrow().invoice_id;
+    let d = digest(&env, 0x01);
+
+    client.bind_primary_attestation_hash(&d);
+    let bind_event = env.events().all().events().first().unwrap().clone();
+
+    client.append_attestation_digest(&digest(&env, 0x02));
+    let append_event = env.events().all().events().first().unwrap().clone();
+
+    assert_ne!(
+        bind_event, append_event,
+        "bind and append events must be distinct"
+    );
+}
+
+/// `revoke_attestation_digest` and `unrevoke_attestation_digest` events are distinct.
+#[test]
+fn test_revoke_and_unrevoke_events_have_different_topics() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+
+    client.revoke_attestation_digest(&0);
+    let revoke_event = env.events().all().events().first().unwrap().clone();
+
+    client.unrevoke_attestation_digest(&0);
+    let unrevoke_event = env.events().all().events().first().unwrap().clone();
+
+    assert_ne!(
+        revoke_event, unrevoke_event,
+        "revoke and unrevoke events must be distinct"
+    );
+}
+
+/// A full round-trip (bind → append → revoke → unrevoke) captures four distinct
+/// events with the correct topic symbols in sequence.
+#[test]
+fn test_attestation_event_round_trip_topics_in_sequence() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    let invoice_id = client.get_escrow().invoice_id;
+
+    // Step 1: bind
+    client.bind_primary_attestation_hash(&digest(&env, 0x01));
+    let bind_evt = env.events().all().events().first().unwrap().clone();
+    assert_eq!(
+        bind_evt,
+        crate::PrimaryAttestationBound {
+            name: symbol_short!("att_bind"),
+            invoice_id: invoice_id.clone(),
+            digest: digest(&env, 0x01),
+        }
+        .to_xdr(&env, &client.address)
+    );
+
+    // Step 2: append
+    client.append_attestation_digest(&digest(&env, 0x02));
+    let app_evt = env.events().all().events().first().unwrap().clone();
+    assert_eq!(
+        app_evt,
+        crate::AttestationDigestAppended {
+            name: symbol_short!("att_app"),
+            invoice_id: invoice_id.clone(),
+            index: 0,
+            digest: digest(&env, 0x02),
+        }
+        .to_xdr(&env, &client.address)
+    );
+
+    // Step 3: revoke
+    client.revoke_attestation_digest(&0);
+    let rev_evt = env.events().all().events().first().unwrap().clone();
+    assert_eq!(
+        rev_evt,
+        crate::AttestationDigestRevoked {
+            name: symbol_short!("att_rev"),
+            invoice_id: invoice_id.clone(),
+            index: 0,
+        }
+        .to_xdr(&env, &client.address)
+    );
+
+    // Step 4: unrevoke
+    client.unrevoke_attestation_digest(&0);
+    let unrev_evt = env.events().all().events().first().unwrap().clone();
+    assert_eq!(
+        unrev_evt,
+        crate::AttestationDigestUnrevoked {
+            name: symbol_short!("att_unrev"),
+            invoice_id: invoice_id.clone(),
+            index: 0,
+        }
+        .to_xdr(&env, &client.address)
+    );
+
+    // All four events are pairwise distinct.
+    let all = [bind_evt, app_evt, rev_evt, unrev_evt];
+    for i in 0..all.len() {
+        for j in (i + 1)..all.len() {
+            assert_ne!(all[i], all[j], "event collision at ({i}, {j})");
+        }
+    }
+}


### PR DESCRIPTION
Closes #879
Closes #880
Closes #881
Closes #884

## #879 — docs/settlement-errors.md
New reference listing every typed EscrowError code emitted by partial_settle, settle,
withdraw, and claim_investor_payout. Sections: legal-hold guards, pause guards,
auth/caller guards, status guards, maturity guard, balance/arithmetic guards,
investor-payout guards, SEP-41 token-safety codes (36–41). Includes guard-ordering
summary per entrypoint and cross-references.

## #884 — docs/attestation-errors.md
New reference listing every typed EscrowError code emitted by bind_primary_attestation_hash,
append_attestation_digest, revoke_attestation_digest, revoke_attestation_digests, and
unrevoke_attestation_digest. Includes guard-ordering, read-only entrypoint table, lifecycle
example, and stability policy.

## #880 — AttestationConfig + get_attestation_config
Added AttestationConfig (#[contracttype]) and get_attestation_config(env) pure-read entrypoint.
Returns static constants (max_append_entries, max_revoke_batch, max_read_page) and runtime
state (append_log_len, append_log_remaining, has_primary_hash). Returns sensible zero/false
defaults before init. No auth, no storage writes.

## #881 — Attestation event-topic and config-view tests (18 new tests)
- get_attestation_config: pre-init defaults, post-init defaults, primary-hash flip, length
  tracking, full-log remaining=0, revocation does not change length, idempotency, constants
  match crate values.
- Event topics/payloads: each emitting entrypoint asserts topic symbol and all payload fields;
  batch revoke asserts one event per index; no-collision check for all four topic symbols;
  bind≠append, revoke≠unrevoke; full round-trip with pairwise-distinct assertion.

## Files changed
| File | Change |
|---|---|
| docs/settlement-errors.md | New — #879 |
| docs/attestation-errors.md | New — #884 |
| escrow/src/lib.rs | AttestationConfig struct + get_attestation_config — #880 |
| escrow/src/tests.rs | Added AttestationConfig, MAX_ATTESTATION_REVOKE_BATCH, MAX_ATTESTATION_READ_PAGE imports |
| escrow/src/tests/attestations.rs | 18 new tests — #881 |
