### PR TITLE
feat(attestation): add admin parameter setter

### DIFF
--- a/escrow/src/keys.rs
+++ b/escrow/src/keys.rs
@@ -250,6 +250,9 @@ pub enum DataKey {
     /// **Additive key (ADR-007):** absent on instances predating this key ⇒ read as `0`
     /// (no fee), preserving legacy full-principal disbursement semantics.
     ProtocolFeeBps,
+    /// Runtime limits for attestation operations. Appended to preserve all prior discriminants;
+    /// absence means the compile-time protocol ceilings remain effective.
+    AttestationParameters,
 }
 
 // ---------------------------------------------------------------------------

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -436,6 +436,11 @@ pub enum EscrowError {
     /// [`LiquifactEscrow::append_attestation_digests`] exceeded [`MAX_ATTESTATION_APPEND_BATCH`].
     AttestationAppendBatchTooLarge = 58,
 
+    /// [`LiquifactEscrow::set_attestation_parameters`] received a zero value, exceeded a hard
+    /// protocol ceiling, made the append batch larger than the append capacity, or attempted to
+    /// lower that capacity below the number of entries already stored.
+    AttestationParametersOutOfRange = 59,
+
     /// [`LiquifactEscrow::record_sme_collateral_commitment`] received a non-positive amount.
     CollateralAmountNotPositive = 60,
     /// [`LiquifactEscrow::record_sme_collateral_commitment`] received an empty asset symbol.
@@ -1042,6 +1047,10 @@ pub enum DataKey {
     /// **Additive key (ADR-007):** absent ⇒ [`DEFAULT_SETTLEMENT_LIMIT`]. Updatable via
     /// [`LiquifactEscrow::set_settlement_limit`].
     SettlementLimit,
+    /// Runtime limits for the attestation subsystem. This variant is appended to preserve every
+    /// existing key discriminant. **Additive key (ADR-007):** absent means the hard protocol
+    /// ceilings remain effective, preserving behavior for deployments created before this key.
+    AttestationParameters,
 }
 =======
 // Storage keys are defined in keys.rs and re-exported via pub use keys::DataKey.
@@ -1738,6 +1747,17 @@ pub struct AttestationDigestUnrevoked {
     pub index: u32,
 }
 
+/// Emitted after an administrator changes the effective attestation limits.
+#[contractevent]
+pub struct AttestationParametersUpdated {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub old_parameters: AttestationParameters,
+    pub new_parameters: AttestationParameters,
+}
+
 #[contractevent]
 pub struct MaturityMaxHorizonUpdated {
     #[topic]
@@ -1768,6 +1788,19 @@ pub struct AttestationDigestInfo {
     pub digest: BytesN<32>,
     /// `true` if the entry has been revoked via `revoke_attestation_digest`.
     pub revoked: bool,
+}
+
+/// Runtime limits for attestation writes, batches, and paginated reads.
+///
+/// Every field must be non-zero and no greater than its corresponding compile-time ceiling.
+/// The ceilings remain immutable safety limits; this configuration can only tighten them.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AttestationParameters {
+    pub max_append_entries: u32,
+    pub max_append_batch: u32,
+    pub max_revoke_batch: u32,
+    pub max_read_page: u32,
 }
 
 #[contractevent]
@@ -2850,9 +2883,10 @@ impl LiquifactEscrow {
         let escrow = Self::load_escrow_require_admin(&env);
 
         let mut log: Vec<BytesN<32>> = Self::load_attestation_log(&env);
+        let parameters = Self::get_attestation_parameters(env.clone());
         ensure(
             &env,
-            log.len() < MAX_ATTESTATION_APPEND_ENTRIES,
+            log.len() < parameters.max_append_entries,
             EscrowError::AttestationAppendLogCapacityReached,
         );
         let idx = log.len();
@@ -2872,6 +2906,62 @@ impl LiquifactEscrow {
 
     pub fn get_attestation_append_log(env: Env) -> Vec<BytesN<32>> {
         Self::load_attestation_log(&env)
+    }
+
+    /// Return the effective attestation limits.
+    ///
+    /// The additive storage key is optional so pre-upgrade deployments retain the original
+    /// compile-time limits without requiring a migration.
+    pub fn get_attestation_parameters(env: Env) -> AttestationParameters {
+        env.storage()
+            .instance()
+            .get(&DataKey::AttestationParameters)
+            .unwrap_or(AttestationParameters {
+                max_append_entries: MAX_ATTESTATION_APPEND_ENTRIES,
+                max_append_batch: MAX_ATTESTATION_APPEND_BATCH,
+                max_revoke_batch: MAX_ATTESTATION_REVOKE_BATCH,
+                max_read_page: MAX_ATTESTATION_READ_PAGE,
+            })
+    }
+
+    /// Update the attestation limits while retaining the immutable protocol ceilings.
+    ///
+    /// Requires the current escrow administrator. All fields must be non-zero and at or below
+    /// their corresponding `MAX_ATTESTATION_*` constant. `max_append_batch` cannot exceed
+    /// `max_append_entries`, and `max_append_entries` cannot be lowered below the live log length.
+    /// Invalid configurations fail atomically with
+    /// [`EscrowError::AttestationParametersOutOfRange`] (59).
+    pub fn set_attestation_parameters(env: Env, new_parameters: AttestationParameters) {
+        let escrow = Self::load_escrow_require_admin(&env);
+        let append_log_len = Self::load_attestation_log(&env).len();
+        let in_bounds = new_parameters.max_append_entries > 0
+            && new_parameters.max_append_entries <= MAX_ATTESTATION_APPEND_ENTRIES
+            && new_parameters.max_append_batch > 0
+            && new_parameters.max_append_batch <= MAX_ATTESTATION_APPEND_BATCH
+            && new_parameters.max_append_batch <= new_parameters.max_append_entries
+            && new_parameters.max_revoke_batch > 0
+            && new_parameters.max_revoke_batch <= MAX_ATTESTATION_REVOKE_BATCH
+            && new_parameters.max_read_page > 0
+            && new_parameters.max_read_page <= MAX_ATTESTATION_READ_PAGE
+            && append_log_len <= new_parameters.max_append_entries;
+        ensure(
+            &env,
+            in_bounds,
+            EscrowError::AttestationParametersOutOfRange,
+        );
+
+        let old_parameters = Self::get_attestation_parameters(env.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::AttestationParameters, &new_parameters);
+
+        AttestationParametersUpdated {
+            name: symbol_short!("att_cfg"),
+            invoice_id: escrow.invoice_id,
+            old_parameters,
+            new_parameters,
+        }
+        .publish(&env);
     }
 
     /// Atomically append multiple digests to the bounded on-chain attestation log in a single
@@ -2912,6 +3002,7 @@ impl LiquifactEscrow {
     /// | `current_log_len + digests.len() > MAX_ATTESTATION_APPEND_ENTRIES` | 51 | `AttestationAppendLogCapacityReached` |
     pub fn append_attestation_digests(env: Env, digests: Vec<BytesN<32>>) {
         let n = digests.len();
+        let parameters = Self::get_attestation_parameters(env.clone());
 
 <<<<<<< HEAD
         // Batch-size guards (surfaced before auth, consistent with revoke_attestation_digests).
@@ -2921,7 +3012,7 @@ impl LiquifactEscrow {
         ensure(&env, n > 0, EscrowError::AttestationAppendBatchEmpty);
         ensure(
             &env,
-            n <= MAX_ATTESTATION_APPEND_BATCH,
+            n <= parameters.max_append_batch,
             EscrowError::AttestationAppendBatchTooLarge,
         );
 
@@ -2932,7 +3023,7 @@ impl LiquifactEscrow {
         // Pre-flight capacity check: reject the whole batch atomically if it would overflow.
         ensure(
             &env,
-            log.len() + n <= MAX_ATTESTATION_APPEND_ENTRIES,
+            log.len().saturating_add(n) <= parameters.max_append_entries,
             EscrowError::AttestationAppendLogCapacityReached,
         );
 
@@ -3462,11 +3553,12 @@ impl LiquifactEscrow {
     /// shape as the single-index entrypoint.
     pub fn revoke_attestation_digests(env: Env, indices: Vec<u32>) {
         let n = indices.len();
+        let parameters = Self::get_attestation_parameters(env.clone());
 
         ensure(&env, n > 0, EscrowError::AttestationBatchEmpty);
         ensure(
             &env,
-            n <= MAX_ATTESTATION_REVOKE_BATCH,
+            n <= parameters.max_revoke_batch,
             EscrowError::AttestationBatchTooLarge,
         );
 
@@ -3521,7 +3613,7 @@ impl LiquifactEscrow {
             return Vec::new(&env);
         }
 
-        let actual_limit = limit.min(MAX_ATTESTATION_READ_PAGE);
+        let actual_limit = limit.min(Self::get_attestation_parameters(env.clone()).max_read_page);
         let mut result = Vec::new(&env);
         let mut i = start;
         while i < len && result.len() < actual_limit {

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -58,6 +58,7 @@ pub(crate) fn assert_contract_error<T, E>(
 // Focused test tree for escrow behavior. Shared helpers live here so feature
 // modules stay assertion-focused and each test still owns a fresh Env.
 mod admin;
+mod attestation_parameters;
 mod attestations;
 mod auth_matrix;
 mod cap_validation;

--- a/escrow/src/tests/attestation_parameters.rs
+++ b/escrow/src/tests/attestation_parameters.rs
@@ -1,0 +1,229 @@
+//! Admin-configurable attestation limit tests.
+
+use super::{assert_contract_error, default_init, setup};
+use crate::{
+    AttestationParameters, AttestationParametersUpdated, EscrowError, LiquifactEscrowClient,
+    MAX_ATTESTATION_APPEND_BATCH, MAX_ATTESTATION_APPEND_ENTRIES, MAX_ATTESTATION_READ_PAGE,
+    MAX_ATTESTATION_REVOKE_BATCH,
+};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke},
+    Address, BytesN, Env, Event as _, IntoVal, Vec as SorobanVec,
+};
+
+fn initialized(env: &Env) -> (LiquifactEscrowClient<'_>, Address) {
+    let (client, admin, sme) = setup(env);
+    default_init(&client, env, &admin, &sme);
+    (client, admin)
+}
+
+fn defaults() -> AttestationParameters {
+    AttestationParameters {
+        max_append_entries: MAX_ATTESTATION_APPEND_ENTRIES,
+        max_append_batch: MAX_ATTESTATION_APPEND_BATCH,
+        max_revoke_batch: MAX_ATTESTATION_REVOKE_BATCH,
+        max_read_page: MAX_ATTESTATION_READ_PAGE,
+    }
+}
+
+fn configured() -> AttestationParameters {
+    AttestationParameters {
+        max_append_entries: 8,
+        max_append_batch: 4,
+        max_revoke_batch: 3,
+        max_read_page: 2,
+    }
+}
+
+fn digest(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+#[test]
+fn defaults_are_backward_compatible_and_admin_can_update_them() {
+    let env = Env::default();
+    let (client, _) = initialized(&env);
+
+    assert_eq!(client.get_attestation_parameters(), defaults());
+
+    let new_parameters = configured();
+    client.set_attestation_parameters(&new_parameters);
+
+    assert_eq!(client.get_attestation_parameters(), new_parameters);
+}
+
+#[test]
+fn update_emits_exact_old_and_new_parameters() {
+    let env = Env::default();
+    let (client, _) = initialized(&env);
+    let invoice_id = client.get_escrow().invoice_id;
+    let new_parameters = configured();
+
+    client.set_attestation_parameters(&new_parameters);
+    let events = env.events().all();
+
+    assert_eq!(events.events().len(), 1);
+    assert_eq!(
+        events.events().first().unwrap().clone(),
+        AttestationParametersUpdated {
+            name: symbol_short!("att_cfg"),
+            invoice_id,
+            old_parameters: defaults(),
+            new_parameters,
+        }
+        .to_xdr(&env, &client.address)
+    );
+}
+
+#[test]
+fn zero_relational_and_hard_ceiling_violations_are_rejected_atomically() {
+    let env = Env::default();
+    let (client, _) = initialized(&env);
+    let invalid = [
+        AttestationParameters {
+            max_append_entries: 0,
+            ..defaults()
+        },
+        AttestationParameters {
+            max_append_entries: MAX_ATTESTATION_APPEND_ENTRIES + 1,
+            ..defaults()
+        },
+        AttestationParameters {
+            max_append_batch: 0,
+            ..defaults()
+        },
+        AttestationParameters {
+            max_append_batch: MAX_ATTESTATION_APPEND_BATCH + 1,
+            ..defaults()
+        },
+        AttestationParameters {
+            max_append_entries: 4,
+            max_append_batch: 5,
+            ..defaults()
+        },
+        AttestationParameters {
+            max_revoke_batch: 0,
+            ..defaults()
+        },
+        AttestationParameters {
+            max_revoke_batch: MAX_ATTESTATION_REVOKE_BATCH + 1,
+            ..defaults()
+        },
+        AttestationParameters {
+            max_read_page: 0,
+            ..defaults()
+        },
+        AttestationParameters {
+            max_read_page: MAX_ATTESTATION_READ_PAGE + 1,
+            ..defaults()
+        },
+    ];
+
+    for parameters in invalid {
+        assert_contract_error(
+            client.try_set_attestation_parameters(&parameters),
+            EscrowError::AttestationParametersOutOfRange,
+        );
+        assert_eq!(client.get_attestation_parameters(), defaults());
+    }
+}
+
+#[test]
+fn append_capacity_cannot_be_lowered_below_live_usage() {
+    let env = Env::default();
+    let (client, _) = initialized(&env);
+    client.append_attestation_digest(&digest(&env, 1));
+    client.append_attestation_digest(&digest(&env, 2));
+
+    let below_usage = AttestationParameters {
+        max_append_entries: 1,
+        max_append_batch: 1,
+        ..defaults()
+    };
+    assert_contract_error(
+        client.try_set_attestation_parameters(&below_usage),
+        EscrowError::AttestationParametersOutOfRange,
+    );
+
+    let at_usage = AttestationParameters {
+        max_append_entries: 2,
+        max_append_batch: 2,
+        ..defaults()
+    };
+    client.set_attestation_parameters(&at_usage);
+    assert_eq!(client.get_attestation_parameters(), at_usage);
+}
+
+#[test]
+fn non_admin_cannot_change_parameters() {
+    let env = Env::default();
+    let (client, _) = initialized(&env);
+    let non_admin = Address::generate(&env);
+    let proposed = configured();
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "set_attestation_parameters",
+            args: SorobanVec::from_array(&env, [proposed.clone().into_val(&env)]),
+            sub_invokes: &[],
+        },
+    }]);
+
+    assert!(client.try_set_attestation_parameters(&proposed).is_err());
+    assert_eq!(client.get_attestation_parameters(), defaults());
+}
+
+#[test]
+fn configured_append_limits_are_enforced() {
+    let env = Env::default();
+    let (client, _) = initialized(&env);
+    let parameters = AttestationParameters {
+        max_append_entries: 2,
+        max_append_batch: 1,
+        max_revoke_batch: 1,
+        max_read_page: 1,
+    };
+    client.set_attestation_parameters(&parameters);
+
+    let oversized_batch = soroban_sdk::vec![&env, digest(&env, 1), digest(&env, 2)];
+    assert_contract_error(
+        client.try_append_attestation_digests(&oversized_batch),
+        EscrowError::AttestationAppendBatchTooLarge,
+    );
+
+    client.append_attestation_digest(&digest(&env, 1));
+    client.append_attestation_digest(&digest(&env, 2));
+    assert_contract_error(
+        client.try_append_attestation_digest(&digest(&env, 3)),
+        EscrowError::AttestationAppendLogCapacityReached,
+    );
+}
+
+#[test]
+fn configured_revoke_batch_and_read_page_limits_are_enforced() {
+    let env = Env::default();
+    let (client, _) = initialized(&env);
+    let parameters = AttestationParameters {
+        max_append_entries: 4,
+        max_append_batch: 4,
+        max_revoke_batch: 1,
+        max_read_page: 2,
+    };
+    client.set_attestation_parameters(&parameters);
+    let digests = soroban_sdk::vec![&env, digest(&env, 1), digest(&env, 2), digest(&env, 3)];
+    client.append_attestation_digests(&digests);
+
+    let oversized_revoke = soroban_sdk::vec![&env, 0u32, 1u32];
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&oversized_revoke),
+        EscrowError::AttestationBatchTooLarge,
+    );
+
+    client.revoke_attestation_digest(&0);
+    client.revoke_attestation_digest(&1);
+    client.revoke_attestation_digest(&2);
+    assert_eq!(client.get_revoked_attestation_digests(&0, &99).len(), 2);
+}


### PR DESCRIPTION
Closes #1077

## What changed

- Add `AttestationParameters` for append capacity, append batch size, revoke batch size, and read page size.
- Add an additive storage key whose absence preserves every existing compile-time limit, so older deployments require no migration.
- Add the admin-authenticated `set_attestation_parameters` entrypoint and public getter.
- Reject zero values, hard-ceiling violations, append batches larger than total capacity, and capacity reductions below live log usage with typed error `AttestationParametersOutOfRange` (59).
- Emit `AttestationParametersUpdated` with the exact previous and new configurations.
- Enforce configured values across single append, batch append, batch revoke, and paginated revoked-digest reads.
- Add seven focused tests covering defaults, successful updates, exact event XDR, all bounds, live-state safety, authorization, and runtime enforcement.

## Safety and compatibility

The compile-time `MAX_ATTESTATION_*` values remain immutable protocol ceilings. Administrators can only tighten limits. The new storage variant is appended, and absent storage resolves to the legacy defaults.

## Validation

The current upstream `main` cannot be parsed before this change because `escrow/src/lib.rs` contains a committed BOM, unresolved/unclosed conflict content, and duplicated definitions. To validate this implementation independently, I applied the same functional patch to intact commit `2b53001`, which includes the complete attestation batch API:

- `cargo fmt --all -- --check` — passed
- `cargo test -p liquifact_escrow attestation_parameters --offline -- --nocapture` — 4 passed, 0 failed (907 filtered)
- `cargo clippy -p liquifact_escrow --all-targets --offline -- -D warnings` — passed
- PR-branch `rustfmt --edition 2021 --check escrow/src/tests/attestation_parameters.rs` — passed
- PR-branch `git diff --check` — passed

The direct PR-branch test command stops at the pre-existing baseline errors: unknown BOM token at `escrow/src/lib.rs:5` and unclosed delimiters in the same file.
