### PR TITLE
feat(escrow-summary): add paused flag and protocol fee to EscrowSummary

### DIFF
--- a/docs/escrow-data-model.md
+++ b/docs/escrow-data-model.md
@@ -143,14 +143,18 @@ pub struct EscrowSummary {
     pub sme_collateral_commitment: Option<SmeCollateralCommitment>,
     pub has_primary_attestation: bool,
     pub attestation_log_length: u32,
+    pub paused: bool,
+    pub protocol_fee_bps: i64,
 }
 ```
 
 - `sme_collateral_commitment` — pulled from `DataKey::SmeCollateralPledge`; `None` when never recorded.
 - `has_primary_attestation` — `true` when `DataKey::PrimaryAttestationHash` is present.
 - `attestation_log_length` — length of the `Vec` stored at `DataKey::AttestationAppendLog`; `0` when absent.
+- `paused` — read from `DataKey::Paused` (same key as `is_paused()`); `false` when never paused.
+- `protocol_fee_bps` — read from `DataKey::ProtocolFeeBps` (same key as `get_protocol_fee_bps()`); `0` for pre-fee instances.
 
-Legacy instances (no collateral or attestation keys) return `None` / `false` / `0` respectively,
+Legacy instances (no collateral, attestation, or fee keys) return `None` / `false` / `0` respectively,
 per the additive-key policy.
 
 ### `SmeCollateralCommitment` (stored at `DataKey::SmeCollateralPledge`)

--- a/docs/escrow-read-api.md
+++ b/docs/escrow-read-api.md
@@ -125,6 +125,10 @@ Bundles multiple read-only values in a single host invocation, optimizing read l
 - `sme_collateral_commitment: CollateralCommitmentSnapshot` — Custom option-like enum (`None` or `Some(SmeCollateralCommitment)`).
 - `has_primary_attestation: bool` — Primary attestation binding status.
 - `attestation_log_length: u32` — Number of append-log entries.
+- `paused: bool` — Operational pause flag; mirrors `is_paused()`. Reads `false` for instances that have never been paused.
+- `protocol_fee_bps: i64` — Configured protocol fee in basis points; mirrors `get_protocol_fee_bps()`. Reads `0` for pre-fee instances.
+
+The `paused` and `protocol_fee_bps` fields are read from the same storage keys (`DataKey::Paused`, `DataKey::ProtocolFeeBps`) as their standalone getters, so the summary can never drift from `is_paused()` / `get_protocol_fee_bps()`.
 
 ---
 

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1218,6 +1218,12 @@ pub struct EscrowSummary {
     pub has_primary_attestation: bool,
     /// Number of entries in the attestation append log.
     pub attestation_log_length: u32,
+    /// Whether the lightweight operational pause is active, mirroring
+    /// [`LiquifactEscrow::is_paused`]. Reads `false` for instances that have never been paused.
+    pub paused: bool,
+    /// Immutable protocol fee in basis points, mirroring
+    /// [`LiquifactEscrow::get_protocol_fee_bps`]. Reads `0` for pre-fee instances.
+    pub protocol_fee_bps: i64,
 }
 
 /// Bundled settlement-readiness snapshot returned by
@@ -2770,6 +2776,10 @@ impl LiquifactEscrow {
 
     /// Bundles multiple read-only values to return a comprehensive summary of the escrow state
     /// in a single host invocation.
+    ///
+    /// The `paused` and `protocol_fee_bps` fields are read from the **same** storage keys as the
+    /// standalone [`LiquifactEscrow::is_paused`] and [`LiquifactEscrow::get_protocol_fee_bps`]
+    /// views, so the summary can never drift from those getters.
     pub fn get_escrow_summary(env: Env) -> EscrowSummary {
         let escrow = Self::get_escrow(env.clone());
         let legal_hold = Self::get_legal_hold(env.clone());
@@ -2780,6 +2790,8 @@ impl LiquifactEscrow {
         let sme_collateral_commitment = Self::get_sme_collateral_commitment(env.clone());
         let primary_attestation_hash = Self::get_primary_attestation_hash(env.clone());
         let attestation_append_log = Self::get_attestation_append_log(env.clone());
+        let paused = Self::is_paused(env.clone());
+        let protocol_fee_bps = Self::get_protocol_fee_bps(env.clone());
 
         let funding_close_snapshot = match funding_close_snapshot_opt {
             Some(snap) => EscrowCloseSnapshot::Some(snap),
@@ -2802,6 +2814,8 @@ impl LiquifactEscrow {
             sme_collateral_commitment,
             has_primary_attestation: primary_attestation_hash.is_some(),
             attestation_log_length: attestation_append_log.len(),
+            paused,
+            protocol_fee_bps,
         }
     }
 

--- a/escrow/src/tests/coverage.rs
+++ b/escrow/src/tests/coverage.rs
@@ -2549,6 +2549,11 @@ fn test_get_escrow_summary_happy_path() {
     );
     assert!(!summary.has_primary_attestation);
     assert_eq!(summary.attestation_log_length, 0);
+    // No fee supplied at init and never paused ⇒ additive-key defaults.
+    assert_eq!(summary.paused, client.is_paused());
+    assert_eq!(summary.protocol_fee_bps, client.get_protocol_fee_bps());
+    assert!(!summary.paused);
+    assert_eq!(summary.protocol_fee_bps, 0);
 }
 
 #[test]
@@ -2722,6 +2727,65 @@ fn test_get_escrow_summary_with_collateral_and_attestations() {
     // Verify attestation fields
     assert!(summary.has_primary_attestation);
     assert_eq!(summary.attestation_log_length, 2);
+}
+
+/// The summary's `paused` field must track `set_paused` toggles, and its
+/// `protocol_fee_bps` field must reflect the immutable init-time fee. Both are read from
+/// the same storage keys as `is_paused()` / `get_protocol_fee_bps()`, so they can never
+/// drift from the standalone views.
+#[test]
+fn test_get_escrow_summary_tracks_pause_and_protocol_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, sme) = setup(&env);
+    let (funding_token, treasury) = free_addresses(&env);
+
+    // Initialize with a non-default, immutable protocol fee of 250 bps.
+    let fee_bps: i64 = 250;
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "INV_PAUSE_FEE"),
+        &sme,
+        &1000,
+        &100,
+        &100,
+        &funding_token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &Some(fee_bps),
+    );
+
+    // Fee mirrors the init-time value and the standalone getter from the start.
+    let summary = client.get_escrow_summary();
+    assert_eq!(summary.protocol_fee_bps, fee_bps);
+    assert_eq!(summary.protocol_fee_bps, client.get_protocol_fee_bps());
+
+    // Never paused yet ⇒ false, matching is_paused().
+    assert!(!summary.paused);
+    assert_eq!(summary.paused, client.is_paused());
+
+    // Activate the operational pause; summary must now report paused == true.
+    client.set_paused(&true);
+    let summary = client.get_escrow_summary();
+    assert!(summary.paused);
+    assert_eq!(summary.paused, client.is_paused());
+    // The immutable fee is unaffected by pause toggles.
+    assert_eq!(summary.protocol_fee_bps, fee_bps);
+
+    // Clear the pause; summary tracks the flag back to false.
+    client.set_paused(&false);
+    let summary = client.get_escrow_summary();
+    assert!(!summary.paused);
+    assert_eq!(summary.paused, client.is_paused());
+    assert_eq!(summary.protocol_fee_bps, fee_bps);
 }
 
 #[test]


### PR DESCRIPTION
Closes #654 

# PR: Add `paused` and `protocol_fee_bps` to `EscrowSummary`

**Branch:** `enhancement/contracts-summary-pause-fee`
**Commit:** `feat(escrow-summary): add paused flag and protocol fee to EscrowSummary`
**Diff:** 4 files, +87 / −1

---

## Summary

Extends `EscrowSummary` with two new read-only fields — `paused` (bool) and `protocol_fee_bps` (i64) — so the bundled summary view returns a complete operational snapshot in a single host invocation, eliminating the need for separate `is_paused()` and `get_protocol_fee_bps()` calls by indexers and clients.

Both fields are read from the **same storage keys** (`DataKey::Paused`, `DataKey::ProtocolFeeBps`) as their standalone getters, guaranteeing the summary can never drift from those views.

---

## Changes

### A. `escrow/src/lib.rs` — struct + builder

| Item | Detail |
|---|---|
| `EscrowSummary` struct | Two new fields: `paused: bool`, `protocol_fee_bps: i64` |
| `get_escrow_summary()` | Populates the new fields via `Self::is_paused()` and `Self::get_protocol_fee_bps()` |
| Doc comments | NatSpec `///` on both fields + `get_escrow_summary` updated to document storage-key identity |

### B. `docs/escrow-data-model.md` — data-model docs

- Adds field descriptions for `paused` and `protocol_fee_bps`.
- Updates the additive-key policy sentence to mention fee keys.

### C. `docs/escrow-read-api.md` — read-API docs

- Documents the two new fields in the `EscrowSummary` response.
- Adds a note that the fields mirror the standalone storage keys.

### D. `escrow/src/tests/coverage.rs` — new test

`test_get_escrow_summary_tracks_pause_and_protocol_fee` verifies:

1. After `init` with a non-default `protocol_fee_bps` (250 bps), the summary reports the correct fee and `paused == false`.
2. After `set_paused(true)`, `summary.paused == true` and matches `is_paused()`.
3. After `set_paused(false)`, `summary.paused == false` and matches `is_paused()`.
4. `protocol_fee_bps` remains unchanged through pause toggles (immutable at init).

The existing `test_get_escrow_summary_happy_path` is also updated to assert the additive-key defaults (`paused == false`, `protocol_fee_bps == 0`) for instances without fee/pause keys.

---

## Backward Compatibility

| Concern | Status |
|---|---|
| Schema version | Unchanged — `EscrowSummary` is a view struct, not part of the on-chain schema hash |
| New storage keys | None — reuses `DataKey::Paused` and `DataKey::ProtocolFeeBps` |
| Existing tests | All pass; happy-path test updated to cover new fields |
| SDK / indexer surface | Additive — new fields appear in existing `get_escrow_summary` response |

---

## Verification

```bash
cd escrow
cargo fmt --all -- --check
cargo build
cargo test --lib
```

## Reviewer Checklist

- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo build` clean
- [ ] `cargo test --lib` passes (all prior + new test)
- [ ] New fields use the same storage keys as `is_paused()` / `get_protocol_fee_bps()`
- [ ] Doc updates in `docs/escrow-data-model.md` and `docs/escrow-read-api.md` are accurate
