### PR TITLE
docs(attestation): add state diagram

### DIFF
--- a/docs/attestation-states.md
+++ b/docs/attestation-states.md
@@ -1,0 +1,50 @@
+# Attestation State Machine
+
+This document outlines the state machine for attestations within the Liquifact escrow contract. Attestations are managed through two distinct mechanisms: the **Primary Attestation Hash** (single-set) and the **Attestation Append Log** (append-only with revocation).
+
+## 1. Primary Attestation Hash
+
+The `PrimaryAttestationHash` is a single-set, immutable off-chain attestation digest (e.g., SHA-256 of a legal or KYC bundle) that can only be written once by an administrator.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Unbound : Default State (Absent)
+    
+    Unbound --> Bound : bind_primary_attestation_hash
+    
+    note right of Bound
+        Immutable. 
+        Cannot be altered or revoked.
+    end note
+```
+
+### Enforcing Entrypoints
+- **`LiquifactEscrow::bind_primary_attestation_hash`**: Transitions the state from `Unbound` (absent) to `Bound`. If called when the state is already `Bound`, the contract rejects the transaction with a `PrimaryAttestationAlreadyBound` error.
+
+---
+
+## 2. Attestation Append Log
+
+The `AttestationAppendLog` provides an append-only audit chain of digests. Individual digests inside the log can be explicitly revoked, but the log itself cannot be shortened or deleted. The size of the log is bounded by `MAX_ATTESTATION_APPEND_ENTRIES`.
+
+```mermaid
+stateDiagram-v2
+    [*] --> NonExistent : Before Append
+    
+    NonExistent --> Appended : append_attestation_digest(s)
+    
+    Appended --> Revoked : revoke_attestation_digest(s)
+    
+    note right of Revoked
+        Terminal state.
+        Cannot be un-revoked.
+    end note
+```
+
+### Enforcing Entrypoints
+- **`LiquifactEscrow::append_attestation_digest`** / **`append_attestation_digests`**: 
+  Transitions a new digest from `NonExistent` to `Appended`. The new digest is placed at the next available index in the log. If the log reaches `MAX_ATTESTATION_APPEND_ENTRIES`, it rejects the transaction with `AttestationAppendLogCapacityReached`.
+- **`LiquifactEscrow::revoke_attestation_digest`** / **`revoke_attestation_digests`**: 
+  Transitions an `Appended` digest to `Revoked` by setting the `AttestationRevoked(index)` DataKey. 
+  - If the index is out of bounds, it rejects with `AttestationIndexOutOfRange`.
+  - If the digest is already revoked, it rejects with `AttestationAlreadyRevoked`.


### PR DESCRIPTION
Closes #1016

 Attestation States Diagram
I have successfully added the requested documentation covering the state diagram and entrypoint cross-references for attestation in the Liquifact-contracts repository!

What Changed
1. Created docs/attestation-states.md
I created a detailed markdown file inside the docs/ folder explicitly explaining the state machine for both the Primary Attestation Hash and the Attestation Append Log.

2. State Diagrams (Mermaid)
I embedded interactive Mermaid graphs into the documentation:

The Primary Attestation diagram highlights the Unbound to Bound transition, visually emphasizing that it is immutable once bound.
The Append Log diagram traces the lifecycle of individual digests from NonExistent into Appended/Active and ultimately into an irreversible Revoked state.
3. Entrypoint Cross-Referencing
I mapped out exactly which smart contract entrypoints enforce these state transitions and constraints:

bind_primary_attestation_hash
append_attestation_digest(s)
revoke_attestation_digest(s) I also clearly documented the boundary limits, such as MAX_ATTESTATION_APPEND_ENTRIES and the specific errors emitted when states are violated (e.g., AttestationAlreadyRevoked).