### PR TITLE
feat: resolve #885 #892 #893 #896

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -446,6 +446,11 @@ pub enum EscrowError {
     /// [`LiquifactEscrow::unfund`] blocked because a compliance/legal hold is active.
     /// No fund movement is permitted until the hold is cleared by the admin.
     UnfundLegalHoldActive = 222,
+
+    /// [`LiquifactEscrow::set_yield_tiers`] received a table that violates
+    /// the required invariants (non-negative bps, non-decreasing yields,
+    /// strictly increasing lock times, non-empty).
+    YieldTierTableInvalid = 223,
 }
 
 #[inline(always)]
@@ -1988,6 +1993,21 @@ pub struct EscrowSummary {
     pub attestation_log_length: u32,
 }
 
+/// Bundled read-only snapshot of the collateral subsystem returned by
+/// [`LiquifactEscrow::get_collateral_config`].
+///
+/// Combines the admin-configured collateral limit and the current SME
+/// collateral commitment metadata into a single struct so integrators
+/// can fetch both values in one host invocation.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CollateralConfig {
+    /// Maximum collateral amount the admin has configured (defaults to [`MAX_INVOICE_AMOUNT`]).
+    pub collateral_limit: i128,
+    /// The recorded SME collateral commitment, or `None` if never recorded.
+    pub sme_commitment: CollateralCommitmentSnapshot,
+}
+
 // --- Events ---
 
 #[contractevent]
@@ -2250,6 +2270,17 @@ pub struct ContractUpgraded {
     #[topic]
     pub invoice_id: Symbol,
     pub new_wasm_hash: BytesN<32>,
+}
+
+/// Emitted by [`LiquifactEscrow::set_yield_tiers`] when the admin successfully
+/// replaces the yield-tier table.
+#[contractevent]
+pub struct YieldTierTableUpdated {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub tier_count: u32,
 }
 
 #[contract]
@@ -3154,6 +3185,44 @@ impl LiquifactEscrow {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
+    /// Resolve the effective yield and matched lock for a first-deposit commitment.
+    ///
+    /// Scans the yield-tier table (highest tier first) for the best qualifying
+    /// entry where `min_lock_secs <= lock`. Returns a [`YieldTierPreview`]
+    /// with the tier's `yield_bps` and `min_lock_secs`, or the escrow base
+    /// `yield_bps` with `matched_lock_secs = 0` when no tier qualifies.
+    pub(crate) fn effective_yield_for_commitment(
+        env: &Env,
+        base_yield_bps: i64,
+        lock: u64,
+    ) -> YieldTierPreview {
+        let tiers: Vec<YieldTier> = env
+            .storage()
+            .instance()
+            .get::<DataKey, Vec<YieldTier>>(&DataKey::YieldTierTable)
+            .unwrap_or_else(|| Vec::new(env));
+
+        let mut best_bps = base_yield_bps;
+        let mut best_lock = 0u64;
+
+        let len = tiers.len();
+        let mut i = len;
+        while i > 0 {
+            i -= 1;
+            let tier = tiers.get(i).unwrap();
+            if tier.min_lock_secs <= lock {
+                best_bps = tier.yield_bps;
+                best_lock = tier.min_lock_secs;
+                break;
+            }
+        }
+
+        YieldTierPreview {
+            effective_yield_bps: best_bps,
+            matched_lock_secs: best_lock,
+        }
+    }
+
     /// Pure read — no auth, no storage writes, safe for simulation.
     ///
     /// Returns a [`YieldTierPreview`] for a hypothetical contribution of
@@ -3174,14 +3243,60 @@ impl LiquifactEscrow {
     /// > **Note:** this preview reflects the rule applied at **first deposit only**. A
     /// > follow-on [`LiquifactEscrow::fund`] call does not re-select a tier.
     pub fn preview_yield_tier(env: Env, amount: i128, lock: u64) -> YieldTierPreview {
-        let _ = amount; // accepted for signature parity with fund_with_commitment; unused in lock-only selection
+        let _ = amount;
         let escrow = Self::get_escrow(env.clone());
-        let (effective_yield_bps, matched_lock_secs) =
-            Self::effective_yield_for_commitment(&env, escrow.yield_bps, lock);
-        YieldTierPreview {
-            effective_yield_bps,
-            matched_lock_secs,
+        Self::effective_yield_for_commitment(&env, escrow.yield_bps, lock)
+    }
+
+    /// Admin-only setter that replaces the yield-tier table.
+    ///
+    /// Validates invariants identical to `init`:
+    ///   - Every `yield_bps` must be `>= 0` and `<= 10_000`.
+    ///   - Lock times must be strictly increasing.
+    ///   - Yield `bps` must be non-decreasing across tiers.
+    ///   - The table must be non-empty.
+    ///
+    /// Emits [`YieldTierTableUpdated`] on success.
+    pub fn set_yield_tiers(env: Env, tiers: Vec<YieldTier>) {
+        let escrow = Self::load_escrow_require_admin(&env);
+        let n = tiers.len();
+        ensure(&env, n > 0, EscrowError::YieldTierTableInvalid);
+
+        let mut prev_lock: u64 = 0;
+        let mut prev_bps: i64 = -1;
+
+        for i in 0..n {
+            let tier = tiers.get(i).unwrap();
+            ensure(&env, tier.yield_bps >= 0, EscrowError::YieldTierTableInvalid);
+            ensure(
+                &env,
+                tier.yield_bps <= 10_000,
+                EscrowError::YieldTierTableInvalid,
+            );
+            ensure(
+                &env,
+                tier.min_lock_secs > prev_lock,
+                EscrowError::YieldTierTableInvalid,
+            );
+            ensure(
+                &env,
+                tier.yield_bps >= prev_bps,
+                EscrowError::YieldTierTableInvalid,
+            );
+            prev_lock = tier.min_lock_secs;
+            prev_bps = tier.yield_bps;
         }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::YieldTierTable, &tiers);
+
+        YieldTierTableUpdated {
+            name: symbol_short!("yt_upd"),
+            invoice_id: escrow.invoice_id.clone(),
+            tier_count: n,
+        }
+        .publish(&env);
     }
 
     /// Retrieve the currently recorded SME collateral commitment metadata from storage.
@@ -3195,6 +3310,25 @@ impl LiquifactEscrow {
             .instance()
             .get(&DataKey::CollateralLimit)
             .unwrap_or(MAX_INVOICE_AMOUNT)
+    }
+
+    /// Read-only snapshot of the collateral subsystem: admin limit + current SME
+    /// commitment. Returns sensible defaults (max limit, no commitment) before
+    /// `init` is called.
+    pub fn get_collateral_config(env: Env) -> CollateralConfig {
+        let collateral_limit: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CollateralLimit)
+            .unwrap_or(MAX_INVOICE_AMOUNT);
+        let sme_commitment = match Self::collateral_pledge_get(&env) {
+            Some(c) => CollateralCommitmentSnapshot::Some(c),
+            None => CollateralCommitmentSnapshot::None,
+        };
+        CollateralConfig {
+            collateral_limit,
+            sme_commitment,
+        }
     }
 
     /// Retire the recorded SME collateral pledge.
@@ -3703,6 +3837,14 @@ impl LiquifactEscrow {
             allowed: if allowed { 1 } else { 0 },
         }
         .publish(&env);
+
+        let total_count: u32 = index.len();
+        AllowlistStateChanged {
+            name: symbol_short!("al_st"),
+            invoice_id: escrow.invoice_id.clone(),
+            total_count,
+        }
+        .publish(&env);
     }
 
     /// Batch add or remove investors from the allowlist.
@@ -3767,6 +3909,14 @@ impl LiquifactEscrow {
             }
             .publish(&env);
         }
+
+        let total_count: u32 = index.len();
+        AllowlistStateChanged {
+            name: symbol_short!("al_st"),
+            invoice_id: escrow.invoice_id.clone(),
+            total_count,
+        }
+        .publish(&env);
     }
 
     pub fn is_investor_allowlisted(env: Env, investor: Address) -> bool {
@@ -4573,9 +4723,9 @@ impl LiquifactEscrow {
             }
         } else {
             ensure(&env, prev == 0, EscrowError::TieredSecondDeposit);
-            let (eff, lock) =
+            let tier =
                 Self::effective_yield_for_commitment(&env, escrow.yield_bps, committed_lock_secs);
-            Self::set_persistent_investor_effective_yield(&env, investor.clone(), eff);
+            Self::set_persistent_investor_effective_yield(&env, investor.clone(), tier.effective_yield_bps);
             let now = env.ledger().timestamp();
             let claim_nb = if committed_lock_secs == 0 {
                 0u64
@@ -4583,8 +4733,6 @@ impl LiquifactEscrow {
                 now.checked_add(committed_lock_secs)
                     .unwrap_or_else(|| fail(&env, EscrowError::InvestorClaimTimeOverflow))
             };
-            // Bound: reject if the claim lock would expire after the escrow maturity.
-            // Only constrained when both committed_lock_secs > 0 and maturity > 0.
             if claim_nb > 0 && escrow.maturity > 0 {
                 ensure(
                     &env,
@@ -4593,7 +4741,7 @@ impl LiquifactEscrow {
                 );
             }
             Self::set_persistent_investor_claim_not_before(&env, investor.clone(), claim_nb);
-            (eff, lock)
+            (tier.effective_yield_bps, tier.matched_lock_secs)
         };
 
         escrow.funded_amount = escrow
@@ -6505,11 +6653,11 @@ impl LiquifactEscrow {
             // If prev > 0, preserve existing effective yield and claim lock
         } else {
             ensure(&env, prev == 0, EscrowError::TieredSecondDeposit);
-            let (eff, lock) =
+            let tier =
                 Self::effective_yield_for_commitment(&env, escrow.yield_bps, committed_lock_secs);
-            investor_effective_yield_bps = eff;
-            tier_lock_secs = lock;
-            Self::set_persistent_investor_effective_yield(&env, investor.clone(), eff);
+            investor_effective_yield_bps = tier.effective_yield_bps;
+            tier_lock_secs = tier.matched_lock_secs;
+            Self::set_persistent_investor_effective_yield(&env, investor.clone(), tier.effective_yield_bps);
             let now = env.ledger().timestamp();
             let claim_nb = if committed_lock_secs == 0 {
                 0u64

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -18,12 +18,14 @@
 )]
 #[allow(unused_imports)]
 use super::{
-    AttestationDigestAppended, AttestationDigestRevoked, AttestationDigestUnrevoked,
+    AllowlistEnabledChanged, AllowlistStateChanged, AttestationDigestAppended,
+    AttestationDigestRevoked, AttestationDigestUnrevoked, CollateralConfig,
     CollateralRecordedEvt, ContractUpgraded, DataKey, DeprecatedTransferAdminUsed, EscrowError,
     EscrowFunded, EscrowInitialized, EscrowUnfunded, FundingCancelled, FundingTargetUpdated,
-    InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient, MaturityMaxHorizonUpdated,
-    MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept,
-    YieldTier, MAX_ATTESTATION_APPEND_BATCH, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT,
+    InvestorAllowlistChanged, InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient,
+    MaturityMaxHorizonUpdated, MaxUniqueInvestorsCapLowered, PrimaryAttestationBound,
+    RegistryRefRebound, TreasuryDustSwept, YieldTier, YieldTierTableUpdated,
+    MAX_ATTESTATION_APPEND_BATCH, MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT,
     MAX_FUND_BATCH, SCHEMA_VERSION,
 };
 use soroban_sdk::{
@@ -78,6 +80,11 @@ mod properties;
 mod reconciliation_lifecycle;
 mod settlement;
 mod yield_tier_overflow;
+
+mod collateral_config_view;
+mod yield_tier_setter;
+mod yield_tier_struct;
+mod allowlist_event_payloads;
 
 /// Registers a new escrow contract instance and returns its contract id.
 pub fn deploy_id(env: &Env) -> Address {

--- a/escrow/src/tests/allowlist_event_payloads.rs
+++ b/escrow/src/tests/allowlist_event_payloads.rs
@@ -1,0 +1,233 @@
+use super::super::{
+    AllowlistEnabledChanged, AllowlistStateChanged, InvestorAllowlistChanged, LiquifactEscrow,
+    LiquifactEscrowClient,
+};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events},
+    Address, Env, Event, Vec as SorobanVec,
+};
+
+fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
+    let id = env.register(LiquifactEscrow, ());
+    LiquifactEscrowClient::new(env, &id)
+}
+
+fn init_escrow(env: &Env, client: &LiquifactEscrowClient) -> (Address, Address) {
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let token = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, "ALEVT001"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    (admin, sme)
+}
+
+#[test]
+fn test_allowlist_enabled_changed_topics_and_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
+
+    client.set_allowlist_active(&true);
+    let events = env.events().all();
+
+    let expected = AllowlistEnabledChanged {
+        name: symbol_short!("al_ena"),
+        invoice_id,
+        active: 1,
+    };
+    assert!(events.contains(&expected.to_xdr(&env, &contract_id)));
+}
+
+#[test]
+fn test_allowlist_disabled_changed_topics_and_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
+
+    client.set_allowlist_active(&true);
+    client.set_allowlist_active(&false);
+    let events = env.events().all();
+
+    let enabled = AllowlistEnabledChanged {
+        name: symbol_short!("al_ena"),
+        invoice_id: invoice_id.clone(),
+        active: 1,
+    };
+    let disabled = AllowlistEnabledChanged {
+        name: symbol_short!("al_ena"),
+        invoice_id,
+        active: 0,
+    };
+    assert!(events.contains(&enabled.to_xdr(&env, &contract_id)));
+    assert!(events.contains(&disabled.to_xdr(&env, &contract_id)));
+}
+
+#[test]
+fn test_investor_allowlist_changed_add_and_remove() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
+    let investor = Address::generate(&env);
+
+    client.set_investor_allowlisted(&investor, &true);
+    let events = env.events().all();
+
+    let added = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id: invoice_id.clone(),
+        investor: investor.clone(),
+        allowed: 1,
+    };
+    assert!(events.contains(&added.to_xdr(&env, &contract_id)));
+}
+
+#[test]
+fn test_investor_allowlist_changed_remove_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
+    let investor = Address::generate(&env);
+
+    client.set_investor_allowlisted(&investor, &true);
+    client.set_investor_allowlisted(&investor, &false);
+    let events = env.events().all();
+
+    let removed = InvestorAllowlistChanged {
+        name: symbol_short!("al_set"),
+        invoice_id,
+        investor,
+        allowed: 0,
+    };
+    assert!(events.contains(&removed.to_xdr(&env, &contract_id)));
+}
+
+#[test]
+fn test_allowlist_state_changed_batch_add() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(a);
+    batch.push_back(b);
+
+    client.set_allowlist_active(&true);
+    client.set_investors_allowlisted(&batch, &true);
+    let events = env.events().all();
+
+    let expected = AllowlistStateChanged {
+        name: symbol_short!("al_st"),
+        invoice_id,
+        total_count: 2,
+    };
+    assert!(events.contains(&expected.to_xdr(&env, &contract_id)));
+}
+
+#[test]
+fn test_allowlist_state_changed_single_add() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
+    let investor = Address::generate(&env);
+
+    client.set_investor_allowlisted(&investor, &true);
+    let events = env.events().all();
+
+    let expected = AllowlistStateChanged {
+        name: symbol_short!("al_st"),
+        invoice_id,
+        total_count: 1,
+    };
+    assert!(events.contains(&expected.to_xdr(&env, &contract_id)));
+}
+
+#[test]
+fn test_allowlist_state_changed_after_remove() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
+    let investor = Address::generate(&env);
+
+    client.set_investor_allowlisted(&investor, &true);
+    client.set_investor_allowlisted(&investor, &false);
+    let events = env.events().all();
+
+    let expected = AllowlistStateChanged {
+        name: symbol_short!("al_st"),
+        invoice_id,
+        total_count: 0,
+    };
+    assert!(events.contains(&expected.to_xdr(&env, &contract_id)));
+}
+
+#[test]
+fn test_allowlist_state_changed_batch_remove() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let mut batch: SorobanVec<Address> = SorobanVec::new(&env);
+    batch.push_back(a);
+    batch.push_back(b);
+
+    client.set_investors_allowlisted(&batch, &true);
+    client.set_investors_allowlisted(&batch, &false);
+    let events = env.events().all();
+
+    let expected = AllowlistStateChanged {
+        name: symbol_short!("al_st"),
+        invoice_id,
+        total_count: 0,
+    };
+    assert!(events.contains(&expected.to_xdr(&env, &contract_id)));
+}

--- a/escrow/src/tests/collateral_config_view.rs
+++ b/escrow/src/tests/collateral_config_view.rs
@@ -1,0 +1,76 @@
+use super::super::{CollateralConfig, CollateralCommitmentSnapshot, LiquifactEscrow, LiquifactEscrowClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
+    let id = env.register(LiquifactEscrow, ());
+    LiquifactEscrowClient::new(env, &id)
+}
+
+fn init_escrow(env: &Env, client: &LiquifactEscrowClient) -> (Address, Address) {
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let token = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, "COLCFG01"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    (admin, sme)
+}
+
+#[test]
+fn test_collateral_config_defaults_before_init() {
+    let env = Env::default();
+    let client = deploy(&env);
+
+    let config = client.get_collateral_config();
+    assert_eq!(config.collateral_limit, super::super::MAX_INVOICE_AMOUNT);
+    assert_eq!(config.sme_commitment, CollateralCommitmentSnapshot::None);
+}
+
+#[test]
+fn test_collateral_config_after_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, sme) = init_escrow(&env, &client);
+
+    let config = client.get_collateral_config();
+    assert_eq!(config.collateral_limit, super::super::MAX_INVOICE_AMOUNT);
+    assert_eq!(config.sme_commitment, CollateralCommitmentSnapshot::None);
+}
+
+#[test]
+fn test_collateral_config_matches_individual_getters() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, sme) = init_escrow(&env, &client);
+
+    let config = client.get_collateral_config();
+    let limit = client.get_collateral_limit();
+    let commitment = client.get_sme_collateral_commitment();
+
+    assert_eq!(config.collateral_limit, limit);
+    match commitment {
+        Some(c) => assert_eq!(config.sme_commitment, CollateralCommitmentSnapshot::Some(c)),
+        None => assert_eq!(config.sme_commitment, CollateralCommitmentSnapshot::None),
+    }
+}

--- a/escrow/src/tests/yield_tier_setter.rs
+++ b/escrow/src/tests/yield_tier_setter.rs
@@ -1,0 +1,203 @@
+use super::super::{
+    EscrowError, LiquifactEscrow, LiquifactEscrowClient, YieldTier, YieldTierTableUpdated,
+};
+use super::super::tests::assert_contract_error;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events},
+    Address, Env, Event, Vec as SorobanVec,
+};
+
+fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
+    let id = env.register(LiquifactEscrow, ());
+    LiquifactEscrowClient::new(env, &id)
+}
+
+fn init_escrow(env: &Env, client: &LiquifactEscrowClient) -> (Address, Address) {
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let token = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, "YTTSET01"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    (admin, sme)
+}
+
+fn make_tier(env: &Env, lock: u64, bps: i64) -> YieldTier {
+    YieldTier {
+        min_lock_secs: lock,
+        yield_bps: bps,
+    }
+}
+
+#[test]
+fn test_set_yield_tiers_and_read_back() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 200));
+    tiers.push_back(make_tier(&env, 604_800, 500));
+
+    client.set_yield_tiers(&tiers);
+
+    let read_back = client.get_yield_tiers();
+    assert_eq!(read_back.len(), 2);
+    assert_eq!(read_back.get_unchecked(0), tiers.get_unchecked(0));
+    assert_eq!(read_back.get_unchecked(1), tiers.get_unchecked(1));
+}
+
+#[test]
+#[should_panic]
+fn test_set_yield_tiers_requires_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 200));
+
+    env.mock_auths(&[]);
+    client.set_yield_tiers(&tiers);
+}
+
+#[test]
+fn test_set_yield_tiers_rejects_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    assert_contract_error(
+        client.try_set_yield_tiers(&tiers),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn test_set_yield_tiers_rejects_negative_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, -1));
+
+    assert_contract_error(
+        client.try_set_yield_tiers(&tiers),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn test_set_yield_tiers_rejects_bps_over_10000() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 10_001));
+
+    assert_contract_error(
+        client.try_set_yield_tiers(&tiers),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn test_set_yield_tiers_rejects_non_increasing_locks() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 200));
+    tiers.push_back(make_tier(&env, 86_400, 300));
+
+    assert_contract_error(
+        client.try_set_yield_tiers(&tiers),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn test_set_yield_tiers_rejects_decreasing_yields() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 300));
+    tiers.push_back(make_tier(&env, 604_800, 200));
+
+    assert_contract_error(
+        client.try_set_yield_tiers(&tiers),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn test_set_yield_tiers_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+    let invoice_id = client.get_escrow().invoice_id;
+    let contract_id = client.address.clone();
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 200));
+    tiers.push_back(make_tier(&env, 604_800, 500));
+
+    client.set_yield_tiers(&tiers);
+    let events = env.events().all();
+
+    let expected = YieldTierTableUpdated {
+        name: symbol_short!("yt_upd"),
+        invoice_id,
+        tier_count: 2,
+    };
+    assert!(events.contains(&expected.to_xdr(&env, &contract_id)));
+}
+
+#[test]
+fn test_set_yield_tiers_accepts_max_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 10_000));
+
+    client.set_yield_tiers(&tiers);
+    let read_back = client.get_yield_tiers();
+    assert_eq!(read_back.len(), 1);
+    assert_eq!(read_back.get_unchecked(0).yield_bps, 10_000);
+}

--- a/escrow/src/tests/yield_tier_struct.rs
+++ b/escrow/src/tests/yield_tier_struct.rs
@@ -1,0 +1,121 @@
+use super::super::{LiquifactEscrow, LiquifactEscrowClient, YieldTier, YieldTierPreview};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, Vec as SorobanVec};
+
+fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
+    let id = env.register(LiquifactEscrow, ());
+    LiquifactEscrowClient::new(env, &id)
+}
+
+fn init_escrow(env: &Env, client: &LiquifactEscrowClient) -> (Address, Address) {
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let token = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, "YTPREV01"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    (admin, sme)
+}
+
+fn make_tier(env: &Env, lock: u64, bps: i64) -> YieldTier {
+    YieldTier {
+        min_lock_secs: lock,
+        yield_bps: bps,
+    }
+}
+
+#[test]
+fn test_preview_yield_tier_returns_struct() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let result: YieldTierPreview = client.preview_yield_tier(&1_000i128, &0u64);
+    assert_eq!(result.effective_yield_bps, 800);
+    assert_eq!(result.matched_lock_secs, 0);
+}
+
+#[test]
+fn test_preview_yield_tier_matches_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 200));
+    tiers.push_back(make_tier(&env, 604_800, 500));
+    client.set_yield_tiers(&tiers);
+
+    let result = client.preview_yield_tier(&1_000i128, &604_800u64);
+    assert_eq!(result.effective_yield_bps, 500);
+    assert_eq!(result.matched_lock_secs, 604_800);
+}
+
+#[test]
+fn test_preview_yield_tier_picks_highest_qualifying() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 200));
+    tiers.push_back(make_tier(&env, 604_800, 500));
+    client.set_yield_tiers(&tiers);
+
+    let result = client.preview_yield_tier(&1_000i128, &1_000_000u64);
+    assert_eq!(result.effective_yield_bps, 500);
+    assert_eq!(result.matched_lock_secs, 604_800);
+}
+
+#[test]
+fn test_preview_yield_tier_falls_back_to_base_when_no_tier_qualifies() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 200));
+    client.set_yield_tiers(&tiers);
+
+    let result = client.preview_yield_tier(&1_000i128, &10u64);
+    assert_eq!(result.effective_yield_bps, 800);
+    assert_eq!(result.matched_lock_secs, 0);
+}
+
+#[test]
+fn test_preview_yield_tier_zero_lock_falls_back_to_base() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let (admin, _) = init_escrow(&env, &client);
+
+    let mut tiers: SorobanVec<YieldTier> = SorobanVec::new(&env);
+    tiers.push_back(make_tier(&env, 86_400, 200));
+    client.set_yield_tiers(&tiers);
+
+    let result = client.preview_yield_tier(&1_000i128, &0u64);
+    assert_eq!(result.effective_yield_bps, 800);
+    assert_eq!(result.matched_lock_secs, 0);
+}


### PR DESCRIPTION

## Summary

Closes #885 Add CollateralConfig struct and get_collateral_config() read-only view
  - Bundles collateral_limit and sme_commitment into a single snapshot
  - Returns sensible defaults before init

Closes #892 Return typed YieldTierPreview struct from effective_yield_for_commitment
  - Define effective_yield_for_commitment returning YieldTierPreview (not tuple)
  - Update preview_yield_tier, fund_with_commitment, partial_settle call sites

Closes #893 Add admin setter for yield-tier parameters with bounds validation
  - set_yield_tiers: admin-only, validates non-negative bps <= 10_000, strictly increasing locks, non-decreasing yields, non-empty table
  - YieldTierTableInvalid error variant (223)
  - YieldTierTableUpdated event on success

Closes #896 Emit AllowlistStateChanged event with total_count payload
  - Emitted from set_investor_allowlisted and set_investors_allowlisted
  - Tests verify event topics and payloads for all three allowlist events