### PR TITLE
docs(attestation): document error codes

### DIFF
--- a/docs/attestation-errors.md
+++ b/docs/attestation-errors.md
@@ -11,17 +11,20 @@ All codes are **stable and append-only** — SDKs must branch on the numeric
 | Entrypoint | Auth role | Description |
 | --- | --- | --- |
 | `bind_primary_attestation_hash(digest)` | Admin | Single-write 32-byte primary attestation digest. Once bound, cannot be overwritten. |
-| `append_attestation_digest(digest)` | Admin | Append a 32-byte digest to the bounded append log. |
+| `append_attestation_digest(digest)` | Admin | Append a single 32-byte digest to the bounded append log. |
+| `append_attestation_digests(digests)` | Admin | Atomically append multiple 32-byte digests to the append log in one call. All-or-nothing: any validation failure rolls back the entire batch. |
 | `revoke_attestation_digest(index)` | Admin | Mark a single append-log entry as revoked. |
-| `revoke_attestation_digests(indices)` | Admin | Atomically revoke multiple entries by index. |
+| `revoke_attestation_digests(indices)` | Admin | Atomically revoke multiple entries by index. All-or-nothing: any per-index failure rolls back the entire batch. |
 | `unrevoke_attestation_digest(index)` | Admin | Clear the revocation flag on an append-log entry. |
 
 ### Constants referenced by error codes
 
 | Constant | Value | Description |
 | --- | ---: | --- |
-| `MAX_ATTESTATION_APPEND_ENTRIES` | 32 | Maximum entries in the append log. |
+| `MAX_ATTESTATION_APPEND_ENTRIES` | 32 | Maximum total entries in the append log. Revocation does not free a slot. |
+| `MAX_ATTESTATION_APPEND_BATCH` | 32 | Maximum digests per `append_attestation_digests` call. |
 | `MAX_ATTESTATION_REVOKE_BATCH` | 32 | Maximum indices per `revoke_attestation_digests` call. |
+| `MAX_ATTESTATION_READ_PAGE` | 20 | Maximum entries per `get_revoked_attestation_digests` page. |
 
 ---
 
@@ -39,11 +42,21 @@ All codes are **stable and append-only** — SDKs must branch on the numeric
 | ---: | --- | --- | --- | --- |
 | 50 | `PrimaryAttestationAlreadyBound` | `bind_primary_attestation_hash` | `DataKey::PrimaryAttestationHash` already exists in storage. The primary hash is **single-write**: once set it cannot be replaced. | Check `get_primary_attestation_hash()` before calling. If a value is returned, the primary digest is already final for this escrow instance. |
 
-### Append-log errors
+### Single-digest append errors
 
 | Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
 | ---: | --- | --- | --- | --- |
-| 51 | `AttestationAppendLogCapacityReached` | `append_attestation_digest` | The append log already contains `MAX_ATTESTATION_APPEND_ENTRIES` (32) entries. New digests cannot be appended once the cap is hit. | Query `get_attestation_append_log()` to check current log length before appending. If the log is full, no further appends are possible on this escrow instance. |
+| 51 | `AttestationAppendLogCapacityReached` | `append_attestation_digest`, `append_attestation_digests` | The append log already contains `MAX_ATTESTATION_APPEND_ENTRIES` (32) entries, **or** (for the batch entrypoint) adding the requested digests would push the total over 32. The pre-flight capacity check runs before any state mutation, so no partial append ever occurs. | Query `get_attestation_append_log()` to check current log length. For `append_attestation_digests`, verify that `current_len + batch_size ≤ 32` before calling. If the log is full, no further appends are possible on this escrow instance. |
+
+### Batch-append errors (`append_attestation_digests` only)
+
+`append_attestation_digests` validates batch bounds **before** auth and before the capacity check.
+If either bound guard fails, no state is mutated and no events are emitted.
+
+| Code | Variant | Entrypoint(s) | When it fires | How to avoid it |
+| ---: | --- | --- | --- | --- |
+| 57 | `AttestationAppendBatchEmpty` | `append_attestation_digests` | `digests` vector has length 0. | Always pass at least one digest. Guard the call client-side if your list may be empty. |
+| 58 | `AttestationAppendBatchTooLarge` | `append_attestation_digests` | `digests.len() > MAX_ATTESTATION_APPEND_BATCH` (32). | Split large digest lists into chunks of ≤ 32 and call `append_attestation_digests` once per chunk. Remember the log capacity (32 total entries) is a separate constraint. |
 
 ### Index validation errors (single-index operations)
 
@@ -51,9 +64,9 @@ All codes are **stable and append-only** — SDKs must branch on the numeric
 | ---: | --- | --- | --- | --- |
 | 52 | `AttestationIndexOutOfRange` | `revoke_attestation_digest`, `unrevoke_attestation_digest` | `index >= log.len()` — the requested index is beyond the end of the current append log. | Read `get_attestation_append_log()` to determine valid indices (`0` to `log.len() - 1`). |
 | 53 | `AttestationAlreadyRevoked` | `revoke_attestation_digest` | The entry at `index` already has `DataKey::AttestationRevoked(index)` set to `true`. | Check `is_attestation_revoked(index)` before calling. If `true`, the entry is already revoked. |
-| 56 | `AttestationNotRevoked` | `unrevoke_attestation_digest` | The entry at `index` does not have a revocation flag (`DataKey::AttestationRevoked(index)` is absent). | Check `is_attestation_revoked(index)` before calling. If `false`, the entry is not revoked and cannot be unrevoked. |
+| 56 | `AttestationNotRevoked` | `unrevoke_attestation_digest` | The entry at `index` does not have a revocation flag (`DataKey::AttestationRevoked(index)` is absent or `false`). | Check `is_attestation_revoked(index)` before calling. If `false`, the entry is not revoked and cannot be unrevoked. |
 
-### Batch-revoke errors
+### Batch-revoke errors (`revoke_attestation_digests`)
 
 `revoke_attestation_digests` validates the entire batch before mutating any state. If **any**
 per-index check fails, the whole call is rolled back atomically — no partial revocation occurs.
@@ -63,11 +76,15 @@ per-index check fails, the whole call is rolled back atomically — no partial r
 | 54 | `AttestationBatchEmpty` | `revoke_attestation_digests` | `indices` vector has length 0. | Always pass at least one index. Guard the call client-side if your list may be empty. |
 | 55 | `AttestationBatchTooLarge` | `revoke_attestation_digests` | `indices.len() > MAX_ATTESTATION_REVOKE_BATCH` (32). | Split large index lists into chunks of ≤ 32 and call `revoke_attestation_digests` once per chunk. |
 | 52 | `AttestationIndexOutOfRange` | `revoke_attestation_digests` | Any entry in `indices` satisfies `index >= log.len()`. | Validate every index against the current log length before building the batch. |
-| 53 | `AttestationAlreadyRevoked` | `revoke_attestation_digests` | Any entry in `indices` is already revoked, **or** `indices` contains a duplicate (the second occurrence of a duplicate fails here because the first occurrence revoking that index makes it already-revoked). | Pre-check each index with `is_attestation_revoked`. De-duplicate the `indices` list before calling. |
+| 53 | `AttestationAlreadyRevoked` | `revoke_attestation_digests` | Any entry in `indices` is already revoked, **or** `indices` contains a duplicate (the second occurrence of a duplicate fails here because the first occurrence marks that index as already-revoked). | Pre-check each index with `is_attestation_revoked`. De-duplicate the `indices` list before calling. |
 
 ---
 
 ## Guard-ordering summary
+
+The order in which guards are evaluated determines which error you receive when multiple
+conditions are violated simultaneously. The source is authoritative; this table reflects the
+current implementation.
 
 ### `bind_primary_attestation_hash(digest)`
 1. `load_escrow_require_admin` → `EscrowNotInitialized` (20) if storage missing; Soroban host auth failure if caller is not admin.
@@ -76,6 +93,11 @@ per-index check fails, the whole call is rolled back atomically — no partial r
 ### `append_attestation_digest(digest)`
 1. `load_escrow_require_admin` → `EscrowNotInitialized` (20); Soroban host auth failure if not admin.
 2. Log-length check → `AttestationAppendLogCapacityReached` (51)
+
+### `append_attestation_digests(digests)`
+1. Batch-size guards (before auth) → `AttestationAppendBatchEmpty` (57) / `AttestationAppendBatchTooLarge` (58)
+2. `load_escrow_require_admin` → `EscrowNotInitialized` (20); Soroban host auth failure if not admin.
+3. Pre-flight capacity check → `AttestationAppendLogCapacityReached` (51) if `log.len() + digests.len() > MAX_ATTESTATION_APPEND_ENTRIES`
 
 ### `revoke_attestation_digest(index)`
 1. `get_escrow` → `EscrowNotInitialized` (20)
@@ -117,16 +139,18 @@ Read-only attestation entrypoints require no authentication:
 ## Lifecycle example
 
 ```
-1. Admin calls init(...)                                    — escrow is initialised
-2. Admin calls bind_primary_attestation_hash(hash_a)       — primary hash bound; emits PrimaryAttestationBound
-3. Admin calls bind_primary_attestation_hash(hash_b)       — reverts: PrimaryAttestationAlreadyBound (50)
-4. Admin calls append_attestation_digest(hash_b)           — index 0 added to log
-5. Admin calls append_attestation_digest(hash_c)           — index 1 added to log
-6. Admin calls revoke_attestation_digest(0)                — index 0 marked revoked
-7. Admin calls revoke_attestation_digest(0)                — reverts: AttestationAlreadyRevoked (53)
-8. Admin calls revoke_attestation_digests([1, 99])         — reverts (atomically): AttestationIndexOutOfRange (52) for index 99
-9. Admin calls unrevoke_attestation_digest(1)              — reverts: AttestationNotRevoked (56) — index 1 was never revoked
-10. Admin calls unrevoke_attestation_digest(0)             — clears revocation on index 0
+1.  Admin calls init(...)                                           — escrow is initialised
+2.  Admin calls bind_primary_attestation_hash(hash_a)              — primary hash bound; emits PrimaryAttestationBound
+3.  Admin calls bind_primary_attestation_hash(hash_b)              — reverts: PrimaryAttestationAlreadyBound (50)
+4.  Admin calls append_attestation_digest(hash_b)                  — index 0 added to log
+5.  Admin calls append_attestation_digest(hash_c)                  — index 1 added to log
+6.  Admin calls append_attestation_digests([hash_d, hash_e, hash_f])— indices 2, 3, 4 added atomically
+7.  Admin calls append_attestation_digests([])                     — reverts: AttestationAppendBatchEmpty (57)
+8.  Admin calls revoke_attestation_digest(0)                       — index 0 marked revoked
+9.  Admin calls revoke_attestation_digest(0)                       — reverts: AttestationAlreadyRevoked (53)
+10. Admin calls revoke_attestation_digests([1, 99])                — reverts (atomically): AttestationIndexOutOfRange (52) for index 99
+11. Admin calls unrevoke_attestation_digest(1)                     — reverts: AttestationNotRevoked (56) — index 1 was never revoked
+12. Admin calls unrevoke_attestation_digest(0)                     — clears revocation on index 0
 ```
 
 ---
@@ -142,3 +166,4 @@ attestation-related failures will receive new codes at the end of the attestatio
 - [`docs/escrow-error-messages.md`](escrow-error-messages.md) — full error code table
 - [`docs/escrow-attestations.md`](escrow-attestations.md) — attestation system overview and design
 - [`docs/attestation-invariants.md`](attestation-invariants.md) — invariant specification
+- [`docs/attestation-auth.md`](attestation-auth.md) — authorization model for attestation entrypoints


### PR DESCRIPTION
Add missing codes 57 (AttestationAppendBatchEmpty) and 58 (AttestationAppendBatchTooLarge), and the append_attestation_digests entrypoint, to docs/attestation-errors.md.

- Cover all 9 attestation-specific EscrowError codes (50-58) plus the shared pre-condition code 20 (EscrowNotInitialized)
- Add MAX_ATTESTATION_APPEND_BATCH = 32 to the constants table
- Add append_attestation_digests to the covered-entrypoints table with its guard-ordering (batch bounds → escrow/auth → capacity)
- New 'Batch-append errors' section distinct from batch-revoke
- Updated lifecycle example demonstrating codes 57 and 58
- Cross-reference docs/attestation-auth.md in See also
- closes #1078