### PR TITLE
test(yield-tier): add boundary tests

### DIFF
--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -220,3 +220,5 @@ pub fn init_and_fund_with_real_token<'a>(
 
     (client, escrow_id, sme)
 }
+
+mod yield_tier_boundaries;

--- a/escrow/src/tests/yield_tier_boundaries.rs
+++ b/escrow/src/tests/yield_tier_boundaries.rs
@@ -1,0 +1,212 @@
+//! Bounded boundary coverage for yield-tier validation and selection.
+//!
+//! The production code currently has no explicit upper bound on tier-table
+//! length. A 64-entry probe records that gap without creating an unbounded run.
+//! It also accepts a first tier with `min_lock_secs == 0`, although selection
+//! short-circuits lock zero to the base yield, making that tier unreachable at
+//! its exact threshold.
+
+use super::{assert_contract_error, deploy, LiquifactEscrowClient, TARGET};
+use crate::{EscrowError, YieldTier};
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec as SorobanVec};
+
+const BOUNDED_TIER_COUNT_PROBE: u32 = 64;
+
+fn tier(min_lock_secs: u64, yield_bps: i64) -> YieldTier {
+    YieldTier {
+        min_lock_secs,
+        yield_bps,
+    }
+}
+
+fn init_with_tiers<'a>(
+    env: &'a Env,
+    base_yield_bps: i64,
+    tiers: Option<SorobanVec<YieldTier>>,
+) -> LiquifactEscrowClient<'a> {
+    env.mock_all_auths();
+    let client = deploy(env);
+    client.init(
+        &Address::generate(env),
+        &String::from_str(env, "YTBOUND"),
+        &Address::generate(env),
+        &TARGET,
+        &base_yield_bps,
+        &0u64,
+        &Address::generate(env),
+        &None,
+        &Address::generate(env),
+        &tiers,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    client
+}
+
+fn assert_init_error(
+    env: &Env,
+    base_yield_bps: i64,
+    tiers: SorobanVec<YieldTier>,
+    expected: EscrowError,
+) {
+    env.mock_all_auths();
+    let client = deploy(env);
+    let result = client.try_init(
+        &Address::generate(env),
+        &String::from_str(env, "YTERROR"),
+        &Address::generate(env),
+        &TARGET,
+        &base_yield_bps,
+        &0u64,
+        &Address::generate(env),
+        &None,
+        &Address::generate(env),
+        &Some(tiers),
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+    assert_contract_error(result, expected);
+}
+
+#[test]
+fn test_yield_bps_accepts_zero_and_max_boundaries() {
+    for yield_bps in [0, 10_000] {
+        let env = Env::default();
+        let tiers = SorobanVec::from_array(&env, [tier(1, yield_bps)]);
+        let client = init_with_tiers(&env, 0, Some(tiers));
+
+        assert_eq!(
+            client.get_yield_tiers().get_unchecked(0).yield_bps,
+            yield_bps
+        );
+    }
+}
+
+#[test]
+fn test_yield_bps_rejects_just_outside_range_with_typed_error() {
+    for yield_bps in [-1, 10_001] {
+        let env = Env::default();
+        let tiers = SorobanVec::from_array(&env, [tier(1, yield_bps)]);
+
+        assert_init_error(&env, 0, tiers, EscrowError::TierYieldOutOfRange);
+    }
+}
+
+#[test]
+fn test_yield_bps_rejects_just_below_base_with_typed_error() {
+    let env = Env::default();
+    let tiers = SorobanVec::from_array(&env, [tier(1, 799)]);
+
+    assert_init_error(&env, 800, tiers, EscrowError::TierYieldBelowBase);
+}
+
+#[test]
+fn test_lock_boundaries_accept_zero_and_u64_max() {
+    let env = Env::default();
+    let tiers = SorobanVec::from_array(&env, [tier(0, 100), tier(u64::MAX, 10_000)]);
+    let client = init_with_tiers(&env, 0, Some(tiers));
+
+    let stored = client.get_yield_tiers();
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored.get_unchecked(0).min_lock_secs, 0);
+    assert_eq!(stored.get_unchecked(1).min_lock_secs, u64::MAX);
+
+    assert_eq!(client.preview_yield_tier(&1i128, &0u64), (0, 0));
+    assert_eq!(
+        client.preview_yield_tier(&1i128, &u64::MAX),
+        (10_000, u64::MAX)
+    );
+}
+
+#[test]
+fn test_lock_order_rejects_equal_and_decreasing_boundaries() {
+    for second_lock in [10, 9] {
+        let env = Env::default();
+        let tiers = SorobanVec::from_array(&env, [tier(10, 100), tier(second_lock, 200)]);
+
+        assert_init_error(&env, 0, tiers, EscrowError::TierLockNotIncreasing);
+    }
+}
+
+#[test]
+fn test_yield_order_rejects_decrease_with_typed_error() {
+    let env = Env::default();
+    let tiers = SorobanVec::from_array(&env, [tier(1, 500), tier(2, 499)]);
+
+    assert_init_error(&env, 0, tiers, EscrowError::TierYieldNotNonDecreasing);
+}
+
+#[test]
+fn test_tier_table_accepts_zero_and_single_entry_lengths() {
+    let empty_env = Env::default();
+    let empty = SorobanVec::new(&empty_env);
+    let empty_client = init_with_tiers(&empty_env, 0, Some(empty));
+    assert_eq!(empty_client.get_yield_tiers().len(), 0);
+
+    let single_env = Env::default();
+    let single = SorobanVec::from_array(&single_env, [tier(1, 0)]);
+    let single_client = init_with_tiers(&single_env, 0, Some(single));
+    assert_eq!(single_client.get_yield_tiers().len(), 1);
+}
+
+#[test]
+fn test_tier_table_has_no_explicit_length_cap_bounded_probe() {
+    let env = Env::default();
+    let mut tiers = SorobanVec::new(&env);
+    for index in 0..BOUNDED_TIER_COUNT_PROBE {
+        tiers.push_back(tier(u64::from(index) + 1, 800));
+    }
+
+    let client = init_with_tiers(&env, 800, Some(tiers));
+
+    assert_eq!(client.get_yield_tiers().len(), BOUNDED_TIER_COUNT_PROBE);
+}
+
+#[test]
+fn test_preview_selection_uses_bounded_boundary_matrix() {
+    let env = Env::default();
+    let tiers = SorobanVec::from_array(
+        &env,
+        [
+            tier(1, 100),
+            tier(10, 200),
+            tier(100, 300),
+            tier(u64::MAX, 10_000),
+        ],
+    );
+    let client = init_with_tiers(&env, 0, Some(tiers));
+
+    let cases = [
+        (0, (0, 0)),
+        (1, (100, 1)),
+        (2, (100, 1)),
+        (9, (100, 1)),
+        (10, (200, 10)),
+        (11, (200, 10)),
+        (99, (200, 10)),
+        (100, (300, 100)),
+        (101, (300, 100)),
+        (u64::MAX - 1, (300, 100)),
+        (u64::MAX, (10_000, u64::MAX)),
+    ];
+
+    for (lock, expected) in cases {
+        assert_eq!(
+            client.preview_yield_tier(&i128::MAX, &lock),
+            expected,
+            "unexpected tier resolution for lock={lock}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add bounded boundary coverage for yield-tier validation and preview selection
- cover zero, maximum, just-outside-range, ordering, and tier-table length cases
- assert the typed escrow errors returned for invalid yield and lock configurations
- keep the largest table probe bounded at 64 entries

## Boundary coverage

- `yield_bps`: `0`, `10_000`, `-1`, `10_001`, and just below the base yield
- `min_lock_secs`: `0`, equal/decreasing values, and `u64::MAX`
- tier-table lengths: empty, single entry, and a bounded 64-entry probe
- selection: values immediately below, at, and above tier thresholds

## Unguarded boundaries found

- Yield-tier tables have no explicit maximum length. A valid 64-entry table is accepted.
- A first tier with `min_lock_secs == 0` is accepted, but lock-zero selection returns the base yield before scanning tiers, so that tier is unreachable at its exact threshold.

## Coverage

This is a test-only change. The nine new focused tests directly exercise the impacted yield-tier validation and selection branches. `cargo-llvm-cov` is not installed in the development environment, so no additional coverage-tool download or instrumented build was performed.

## Repository baseline

Verification was performed from `e2eaacd`, the last explicit green-restoration commit and an ancestor of current `main`. As of July 28, 2026, current `main` at `769f45d` contains committed merge-conflict markers in core escrow sources, so rebasing onto it would prevent the required checks from compiling. The test-module registration was merge-tested against current `main` and applies without a conflict.

## Test output

### `cargo fmt --all -- --check`

```text
(no output; exit status 0)
```

### `cargo clippy --all-targets -- -D warnings`

```text
    Checking liquifact_escrow v0.1.0 (/home/jerry/projects/Liquifact-contracts/escrow)
    Finished `dev` profile [unoptimized] target(s) in 52.17s
```

### `cargo test yield_tier_boundaries`

```text
    Finished `test` profile [unoptimized] target(s) in 1m 18s
     Running unittests src/lib.rs (target/debug/deps/liquifact_escrow-3ad00b3173573bf9)

running 9 tests
test tests::yield_tier_boundaries::test_lock_order_rejects_equal_and_decreasing_boundaries ... ok
test tests::yield_tier_boundaries::test_lock_boundaries_accept_zero_and_u64_max ... ok
test tests::yield_tier_boundaries::test_tier_table_accepts_zero_and_single_entry_lengths ... ok
test tests::yield_tier_boundaries::test_preview_selection_uses_bounded_boundary_matrix ... ok
test tests::yield_tier_boundaries::test_yield_bps_accepts_zero_and_max_boundaries ... ok
test tests::yield_tier_boundaries::test_yield_bps_rejects_just_below_base_with_typed_error ... ok
test tests::yield_tier_boundaries::test_yield_order_rejects_decrease_with_typed_error ... ok
test tests::yield_tier_boundaries::test_yield_bps_rejects_just_outside_range_with_typed_error ... ok
test tests::yield_tier_boundaries::test_tier_table_has_no_explicit_length_cap_bounded_probe ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 902 filtered out; finished in 0.16s
```

### `cargo test -- --format terse`

```text
    Finished `test` profile [unoptimized] target(s) in 5.74s
     Running unittests src/lib.rs (target/debug/deps/liquifact_escrow-3ad00b3173573bf9)

running 911 tests
....................................................................................... 87/911
.............i..........................................................i.............. 174/911
..........i..........................................................................i. 261/911
...i..................i.................................................i.............. 348/911
....iii..i..ii.i..i...i.....................i..............i.iii........i..iii......... 435/911
.....i...i.ii..i..............i.....i....................i............i................ 522/911
...i......i........................i...i............................................... 609/911
...................ii............................ii..i...i..ii..........i..i........... 696/911
....................................................................................... 783/911
.....test tests::properties::prop_aggregate_payout_le_settle_pool_tiered has been running for over 60 seconds
.............................i.i................i................................. 870/911
.................iii....................test tests::properties::prop_remaining_slots_conservation_non_underflow has been running for over 60 seconds
.
test result: ok. 857 passed; 0 failed; 54 ignored; 0 measured; 0 filtered out; finished in 116.09s

   Doc-tests liquifact_escrow

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Closes #1023
