### PR TITLE
feat: add paginated read view for collateral records

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -99,6 +99,9 @@ pub const MAX_INVESTOR_ALLOWLIST_BATCH: u32 = 32;
 /// Upper bound on [`LiquifactEscrow::get_contributions`] / investor read batch size.
 pub const MAX_INVESTOR_READ_BATCH: u32 = 50;
 
+/// Upper bound on collateral records read page size.
+pub const MAX_COLLATERAL_READ_PAGE: u32 = 50;
+
 /// Upper bound on attestation digest read page size.
 pub const MAX_ATTESTATION_READ_PAGE: u32 = 20;
 
@@ -1797,6 +1800,9 @@ pub enum DataKey {
     /// Optional SME collateral commitment metadata (record-only — not an on-chain asset lock).
     /// Absent when no commitment has been recorded. Replaceable by the SME.
     SmeCollateralPledge,
+    /// Append-only log of SME collateral commitment metadata (record-only).
+    /// Bounded by the pagination ceiling logic; holds historical collateral records.
+    CollateralRecords,
     /// Set to `true` when an investor has exercised a claim after settlement.
     /// **Persistent** storage. Absent ⇒ `false`. Written once; a second claim returns without re-emitting.
     InvestorClaimed(Address),
@@ -5953,6 +5959,16 @@ impl LiquifactEscrow {
             .instance()
             .set(&DataKey::SmeCollateralPledge, &commitment);
 
+        let mut log: Vec<SmeCollateralCommitment> = env
+            .storage()
+            .instance()
+            .get(&DataKey::CollateralRecords)
+            .unwrap_or_else(|| Vec::new(&env));
+        log.push_back(commitment.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::CollateralRecords, &log);
+
         CollateralRecordedEvt {
             name: symbol_short!("coll_rec"),
             invoice_id: escrow.invoice_id.clone(),
@@ -5962,6 +5978,36 @@ impl LiquifactEscrow {
         .publish(&env);
 
         commitment
+    }
+
+    /// Returns a paginated list of all collateral commitments recorded.
+    ///
+    /// # Arguments
+    /// * `start` - The starting index (0-based) of the pagination.
+    /// * `limit` - The maximum number of records to return (capped at [`MAX_COLLATERAL_READ_PAGE`]).
+    ///
+    /// # Returns
+    /// A `Vec<SmeCollateralCommitment>` containing the records within the requested page.
+    pub fn get_collateral_records(env: Env, start: u32, limit: u32) -> Vec<SmeCollateralCommitment> {
+        let log: Vec<SmeCollateralCommitment> = env
+            .storage()
+            .instance()
+            .get(&DataKey::CollateralRecords)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let len = log.len();
+        if start >= len || limit == 0 {
+            return Vec::new(&env);
+        }
+
+        let actual_limit = limit.min(MAX_COLLATERAL_READ_PAGE);
+        let end = (start + actual_limit).min(len);
+
+        let mut result = Vec::new(&env);
+        for i in start..end {
+            result.push_back(log.get(i).unwrap());
+        }
+        result
     }
 
     /// Set or clear compliance hold. Only the **current** [`InvoiceEscrow::admin`] may call.

--- a/escrow/src/tests/paginated_views.rs
+++ b/escrow/src/tests/paginated_views.rs
@@ -551,3 +551,64 @@ fn get_revoked_attestation_digests_continuation_start() {
         soroban_sdk::BytesN::from_array(&env, &[3u8; 32])
     );
 }
+
+// ── get_collateral_records ────────────────────────────────────────────────────
+
+#[test]
+fn get_collateral_records_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_attestation_escrow(&env);
+
+    let result = client.get_collateral_records(&0, &10);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn get_collateral_records_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_attestation_escrow(&env);
+
+    for i in 1..=4 {
+        env.ledger().with_mut(|l| l.timestamp = (i as u64) * 100);
+        client.record_sme_collateral_commitment(&soroban_sdk::Symbol::new(&env, "USDC"), &(i as i128));
+    }
+
+    let result = client.get_collateral_records(&0, &2);
+    assert_eq!(result.len(), 2);
+    assert_eq!(result.get(0).unwrap().amount, 1);
+    assert_eq!(result.get(1).unwrap().amount, 2);
+}
+
+#[test]
+fn get_collateral_records_continuation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_attestation_escrow(&env);
+
+    for i in 1..=4 {
+        env.ledger().with_mut(|l| l.timestamp = (i as u64) * 100);
+        client.record_sme_collateral_commitment(&soroban_sdk::Symbol::new(&env, "USDC"), &(i as i128));
+    }
+
+    let result = client.get_collateral_records(&2, &5);
+    assert_eq!(result.len(), 2);
+    assert_eq!(result.get(0).unwrap().amount, 3);
+    assert_eq!(result.get(1).unwrap().amount, 4);
+}
+
+#[test]
+fn get_collateral_records_ceiling() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup_attestation_escrow(&env);
+
+    for i in 1..=55 {
+        env.ledger().with_mut(|l| l.timestamp = (i as u64) * 100);
+        client.record_sme_collateral_commitment(&soroban_sdk::Symbol::new(&env, "USDC"), &(i as i128));
+    }
+
+    let result = client.get_collateral_records(&0, &100);
+    assert_eq!(result.len(), 50);
+}


### PR DESCRIPTION
Closes #805

## Description

Enumerating collateral records historically required reading all events or iterating off-chain. This PR adds a bounded, paginated read view over collateral records directly in the contract, enforcing shared start/limit bounds, read-only safety, and empty-safe fallbacks.

The `SmeCollateralPledge` behavior was preserved to maintain compatibility, but we introduced a new append-only `CollateralRecords` state array to persist the historical log of SME commitments for pagination.

Closes #805 

---

## Technical Details & Changes Made

- **Pagination Ceiling Enforcement**: Added `MAX_COLLATERAL_READ_PAGE = 50` in `lib.rs` to enforce a maximum page size per-call, preventing gas exhaustion during reads.
- **State Model Update**: Added `DataKey::CollateralRecords` which maintains an append-only `Vec<SmeCollateralCommitment>`.
- **Commitment Persistence**: Updated `record_sme_collateral_commitment` to push new records onto `DataKey::CollateralRecords` while continuing to update the legacy pledge.
- **Paginated Read View**: Implemented `get_collateral_records(env, start, limit)` that correctly bounds slices, respects the pagination ceiling, and ensures empty-safety.
- **Test Coverage**: Added comprehensive unit tests in `escrow/src/tests/paginated_views.rs` verifying:
  - Empty state (`get_collateral_records_empty`)
  - Initial page boundaries (`get_collateral_records_page`)
  - Continuation offsets (`get_collateral_records_continuation`)
  - The 50-item ceiling limit (`get_collateral_records_ceiling`)

---

## Verification Plan

### Automated Verification
Run the contract test suite:
```bash
cargo test --package escrow
```
*Tests added under:* `escrow/src/tests/paginated_views.rs`

### Manual Verification
- Verified compilation cleanliness.
- Verified test suite assertions validate ceiling limits and empty bounds correctly.
