### PR TITLE
[1009] Extract settlement validation into a helper

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -730,6 +730,50 @@ pub(crate) fn validate_maturity_bounds(env: &Env, maturity: u64, max_horizon: u6
     );
 }
 
+/// Predicate: `true` when there is no maturity lock (`maturity == 0`) or the ledger timestamp
+/// has reached the configured maturity (`now >= maturity`, inclusive boundary).
+///
+/// Centralises the maturity-reached comparison used by [`LiquifactEscrow::settle`],
+/// [`LiquifactEscrow::is_settleable`], and [`LiquifactEscrow::get_settlement_readiness`] so the
+/// settlement gate cannot drift across call sites.
+///
+/// # Notes
+/// Pure function aside from the ledger timestamp read. No storage access.
+#[inline(always)]
+pub(crate) fn is_maturity_reached(env: &Env, maturity: u64) -> bool {
+    maturity == 0 || env.ledger().timestamp() >= maturity
+}
+
+/// Shared guard: assert escrow is in funded status (`status == 1`) and settlement maturity has
+/// been reached.
+///
+/// Replaces the repeated inline pattern in [`LiquifactEscrow::settle`]:
+/// ```ignore
+/// ensure(&env, escrow.status == 1, EscrowError::SettlementNotFunded);
+/// if escrow.maturity > 0 {
+///     ensure(&env, now >= escrow.maturity, EscrowError::MaturityNotReached);
+/// }
+/// ```
+///
+/// Does **not** check pause or legal hold — entrypoints compose those gates separately per
+/// ADR-002.
+///
+/// # Errors
+/// - [`EscrowError::SettlementNotFunded`] when `escrow.status != 1`.
+/// - [`EscrowError::MaturityNotReached`] when `maturity > 0` and
+///   [`is_maturity_reached`] is `false`.
+#[inline(always)]
+pub(crate) fn validate_settlement_state(env: &Env, escrow: &InvoiceEscrow) {
+    guard_status_eq(env, escrow.status, 1, EscrowError::SettlementNotFunded);
+    if escrow.maturity > 0 {
+        ensure(
+            env,
+            is_maturity_reached(env, escrow.maturity),
+            EscrowError::MaturityNotReached,
+        );
+    }
+}
+
 // --- Storage keys ---
 
 #[contracttype]
@@ -2960,13 +3004,7 @@ impl LiquifactEscrow {
             return false;
         }
         let escrow = Self::get_escrow(env.clone());
-        if escrow.status != 1 {
-            return false;
-        }
-        if escrow.maturity > 0 && env.ledger().timestamp() < escrow.maturity {
-            return false;
-        }
-        true
+        escrow.status == 1 && is_maturity_reached(env, escrow.maturity)
     }
 
     /// Returns `true` when [`LiquifactEscrow::settle`] would succeed for the current ledger state.
@@ -2999,7 +3037,7 @@ impl LiquifactEscrow {
     pub fn get_settlement_readiness(env: Env) -> SettlementReadiness {
         let legal_hold_active = Self::legal_hold_active(&env);
         let escrow = Self::get_escrow(env.clone());
-        let maturity_reached = escrow.maturity == 0 || env.ledger().timestamp() >= escrow.maturity;
+        let maturity_reached = is_maturity_reached(&env, escrow.maturity);
 
         // Reuse the single-source-of-truth gate so this view cannot drift from `settle`.
         let is_settleable = Self::settleable_now(&env);
@@ -4288,16 +4326,9 @@ impl LiquifactEscrow {
         // env.clone(): env is used again after this call for ledger timestamp, storage set, and publish.
         let mut escrow = Self::load_escrow_require_sme(&env);
 
-        ensure(&env, escrow.status == 1, EscrowError::SettlementNotFunded);
+        validate_settlement_state(&env, &escrow);
 
         let now = env.ledger().timestamp();
-        if escrow.maturity > 0 {
-            ensure(
-                &env,
-                now >= escrow.maturity,
-                EscrowError::MaturityNotReached,
-            );
-        }
 
         // Compute settle_pool using the same arithmetic as compute_investor_payout.
         // coupon = funded_amount × yield_bps / 10_000  (floor)

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -4020,3 +4020,143 @@ fn refactor_gate_helpers_rotate_blocked_post_settlement() {
         EscrowError::RotationNotOpen,
     );
 }
+
+// =============================================================================
+// Settlement validation helper parity tests (issue #1009)
+//
+// Asserts that `is_maturity_reached` and `validate_settlement_state` are
+// behaviour-preserving replacements for the inline settlement checks that
+// previously appeared in `settle`, `settleable_now`, and
+// `get_settlement_readiness`.
+// =============================================================================
+
+/// Pure-function boundary coverage for `is_maturity_reached`: vacuous reach when
+/// `maturity == 0`, and inclusive `>=` at the configured maturity timestamp.
+#[test]
+fn settlement_validation_maturity_reached_predicate_boundaries() {
+    let env = Env::default();
+
+    assert!(
+        crate::is_maturity_reached(&env, 0),
+        "maturity == 0 must be vacuously reached"
+    );
+
+    let maturity: u64 = 10_000;
+    env.ledger().with_mut(|l| l.timestamp = maturity - 1);
+    assert!(
+        !crate::is_maturity_reached(&env, maturity),
+        "one second before maturity must not be reached"
+    );
+
+    env.ledger().with_mut(|l| l.timestamp = maturity);
+    assert!(
+        crate::is_maturity_reached(&env, maturity),
+        "exact maturity boundary must be inclusive"
+    );
+
+    env.ledger().with_mut(|l| l.timestamp = maturity + 1);
+    assert!(
+        crate::is_maturity_reached(&env, maturity),
+        "after maturity must be reached"
+    );
+}
+
+/// Confirms `validate_settlement_state` still emits the documented typed errors
+/// through `settle` after the refactor.
+#[test]
+fn settlement_validation_helper_preserves_settle_error_variants() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Open escrow → SettlementNotFunded
+    let (open, _a, _s) = init_open(&env, "SV_OPEN");
+    assert_contract_error(open.try_settle(), EscrowError::SettlementNotFunded);
+
+    // Funded but pre-maturity → MaturityNotReached
+    let maturity: u64 = 20_000;
+    let client = super::deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = super::free_addresses(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "SV_MAT"),
+        &sme,
+        &super::TARGET,
+        &0i64,
+        &maturity,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let investor = Address::generate(&env);
+    client.fund(&investor, &super::TARGET);
+    env.ledger().with_mut(|l| l.timestamp = maturity - 1);
+    assert_contract_error(client.try_settle(), EscrowError::MaturityNotReached);
+
+    // At maturity → succeeds
+    env.ledger().with_mut(|l| l.timestamp = maturity);
+    let settled = client.settle();
+    assert_eq!(settled.status, 2);
+}
+
+/// Confirms `get_settlement_readiness().maturity_reached` stays aligned with
+/// `is_maturity_reached` after the helper extraction.
+#[test]
+fn settlement_validation_readiness_maturity_reached_matches_predicate() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let maturity: u64 = 15_000;
+    let client = super::deploy(&env);
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let (token, treasury) = super::free_addresses(&env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "SV_RDY"),
+        &sme,
+        &super::TARGET,
+        &0i64,
+        &maturity,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    let investor = Address::generate(&env);
+    client.fund(&investor, &super::TARGET);
+
+    env.ledger().with_mut(|l| l.timestamp = maturity - 1);
+    let pre = client.get_settlement_readiness();
+    assert_eq!(
+        pre.maturity_reached,
+        crate::is_maturity_reached(&env, maturity)
+    );
+    assert!(!pre.maturity_reached);
+
+    env.ledger().with_mut(|l| l.timestamp = maturity);
+    let at = client.get_settlement_readiness();
+    assert_eq!(
+        at.maturity_reached,
+        crate::is_maturity_reached(&env, maturity)
+    );
+    assert!(at.maturity_reached);
+}


### PR DESCRIPTION
## Summary

- Extracts repeated settlement validation into two shared helpers:
  - `is_maturity_reached` — predicate for inclusive maturity boundary (`maturity == 0` or `now >= maturity`)
  - `validate_settlement_state` — guard emitting `SettlementNotFunded` / `MaturityNotReached`
- Routes `settle`, `settleable_now`, and `get_settlement_readiness` through the helpers so settlement gates cannot drift across call sites.
- Adds parity tests covering maturity boundaries, typed error preservation, and readiness view alignment.

Closes #1009

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`

```
test result: ok. 851 passed; 0 failed; 54 ignored; 0 measured; 0 filtered out; finished in 344.98s
```

New tests:
- `settlement_validation_maturity_reached_predicate_boundaries`
- `settlement_validation_helper_preserves_settle_error_variants`
- `settlement_validation_readiness_maturity_reached_matches_predicate`


Made with [Cursor](https://cursor.com)