### PR TITLE
feat(funding): add config read view and event topic/payload tests

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1947,6 +1947,37 @@ pub struct EscrowSummary {
     pub attestation_log_length: u32,
 }
 
+/// Read-only snapshot of all funding configuration values.
+///
+/// Returns every governance-set parameter that shapes [`LiquifactEscrow::fund`] /
+/// [`LiquifactEscrow::fund_with_commitment`] / [`LiquifactEscrow::fund_batch`] behavior.
+/// All fields carry sensible defaults so callers can invoke this view before
+/// [`LiquifactEscrow::init`] without a panic.
+#[contracttype]
+#[derive(Debug, PartialEq)]
+pub struct FundingConfig {
+    /// Current funding target; defaults to `0` before init.
+    pub funding_target: i128,
+    /// Base annualized yield in basis points; defaults to `0`.
+    pub yield_bps: i64,
+    /// Maturity ledger timestamp (0 = no maturity lock); defaults to `0`.
+    pub maturity: u64,
+    /// Minimum per-call contribution floor; defaults to `0` (no floor).
+    pub min_contribution_floor: i128,
+    /// Cap on distinct investor addresses; `None` = unlimited.
+    pub max_unique_investors_cap: Option<u32>,
+    /// Per-investor cap on total principal; `None` = unlimited.
+    pub max_per_investor_cap: Option<i128>,
+    /// Optional funding deadline timestamp; `None` = no deadline.
+    pub funding_deadline: Option<u64>,
+    /// Immutable protocol fee in basis points; defaults to `0`.
+    pub protocol_fee_bps: i64,
+    /// Yield-tier ladder; empty `Vec` = no tiering.
+    pub yield_tiers: Vec<YieldTier>,
+    /// Whether the investor allowlist gate is active; defaults to `false`.
+    pub allowlist_active: bool,
+}
+
 // --- Events ---
 
 #[contractevent]
@@ -2751,6 +2782,67 @@ impl LiquifactEscrow {
             sme_collateral_commitment,
             has_primary_attestation: primary_attestation_hash.is_some(),
             attestation_log_length: attestation_append_log.len(),
+        }
+    }
+
+    /// Returns a snapshot of every governance-set funding parameter.
+    ///
+    /// Pure read-only view: no auth, no storage writes. All fields fall back to
+    /// sensible defaults when the escrow has not yet been initialised, so callers
+    /// can invoke this view at any time without a panic.
+    pub fn get_funding_config(env: Env) -> FundingConfig {
+        let escrow: Option<InvoiceEscrow> = env.storage().instance().get(&DataKey::Escrow);
+
+        let (funding_target, yield_bps, maturity) = match &escrow {
+            Some(e) => (e.funding_target, e.yield_bps, e.maturity),
+            None => (0i128, 0i64, 0u64),
+        };
+
+        let min_contribution_floor: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinContributionFloor)
+            .unwrap_or(0);
+
+        let max_unique_investors_cap: Option<u32> = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxUniqueInvestorsCap);
+
+        let max_per_investor_cap: Option<i128> =
+            env.storage().instance().get(&DataKey::MaxPerInvestorCap);
+
+        let funding_deadline: Option<u64> = env.storage().instance().get(&DataKey::FundingDeadline);
+
+        let protocol_fee_bps: i64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProtocolFeeBps)
+            .unwrap_or(0);
+
+        let yield_tiers: Vec<YieldTier> = env
+            .storage()
+            .instance()
+            .get(&DataKey::YieldTierTable)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let allowlist_active: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllowlistActive)
+            .unwrap_or(false);
+
+        FundingConfig {
+            funding_target,
+            yield_bps,
+            maturity,
+            min_contribution_floor,
+            max_unique_investors_cap,
+            max_per_investor_cap,
+            funding_deadline,
+            protocol_fee_bps,
+            yield_tiers,
+            allowlist_active,
         }
     }
 

--- a/escrow/src/storage.rs
+++ b/escrow/src/storage.rs
@@ -1,0 +1,1 @@
+//! Stub module — real definitions live inline in `lib.rs`.

--- a/escrow/src/test.rs
+++ b/escrow/src/test.rs
@@ -1,0 +1,1 @@
+#![allow(unused_imports, dead_code)]

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -20,11 +20,11 @@
 use super::{
     AttestationDigestAppended, AttestationDigestRevoked, AttestationDigestUnrevoked,
     CollateralRecordedEvt, ContractUpgraded, DataKey, DeprecatedTransferAdminUsed, EscrowError,
-    EscrowFunded, EscrowInitialized, EscrowUnfunded, FundingCancelled, FundingTargetUpdated,
-    InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient, MaturityMaxHorizonUpdated,
-    MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept,
-    YieldResolution, YieldTier, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT,
-    MAX_FUND_BATCH, SCHEMA_VERSION,
+    EscrowFunded, EscrowInitialized, EscrowPartialSettle, EscrowUnfunded, FundingCancelled,
+    FundingConfig, FundingTargetUpdated, InvestorRefundedEvt, LiquifactEscrow,
+    LiquifactEscrowClient, MaturityMaxHorizonUpdated, MaxUniqueInvestorsCapLowered,
+    PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept, YieldResolution, YieldTier,
+    MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,
@@ -66,6 +66,8 @@ mod cap_validation;
 mod external_calls;
 mod external_calls_mocked;
 mod funding;
+mod funding_config;
+mod funding_events;
 mod init;
 mod integration;
 mod integration_status_guards;

--- a/escrow/src/tests/funding_config.rs
+++ b/escrow/src/tests/funding_config.rs
@@ -1,0 +1,134 @@
+use super::*;
+
+#[test]
+fn test_funding_config_defaults_before_init() {
+    let env = Env::default();
+    let (client, _admin, _sme) = setup(&env);
+
+    let cfg = client.get_funding_config();
+
+    assert_eq!(cfg.funding_target, 0);
+    assert_eq!(cfg.yield_bps, 0);
+    assert_eq!(cfg.maturity, 0);
+    assert_eq!(cfg.min_contribution_floor, 0);
+    assert_eq!(cfg.max_unique_investors_cap, None);
+    assert_eq!(cfg.max_per_investor_cap, None);
+    assert_eq!(cfg.funding_deadline, None);
+    assert_eq!(cfg.protocol_fee_bps, 0);
+    assert!(cfg.yield_tiers.is_empty());
+    assert!(!cfg.allowlist_active);
+}
+
+#[test]
+fn test_funding_config_after_init() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INVCfg"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &1000u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let cfg = client.get_funding_config();
+
+    assert_eq!(cfg.funding_target, TARGET);
+    assert_eq!(cfg.yield_bps, 800);
+    assert_eq!(cfg.maturity, 1000);
+    assert_eq!(cfg.min_contribution_floor, 0);
+    assert_eq!(cfg.max_unique_investors_cap, None);
+    assert_eq!(cfg.max_per_investor_cap, None);
+    assert_eq!(cfg.funding_deadline, None);
+    assert_eq!(cfg.protocol_fee_bps, 0);
+    assert!(cfg.yield_tiers.is_empty());
+    assert!(!cfg.allowlist_active);
+}
+
+#[test]
+fn test_funding_config_after_target_update() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INVTgt"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let new_target = 50_000_000_000i128;
+    client.update_funding_target(&new_target);
+
+    let cfg = client.get_funding_config();
+    assert_eq!(cfg.funding_target, new_target);
+}
+
+#[test]
+fn test_funding_config_with_caps_and_deadline() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+
+    let deadline = 1_000_000u64;
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INVCap"),
+        &sme,
+        &TARGET,
+        &500i64,
+        &0u64,
+        &Address::generate(&env),
+        &None,
+        &Address::generate(&env),
+        &Some(10i128),
+        &Some(5u32),
+        &Some(500_000i128),
+        &Some(200i64),
+        &None,
+        &None,
+        &Some(deadline),
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let cfg = client.get_funding_config();
+
+    assert_eq!(cfg.funding_target, TARGET);
+    assert_eq!(cfg.yield_bps, 500);
+    assert_eq!(cfg.min_contribution_floor, 10);
+    assert_eq!(cfg.max_unique_investors_cap, Some(5));
+    assert_eq!(cfg.max_per_investor_cap, Some(500_000));
+    assert_eq!(cfg.funding_deadline, Some(deadline));
+    assert_eq!(cfg.protocol_fee_bps, 200);
+    assert!(!cfg.allowlist_active);
+}

--- a/escrow/src/tests/funding_events.rs
+++ b/escrow/src/tests/funding_events.rs
@@ -1,0 +1,342 @@
+use super::*;
+
+use soroban_sdk::testutils::Events as _;
+
+// ---------------------------------------------------------------------------
+// Funding event topic and payload coverage (issue #871)
+//
+// Each test captures events immediately after the emitting call and asserts
+// the topic symbols and payload field values.  The Soroban test host retains
+// only the most recent invocation's event buffer, so we snapshot right after
+// every emitting entrypoint.
+// ---------------------------------------------------------------------------
+
+fn funded_init(
+    env: &Env,
+    client: &LiquifactEscrowClient<'_>,
+    admin: &Address,
+    sme: &Address,
+    invoice: &str,
+) -> (Address, Symbol) {
+    let token = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.init(
+        admin,
+        &soroban_sdk::String::from_str(env, invoice),
+        sme,
+        &TARGET,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    let contract_id = client.address.clone();
+    (token, Symbol::new(env, invoice))
+}
+
+// --- EscrowInitialized ----------------------------------------------------
+
+#[test]
+fn test_escrow_initialized_event_topics_and_payload() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+
+    let token = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let contract_id = client.address.clone();
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INVEvt"),
+        &sme,
+        &TARGET,
+        &800i64,
+        &1000u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    let events = env.events().all();
+    let event = events.events().last().unwrap().clone();
+
+    let expected = EscrowInitialized {
+        name: symbol_short!("escrow_ii"),
+        escrow: client.get_escrow(),
+        funding_token: token,
+        treasury,
+        registry: None,
+        has_maturity_lock: true,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert_eq!(event, expected);
+}
+
+// --- EscrowFunded ---------------------------------------------------------
+
+#[test]
+fn test_escrow_funded_event_topics_and_payload() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+
+    let (token, invoice_id) = funded_init(&env, &client, &admin, &sme, "INVFnd");
+
+    let investor = Address::generate(&env);
+    client.fund(&investor, &TARGET);
+
+    let events = env.events().all();
+    let event = events.events().last().unwrap().clone();
+
+    let expected = EscrowFunded {
+        name: symbol_short!("funded"),
+        invoice_id,
+        investor,
+        amount: TARGET,
+        funded_amount: TARGET,
+        status: 1,
+        investor_effective_yield_bps: 800,
+        tier_lock_secs: 0,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert_eq!(event, expected);
+}
+
+// --- EscrowUnfunded -------------------------------------------------------
+
+#[test]
+fn test_escrow_unfunded_event_topics_and_payload() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+
+    let (_token, invoice_id) = funded_init(&env, &client, &admin, &sme, "INVUfn");
+
+    let investor = Address::generate(&env);
+    let half = TARGET / 2;
+    client.fund(&investor, &half);
+
+    let unfunded = client.unfund(&investor, &half);
+
+    let events = env.events().all();
+    let event = events.events().last().unwrap().clone();
+
+    let expected = EscrowUnfunded {
+        name: symbol_short!("unfund"),
+        invoice_id,
+        investor,
+        amount: half,
+        funded_amount: unfunded.funded_amount,
+        status: unfunded.status,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert_eq!(event, expected);
+}
+
+// --- FundingTargetUpdated -------------------------------------------------
+
+#[test]
+fn test_funding_target_updated_event_topics_and_payload() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+
+    let (_token, invoice_id) = funded_init(&env, &client, &admin, &sme, "INVTgt");
+
+    let new_target = 200_000_000_000i128;
+    client.update_funding_target(&new_target);
+
+    let events = env.events().all();
+    let event = events.events().last().unwrap().clone();
+
+    let expected = FundingTargetUpdated {
+        name: symbol_short!("fund_tgt"),
+        invoice_id,
+        old_target: TARGET,
+        new_target,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert_eq!(event, expected);
+}
+
+// --- FundingCancelled -----------------------------------------------------
+
+#[test]
+fn test_funding_cancelled_event_topics_and_payload() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+
+    let (_token, invoice_id) = funded_init(&env, &client, &admin, &sme, "INVCanc");
+
+    let investor = Address::generate(&env);
+    client.fund(&investor, &(TARGET / 2));
+
+    client.cancel_funding();
+
+    let events = env.events().all();
+    let event = events.events().last().unwrap().clone();
+
+    let expected = FundingCancelled {
+        name: symbol_short!("fund_cn"),
+        invoice_id,
+        funded_amount: TARGET / 2,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert_eq!(event, expected);
+}
+
+// --- EscrowPartialSettle --------------------------------------------------
+
+#[test]
+fn test_escrow_partial_settle_event_topics_and_payload() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+
+    let (_token, invoice_id) = funded_init(&env, &client, &admin, &sme, "INVPstl");
+
+    let investor = Address::generate(&env);
+    client.fund(&investor, &TARGET);
+
+    let partial_amount = TARGET / 4;
+    client.partial_settle(&partial_amount);
+
+    let events = env.events().all();
+    let event = events.events().last().unwrap().clone();
+
+    let expected = EscrowPartialSettle {
+        name: symbol_short!("prtstle"),
+        invoice_id,
+        funded_amount: TARGET,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert_eq!(event, expected);
+}
+
+// --- No topic collision across funding events --------------------------------
+
+#[test]
+fn test_no_funding_event_topic_collision() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+
+    let _ = funded_init(&env, &client, &admin, &sme, "INVColl");
+
+    let investor = Address::generate(&env);
+    client.fund(&investor, &TARGET);
+
+    let funded_events = env.events().all();
+    let funded_event = funded_events.events().last().unwrap().clone();
+
+    client.update_funding_target(&(TARGET * 2));
+
+    let target_events = env.events().all();
+    let target_event = target_events.events().last().unwrap().clone();
+
+    // Both events must exist and not be identical (topics differ).
+    assert_ne!(funded_event, target_event);
+}
+
+// --- Multiple funders, sequential topic integrity ---------------------------
+
+#[test]
+fn test_sequential_funded_events_carry_distinct_investor_topics() {
+    use soroban_sdk::testutils::Events as _;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let contract_id = client.address.clone();
+
+    let (_token, invoice_id) = funded_init(&env, &client, &admin, &sme, "INVMult");
+
+    let inv1 = Address::generate(&env);
+    let inv2 = Address::generate(&env);
+    let half = TARGET / 2;
+
+    client.fund(&inv1, &half);
+    let events1 = env.events().all();
+    let event1 = events1.events().last().unwrap().clone();
+
+    client.fund(&inv2, &half);
+    let events2 = env.events().all();
+    let event2 = events2.events().last().unwrap().clone();
+
+    let expected1 = EscrowFunded {
+        name: symbol_short!("funded"),
+        invoice_id: invoice_id.clone(),
+        investor: inv1,
+        amount: half,
+        funded_amount: half,
+        status: 0,
+        investor_effective_yield_bps: 800,
+        tier_lock_secs: 0,
+    }
+    .to_xdr(&env, &contract_id);
+
+    let expected2 = EscrowFunded {
+        name: symbol_short!("funded"),
+        invoice_id,
+        investor: inv2,
+        amount: half,
+        funded_amount: TARGET,
+        status: 1,
+        investor_effective_yield_bps: 800,
+        tier_lock_secs: 0,
+    }
+    .to_xdr(&env, &contract_id);
+
+    assert_eq!(event1, expected1);
+    assert_eq!(event2, expected2);
+
+    // Events differ because investor topic differs.
+    assert_ne!(expected1, expected2);
+}

--- a/escrow/src/types.rs
+++ b/escrow/src/types.rs
@@ -1,0 +1,1 @@
+//! Stub module — real definitions live inline in `lib.rs`.


### PR DESCRIPTION
Closes #870 
Closes #871

#870 — Read-only funding configuration view
What
Adds FundingConfig (contracttype) and get_funding_config() — a pure read-only view that returns every governance-set funding parameter in a single host invocation.
Field	Type	Default before init
funding_target	i128	0
yield_bps	i64	0
maturity	u64	0
min_contribution_floor	i128	0
max_unique_investors_cap	Option<u32>	None
max_per_investor_cap	Option<i128>	None
funding_deadline	Option<u64>	None
protocol_fee_bps	i64	0
yield_tiers	Vec<YieldTier>	[]
allowlist_active	bool	false
No auth required. No storage writes. Sensible defaults before init.
Tests (tests/funding_config.rs):
- Pre-init defaults are all zeroed/None/empty
- Post-init reflects the values passed to init
- update_funding_target is reflected in the view
- Caps, fee, and deadline set at init are returned correctly
#871 — Funding event topic and payload coverage
What
Adds tests/funding_events.rs that captures events immediately after each emitting call and asserts topic symbols and payload field values.
Covered events:
Event	Topics asserted	Payload asserted
EscrowInitialized	escrow_ii	escrow snapshot, funding_token, treasury, registry, has_maturity_lock
EscrowFunded	funded, invoice_id, investor	amount, funded_amount, status, investor_effective_yield_bps, tier_lock_secs
EscrowUnfunded	unfund, invoice_id, investor	amount, funded_amount, status
FundingTargetUpdated	fund_tgt, invoice_id	old_target, new_target
FundingCancelled	fund_cn, invoice_id	funded_amount
EscrowPartialSettle	prtstle, invoice_id	funded_amount
Edge-case tests:
- No topic collision across different event types
- Sequential fund calls carry distinct investor topics, producing non-identical events
Implementation notes
- FundingConfig struct added after EscrowSummary in the second (canonical) type-definition block
- get_funding_config() reads all keys with .get().unwrap_or(default) for pre-init safety
- Stub files (storage.rs, types.rs, test.rs) added to resolve pre-existing missing-module errors; empty, behavior-neutra