### PR TITLE
Add a version/metadata view to allowlist

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1192,6 +1192,21 @@ pub struct CollateralConfig {
     pub sme_commitment: CollateralCommitmentSnapshot,
 }
 
+/// Read-only metadata for the investor allowlist subsystem.
+///
+/// The view intentionally returns defaults for uninitialized deployments so off-chain
+/// callers can discover allowlist capabilities without first calling `init`.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AllowlistMetadata {
+    /// Stored contract schema version; defaults to `0` before `init` writes `DataKey::Version`.
+    pub schema_version: u32,
+    /// Whether the allowlist gate is currently active; defaults to `false` when unset.
+    pub is_active: bool,
+    /// Number of currently allowlisted investors, filtered through the live per-address flags.
+    pub allowlisted_count: u32,
+}
+
 /// Comprehensive summary of the escrow contract state.
 /// Bundles multiple read-only values to allow a single host invocation
 /// for off-chain indexers and client rendering.
@@ -4309,6 +4324,19 @@ impl LiquifactEscrow {
             }
         }
         count
+    }
+
+    /// Returns read-only metadata for the investor allowlist subsystem.
+    ///
+    /// This view performs no authorization and does not mutate storage. It is safe to call
+    /// before initialization: absent storage keys resolve to `schema_version = 0`,
+    /// `is_active = false`, and `allowlisted_count = 0`.
+    pub fn get_allowlist_metadata(env: Env) -> AllowlistMetadata {
+        AllowlistMetadata {
+            schema_version: Self::get_version(env.clone()),
+            is_active: Self::is_allowlist_active(env.clone()),
+            allowlisted_count: Self::get_allowlisted_investors_count(env),
+        }
     }
 
     /// Convenience alias for [`LiquifactEscrow::set_legal_hold`] with `active = false`.

--- a/escrow/src/test_allowlist_tests.rs
+++ b/escrow/src/test_allowlist_tests.rs
@@ -919,3 +919,36 @@ fn gate_batch_revoke_blocks_all_revoked_members() {
     assert_eq!(client.get_contribution(&a), 1_000i128);
     assert_eq!(client.get_contribution(&b), 1_000i128);
 }
+
+#[test]
+fn test_allowlist_metadata_defaults_before_init() {
+    let env = Env::default();
+    let client = deploy(&env);
+
+    let metadata = client.get_allowlist_metadata();
+
+    assert_eq!(metadata.schema_version, 0);
+    assert!(!metadata.is_active);
+    assert_eq!(metadata.allowlisted_count, 0);
+}
+
+#[test]
+fn test_allowlist_metadata_reflects_initialized_values() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    init(&env, &client);
+    let investor = Address::generate(&env);
+    let removed = Address::generate(&env);
+
+    client.set_allowlist_active(&true);
+    client.set_investor_allowlisted(&investor, &true);
+    client.set_investor_allowlisted(&removed, &true);
+    client.set_investor_allowlisted(&removed, &false);
+
+    let metadata = client.get_allowlist_metadata();
+
+    assert_eq!(metadata.schema_version, crate::SCHEMA_VERSION);
+    assert!(metadata.is_active);
+    assert_eq!(metadata.allowlisted_count, 1);
+}


### PR DESCRIPTION
## Summary
Adds a metadata view feature to the allowlist system, enabling users to view metadata associated with allowlisted items.

## Changes
- Introduces a new metadata view endpoint for the allowlist
- Updates core logic in `lib.rs` to support metadata retrieval
- Adds test coverage in `test_allowlist_tests.rs` for metadata functionality

## Impact
- **New Feature**: Users can now view metadata for allowlisted items
- **Core Logic**: Modified `escrow/src/lib.rs` to include metadata handling
- **Testing**: Extended `escrow/src/test_allowlist_tests.rs` with metadata test cases

closes #1027 