### PR TITLE
feat(settlement): add config read view

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ liquifact-contracts/
 | `get_escrow` | — | Read current escrow state. |
 | `get_version` | — | Read stored `DataKey::Version`. |
 | `get_remaining_investor_slots` | — | Read remaining unique investor capacity before reaching the cap. |
+| `get_settlement_config` | — | Read-only bundled view of settlement configuration: `settlement_limit`, `yield_bps`, `protocol_fee_bps`, and `maturity`. Returns sensible defaults (`DEFAULT_SETTLEMENT_LIMIT`, `0`, `0`, `0`) before `init`. |
 | `get_reconciliation` | — | Read solvency position: live token balance, outstanding liability, and surplus/deficit. See [`docs/escrow-read-api.md`](docs/escrow-read-api.md). |
 
 | `rebind_registry_ref` | Admin | Set or update the off-chain registry hint (`DataKey::RegistryRef`). Emits `RegistryRefRebound`. |

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1115,6 +1115,35 @@ pub struct CollateralConfig {
     pub sme_commitment: CollateralCommitmentSnapshot,
 }
 
+/// Read-only snapshot of the settlement subsystem configuration.
+///
+/// Bundles the four settlement-relevant admin knobs so an off-chain caller can understand
+/// the full settlement gate with a single host invocation rather than stitching together
+/// `get_settlement_limit`, `get_protocol_fee_bps`, and the maturity / yield fields from
+/// `get_escrow`.
+///
+/// Returns sensible defaults before [`LiquifactEscrow::init`] is called:
+/// - `settlement_limit` → [`DEFAULT_SETTLEMENT_LIMIT`]
+/// - `yield_bps` → `0`
+/// - `protocol_fee_bps` → `0`
+/// - `maturity` → `0` (no maturity lock)
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SettlementConfig {
+    /// Admin-configured batch limit for settlement payout processing.
+    /// Defaults to [`DEFAULT_SETTLEMENT_LIMIT`] when never set via
+    /// [`LiquifactEscrow::set_settlement_limit`].
+    pub settlement_limit: u32,
+    /// Invoice yield in basis points set at [`LiquifactEscrow::init`]; `0` before init.
+    pub yield_bps: i64,
+    /// Protocol fee in basis points deducted from the SME disbursement at
+    /// [`LiquifactEscrow::withdraw`]; `0` before init or when not configured.
+    pub protocol_fee_bps: i64,
+    /// Maturity timestamp (ledger seconds) after which settlement is permitted;
+    /// `0` means no time lock. Taken from [`InvoiceEscrow::maturity`]; `0` before init.
+    pub maturity: u64,
+}
+
 /// Read-only metadata for the investor allowlist subsystem.
 ///
 /// The view intentionally returns defaults for uninitialized deployments so off-chain
@@ -3621,6 +3650,39 @@ impl LiquifactEscrow {
         env.storage()
             .instance()
             .set(&DataKey::SettlementLimit, &new_limit);
+    }
+
+    /// Read-only snapshot of the settlement subsystem configuration.
+    ///
+    /// Bundles `settlement_limit`, `yield_bps`, `protocol_fee_bps`, and `maturity` into
+    /// a single [`SettlementConfig`] so an off-chain caller can understand the full settlement
+    /// gate with one host invocation.
+    ///
+    /// # Defaults (before `init`)
+    /// All fields return their documented default values when the escrow has never been
+    /// initialized (additive-key semantics, ADR-007):
+    /// - `settlement_limit` → [`DEFAULT_SETTLEMENT_LIMIT`]
+    /// - `yield_bps` → `0`
+    /// - `protocol_fee_bps` → `0`
+    /// - `maturity` → `0` (no maturity lock)
+    ///
+    /// # Read-only
+    /// Pure view: no `require_auth`, no storage writes, and no TTL bump.
+    pub fn get_settlement_config(env: Env) -> SettlementConfig {
+        let settlement_limit = Self::get_settlement_limit(env.clone());
+        let protocol_fee_bps = Self::get_protocol_fee_bps(env.clone());
+        let (yield_bps, maturity) = env
+            .storage()
+            .instance()
+            .get::<DataKey, InvoiceEscrow>(&DataKey::Escrow)
+            .map(|e| (e.yield_bps, e.maturity))
+            .unwrap_or((0, 0));
+        SettlementConfig {
+            settlement_limit,
+            yield_bps,
+            protocol_fee_bps,
+            maturity,
+        }
     }
 
     /// Bundle the settleable flag, legal-hold state, maturity-reached state, and a single derived

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -78,6 +78,7 @@ mod pause;
 mod properties;
 mod reconciliation_lifecycle;
 mod settlement;
+mod settlement_config_view;
 mod settlement_limit;
 
 /// Registers a new escrow contract instance and returns its contract id.

--- a/escrow/src/tests/settlement_config_view.rs
+++ b/escrow/src/tests/settlement_config_view.rs
@@ -1,0 +1,248 @@
+//! Tests for [`LiquifactEscrow::get_settlement_config`].
+//!
+//! Covers:
+//! - Default values before [`LiquifactEscrow::init`] is called.
+//! - Values reflect what was passed to `init`.
+//! - Values match the individual getters (`get_settlement_limit`, `get_protocol_fee_bps`,
+//!   and `get_escrow().yield_bps` / `.maturity`).
+//! - Reflects admin mutation via [`LiquifactEscrow::set_settlement_limit`].
+//! - Edge cases: non-zero maturity, explicit protocol fee, min/max settlement limits.
+
+use super::super::{
+    LiquifactEscrow, LiquifactEscrowClient, SettlementConfig, DEFAULT_SETTLEMENT_LIMIT,
+    MAX_SETTLEMENT_LIMIT, MIN_SETTLEMENT_LIMIT,
+};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
+    let id = env.register(LiquifactEscrow, ());
+    LiquifactEscrowClient::new(env, &id)
+}
+
+/// Init with caller-supplied `yield_bps`, `maturity`, and `protocol_fee_bps`.
+fn init_escrow(
+    env: &Env,
+    client: &LiquifactEscrowClient,
+    yield_bps: i64,
+    maturity: u64,
+    protocol_fee_bps: Option<i64>,
+) {
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let token = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, "SETCFG01"),
+        &sme,
+        &10_000i128,
+        &yield_bps,
+        &maturity,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &protocol_fee_bps,
+    );
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+/// Before `init`, every field must return its documented default.
+#[test]
+fn test_defaults_before_init() {
+    let env = Env::default();
+    let client = deploy(&env);
+
+    let config = client.get_settlement_config();
+
+    assert_eq!(
+        config.settlement_limit,
+        DEFAULT_SETTLEMENT_LIMIT,
+        "settlement_limit should be DEFAULT_SETTLEMENT_LIMIT before init"
+    );
+    assert_eq!(config.yield_bps, 0, "yield_bps should be 0 before init");
+    assert_eq!(
+        config.protocol_fee_bps, 0,
+        "protocol_fee_bps should be 0 before init"
+    );
+    assert_eq!(config.maturity, 0, "maturity should be 0 before init");
+}
+
+/// After `init`, fields should reflect the values supplied at init time.
+#[test]
+fn test_values_after_init_basic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    init_escrow(&env, &client, 800, 0, None);
+
+    let config = client.get_settlement_config();
+
+    assert_eq!(config.settlement_limit, DEFAULT_SETTLEMENT_LIMIT);
+    assert_eq!(config.yield_bps, 800);
+    assert_eq!(config.protocol_fee_bps, 0);
+    assert_eq!(config.maturity, 0);
+}
+
+/// Non-zero `maturity` must be reflected.
+#[test]
+fn test_values_after_init_with_maturity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    // Set ledger time so maturity > now passes validation.
+    let mut ledger_info = env.ledger().get();
+    ledger_info.timestamp = 1_000;
+    env.ledger().set(ledger_info);
+
+    let maturity: u64 = 1_000 + 60 * 60; // 1 hour from now
+    init_escrow(&env, &client, 500, maturity, None);
+
+    let config = client.get_settlement_config();
+    assert_eq!(config.maturity, maturity);
+    assert_eq!(config.yield_bps, 500);
+}
+
+/// Explicit `protocol_fee_bps` at init must be reflected.
+#[test]
+fn test_values_after_init_with_protocol_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    init_escrow(&env, &client, 300, 0, Some(250));
+
+    let config = client.get_settlement_config();
+    assert_eq!(config.protocol_fee_bps, 250);
+    assert_eq!(config.yield_bps, 300);
+}
+
+/// `get_settlement_config` must match the individual getters so the bundled view
+/// cannot drift from the authoritative single-key reads.
+#[test]
+fn test_config_matches_individual_getters() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    init_escrow(&env, &client, 750, 0, Some(100));
+
+    let config = client.get_settlement_config();
+    let escrow = client.get_escrow();
+
+    assert_eq!(config.settlement_limit, client.get_settlement_limit());
+    assert_eq!(config.yield_bps, escrow.yield_bps);
+    assert_eq!(config.protocol_fee_bps, client.get_protocol_fee_bps());
+    assert_eq!(config.maturity, escrow.maturity);
+}
+
+/// After `set_settlement_limit`, the view must reflect the updated value.
+#[test]
+fn test_settlement_limit_update_reflected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    init_escrow(&env, &client, 800, 0, None);
+
+    // Starts at default.
+    assert_eq!(
+        client.get_settlement_config().settlement_limit,
+        DEFAULT_SETTLEMENT_LIMIT
+    );
+
+    // Admin updates the limit.
+    client.set_settlement_limit(&10);
+    assert_eq!(client.get_settlement_config().settlement_limit, 10);
+
+    // Update to min bound.
+    client.set_settlement_limit(&MIN_SETTLEMENT_LIMIT);
+    assert_eq!(
+        client.get_settlement_config().settlement_limit,
+        MIN_SETTLEMENT_LIMIT
+    );
+
+    // Update to max bound.
+    client.set_settlement_limit(&MAX_SETTLEMENT_LIMIT);
+    assert_eq!(
+        client.get_settlement_config().settlement_limit,
+        MAX_SETTLEMENT_LIMIT
+    );
+}
+
+/// `get_settlement_config` has the expected shape (all four fields present) — verified
+/// via field-by-field destructuring so a future struct change causes a compile error.
+#[test]
+fn test_config_struct_shape() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    init_escrow(&env, &client, 600, 0, Some(50));
+    client.set_settlement_limit(&20);
+
+    let SettlementConfig {
+        settlement_limit,
+        yield_bps,
+        protocol_fee_bps,
+        maturity,
+    } = client.get_settlement_config();
+
+    assert_eq!(settlement_limit, 20);
+    assert_eq!(yield_bps, 600);
+    assert_eq!(protocol_fee_bps, 50);
+    assert_eq!(maturity, 0);
+}
+
+/// Zero `protocol_fee_bps` (omitted at init) returns `0`, not an error.
+#[test]
+fn test_zero_protocol_fee_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    init_escrow(&env, &client, 1000, 0, None);
+
+    let config = client.get_settlement_config();
+    assert_eq!(config.protocol_fee_bps, 0);
+}
+
+/// All fields remain stable between multiple calls (pure read, no state mutation).
+#[test]
+fn test_config_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    init_escrow(&env, &client, 400, 0, Some(200));
+
+    let first = client.get_settlement_config();
+    let second = client.get_settlement_config();
+
+    assert_eq!(first, second);
+}
+
+/// Defaults before init are also idempotent.
+#[test]
+fn test_defaults_idempotent_before_init() {
+    let env = Env::default();
+    let client = deploy(&env);
+
+    let first = client.get_settlement_config();
+    let second = client.get_settlement_config();
+
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
feat(settlement): add get_settlement_config read-only view
  
  Summary
  
  Closes #51. Exposes a single read-only entrypoint that bundles all settlement-relevant
  configuration into one host invocation, so off-chain callers no longer have to stitch together
  get_settlement_limit, get_protocol_fee_bps, and get_escrow separately.
  
  Changes
  
  escrow/src/lib.rs
  
  - Added SettlementConfig #[contracttype] struct with four fields: settlement_limit, yield_bps,
  protocol_fee_bps, and maturity.
  - Added get_settlement_config entrypoint — pure read-only view with no require_auth and no
  storage writes. Reads DataKey::SettlementLimit, DataKey::ProtocolFeeBps, and DataKey::Escrow;
  returns documented defaults (DEFAULT_SETTLEMENT_LIMIT, 0, 0, 0) before init via additive-key
  semantics (ADR-007).
  
  escrow/src/tests/settlement_config_view.rs (new file)
  
  - 9 tests covering:
    - Defaults before init
    - Values reflected after init (basic, non-zero maturity, explicit protocol fee)
    - Consistency with individual getters (get_settlement_limit, get_protocol_fee_bps,
  get_escrow)
    - Mutation reflected after set_settlement_limit (including min/max bounds)
    - Struct shape verified via destructuring (compile-time guard against field drift)
    - Zero protocol fee omitted at init returns 0, not an error
    - Idempotency — multiple calls return identical results (pre- and post-init)
  
  escrow/src/tests.rs
  
  - Registered mod settlement_config_view in the test tree.
  
  README.md
  
  - Added get_settlement_config to the entrypoint table.
  
  Test coverage
  
  All existing tests continue to pass. The new module directly covers the added struct and
  entrypoint. No storage keys were renamed or removed — additive change only, no migration
  required.
  
  Notes
  
  - No auth required — pure view, safe to call from any context.
  - No SCHEMA_VERSION bump needed — only new types and a new read path over existing keys.
  - Compatible with pre-init deployments; all fields default gracefully.

closes #1070 