### PR TITLE
refactor(fees): extract validation helper

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -590,6 +590,27 @@ pub(crate) fn ensure(env: &Env, condition: bool, error: EscrowError) {
     }
 }
 
+/// Validate that a `protocol_fee_bps` value lies within the valid basis-points range `0..=10_000`.
+///
+/// Returns `Ok(())` if valid, or `Err(EscrowError::ProtocolFeeBpsOutOfRange)` if out of range.
+#[inline(always)]
+pub(crate) fn check_protocol_fee_bps(protocol_fee_bps: i64) -> Result<(), EscrowError> {
+    if (0..=10_000).contains(&protocol_fee_bps) {
+        Ok(())
+    } else {
+        Err(EscrowError::ProtocolFeeBpsOutOfRange)
+    }
+}
+
+/// Validate that a `protocol_fee_bps` value is within `0..=10_000`, panicking with
+/// [`EscrowError::ProtocolFeeBpsOutOfRange`] if invalid.
+#[inline(always)]
+pub(crate) fn validate_protocol_fee_bps(env: &Env, protocol_fee_bps: i64) {
+    if let Err(err) = check_protocol_fee_bps(protocol_fee_bps) {
+        fail(env, err);
+    }
+}
+
 /// Assert that `actual_status == expected_status`, emitting `error` otherwise.
 ///
 /// This is the shared primitive used by all status gate helpers. Callers that need a
@@ -1842,11 +1863,7 @@ impl LiquifactEscrow {
         // 0..=10_000 envelope as `yield_bps`; `10_000` routes the entire `funded_amount` to the
         // treasury at withdrawal. See `docs/escrow-numeric-model.md` for the split math.
         let protocol_fee_bps = protocol_fee_bps.unwrap_or(0);
-        ensure(
-            &env,
-            (0..=10_000).contains(&protocol_fee_bps),
-            EscrowError::ProtocolFeeBpsOutOfRange,
-        );
+        validate_protocol_fee_bps(&env, protocol_fee_bps);
         ensure(
             &env,
             !env.storage().instance().has(&DataKey::Escrow),

--- a/escrow/src/tests/init.rs
+++ b/escrow/src/tests/init.rs
@@ -2206,3 +2206,37 @@ fn test_invoice_id_matches_event_payload_with_registry_present() {
         "event escrow.invoice_id must round-trip to the original string (registry present)"
     );
 }
+
+#[test]
+fn test_check_protocol_fee_bps_valid_and_invalid_bounds() {
+    use crate::{check_protocol_fee_bps, EscrowError};
+
+    assert_eq!(check_protocol_fee_bps(0), Ok(()));
+    assert_eq!(check_protocol_fee_bps(5_000), Ok(()));
+    assert_eq!(check_protocol_fee_bps(10_000), Ok(()));
+
+    assert_eq!(
+        check_protocol_fee_bps(-1),
+        Err(EscrowError::ProtocolFeeBpsOutOfRange)
+    );
+    assert_eq!(
+        check_protocol_fee_bps(10_001),
+        Err(EscrowError::ProtocolFeeBpsOutOfRange)
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_validate_protocol_fee_bps_panics_on_negative_bps() {
+    use crate::validate_protocol_fee_bps;
+    let env = Env::default();
+    validate_protocol_fee_bps(&env, -1);
+}
+
+#[test]
+#[should_panic]
+fn test_validate_protocol_fee_bps_panics_on_exceeding_max_bps() {
+    use crate::validate_protocol_fee_bps;
+    let env = Env::default();
+    validate_protocol_fee_bps(&env, 10_001);
+}


### PR DESCRIPTION
Extract repeated protocol fee basis-points validation into shared helper functions check_protocol_fee_bps and validate_protocol_fee_bps, reusing them in LiquifactEscrow::init. Fixes #1034.