### PR TITLE
test(collateral): cover auth negative paths

### DIFF
--- a/escrow/src/tests/auth_matrix.rs
+++ b/escrow/src/tests/auth_matrix.rs
@@ -11,6 +11,7 @@
 //! No production-code changes are made here; any guard gap found should be fixed separately.
 use super::*;
 use soroban_sdk::{
+    symbol_short,
     testutils::{Address as _, MockAuth, MockAuthInvoke},
     Address, BytesN, Env, String as SorobanString, Vec as SorobanVec,
 };
@@ -88,4 +89,102 @@ macro_rules! assert_wrong_auth_panics {
             $fn_name
         );
     }};
+}
+
+// ── collateral authorization tests ──────────────────────────────────────────
+
+#[test]
+fn record_sme_collateral_commitment_no_auth_panics() {
+    let env = Env::default();
+    let (client, _admin, _sme, _treasury, _token) = setup_inited(&env);
+
+    assert_no_auth_panics!(env, {
+        client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+    });
+}
+
+#[test]
+fn record_sme_collateral_commitment_wrong_signer_panics() {
+    let env = Env::default();
+    let (client, _admin, _sme, _treasury, _token) = setup_inited(&env);
+    let wrong = Address::generate(&env);
+
+    assert_wrong_auth_panics!(
+        env,
+        wrong,
+        client.address,
+        symbol_short!("record_sme_collateral_commitment"),
+        &[symbol_short!("USDC").to_val(), 5_000i128.to_val()],
+        {
+            client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+        }
+    );
+}
+
+#[test]
+fn clear_sme_collateral_commitment_no_auth_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _sme, _treasury, _token) = setup_inited(&env);
+    client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+
+    assert_no_auth_panics!(env, {
+        client.clear_sme_collateral_commitment();
+    });
+}
+
+#[test]
+fn clear_sme_collateral_commitment_wrong_signer_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _sme, _treasury, _token) = setup_inited(&env);
+    client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+    let wrong = Address::generate(&env);
+
+    assert_wrong_auth_panics!(
+        env,
+        wrong,
+        client.address,
+        symbol_short!("clear_sme_collateral_commitment"),
+        &[],
+        {
+            client.clear_sme_collateral_commitment();
+        }
+    );
+}
+
+#[test]
+fn record_sme_collateral_commitment_admin_cannot_record() {
+    let env = Env::default();
+    let (client, admin, _sme, _treasury, _token) = setup_inited(&env);
+
+    assert_wrong_auth_panics!(
+        env,
+        admin,
+        client.address,
+        symbol_short!("record_sme_collateral_commitment"),
+        &[symbol_short!("USDC").to_val(), 5_000i128.to_val()],
+        {
+            client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+        }
+    );
+}
+
+#[test]
+fn clear_sme_collateral_commitment_admin_cannot_clear() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _sme, _treasury, _token) = setup_inited(&env);
+    client.record_sme_collateral_commitment(&symbol_short!("USDC"), &5_000i128);
+
+    assert_wrong_auth_panics!(
+        env,
+        admin,
+        client.address,
+        symbol_short!("clear_sme_collateral_commitment"),
+        &[],
+        {
+            client.clear_sme_collateral_commitment();
+        }
+    );
 }


### PR DESCRIPTION
## What

Collateral authorization rejections were not fully tested in active test modules. The `auth_matrix.rs` file had helpers and macros but zero test functions. This adds 6 negative-path authorization tests.

## Tests added

| Test | Entrypoint | Auth scenario |
|---|---|---|
| `record_sme_collateral_commitment_no_auth_panics` | record | No auth (empty mock_auths) |
| `record_sme_collateral_commitment_wrong_signer_panics` | record | Random wrong address |
| `clear_sme_collateral_commitment_no_auth_panics` | clear | No auth after recording |
| `clear_sme_collateral_commitment_wrong_signer_panics` | clear | Wrong address after recording |
| `record_sme_collateral_commitment_admin_cannot_record` | record | Admin address (non-SME) |
| `clear_sme_collateral_commitment_admin_cannot_clear` | clear | Admin address (non-SME) |

Each test uses the existing `assert_no_auth_panics!` / `assert_wrong_auth_panics!` macros with `setup_inited()`.

Fixes #926