### PR TITLE
refactor(attestation): extract validation helper

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2692,6 +2692,30 @@ impl LiquifactEscrow {
         );
     }
 
+    /// Assert that the revocation marker at `index` matches `expected_revoked`.
+    ///
+    /// Reads `DataKey::AttestationRevoked(index)` (absent ⇒ not revoked) and panics with
+    /// `error` when the current state differs from `expected_revoked`. Consolidates the
+    /// revocation-state guard that was previously inlined at each mutation call site:
+    /// - `revoke_attestation_digest` / `revoke_attestation_digests` require the entry to be
+    ///   **not** revoked, surfacing [`EscrowError::AttestationAlreadyRevoked`] otherwise.
+    /// - `unrevoke_attestation_digest` requires the entry to be **already** revoked, surfacing
+    ///   [`EscrowError::AttestationNotRevoked`] otherwise.
+    ///
+    /// Behaviour is identical to the previous inline checks; only the duplication is removed.
+    fn require_attestation_revocation_state(
+        env: &Env,
+        index: u32,
+        expected_revoked: bool,
+        error: EscrowError,
+    ) {
+        let is_revoked = env
+            .storage()
+            .instance()
+            .has(&DataKey::AttestationRevoked(index));
+        ensure(env, is_revoked == expected_revoked, error);
+    }
+
     pub fn get_version(env: Env) -> u32 {
         env.storage().instance().get(&DataKey::Version).unwrap_or(0)
     }
@@ -3487,11 +3511,10 @@ impl LiquifactEscrow {
 
         let log = Self::load_attestation_log(&env);
         Self::require_attestation_index_in_range(&env, &log, index);
-        ensure(
+        Self::require_attestation_revocation_state(
             &env,
-            !env.storage()
-                .instance()
-                .has(&DataKey::AttestationRevoked(index)),
+            index,
+            false,
             EscrowError::AttestationAlreadyRevoked,
         );
 
@@ -3551,11 +3574,10 @@ impl LiquifactEscrow {
             let index = indices.get(i).unwrap();
 
             Self::require_attestation_index_in_range(&env, &log, index);
-            ensure(
+            Self::require_attestation_revocation_state(
                 &env,
-                !env.storage()
-                    .instance()
-                    .has(&DataKey::AttestationRevoked(index)),
+                index,
+                false,
                 EscrowError::AttestationAlreadyRevoked,
             );
 
@@ -3626,11 +3648,10 @@ impl LiquifactEscrow {
     pub fn unrevoke_attestation_digest(env: Env, index: u32) {
         let log = Self::load_attestation_log(&env);
         Self::require_attestation_index_in_range(&env, &log, index);
-        ensure(
+        Self::require_attestation_revocation_state(
             &env,
-            env.storage()
-                .instance()
-                .has(&DataKey::AttestationRevoked(index)),
+            index,
+            true,
             EscrowError::AttestationNotRevoked,
         );
 

--- a/escrow/src/tests/attestations.rs
+++ b/escrow/src/tests/attestations.rs
@@ -978,6 +978,123 @@ fn test_require_index_in_range_empty_log_index_zero_all_callers() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// require_attestation_revocation_state helper — identical revocation-state guard
+// across all mutation callers
+// ---------------------------------------------------------------------------
+
+/// `revoke_attestation_digest` surfaces `AttestationAlreadyRevoked` when the entry
+/// is already revoked (helper called with `expected_revoked == false`).
+#[test]
+fn test_require_revocation_state_revoke_already_revoked() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    client.revoke_attestation_digest(&0);
+
+    assert_contract_error(
+        client.try_revoke_attestation_digest(&0),
+        EscrowError::AttestationAlreadyRevoked,
+    );
+
+    // State is unchanged — still revoked exactly once.
+    assert!(client.is_attestation_revoked(&0));
+}
+
+/// `revoke_attestation_digests` surfaces `AttestationAlreadyRevoked` on a
+/// duplicate index within the batch, rolling back the whole batch.
+#[test]
+fn test_require_revocation_state_batch_revoke_duplicate_index_rolls_back() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    client.append_attestation_digest(&digest(&env, 0x02));
+
+    // Index 0 appears twice — the second occurrence hits the already-revoked guard.
+    let indices = soroban_sdk::vec![&env, 0u32, 0u32];
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&indices),
+        EscrowError::AttestationAlreadyRevoked,
+    );
+
+    // Whole batch rolled back — nothing revoked.
+    assert!(!client.is_attestation_revoked(&0));
+    assert!(!client.is_attestation_revoked(&1));
+}
+
+/// `revoke_attestation_digests` surfaces `AttestationAlreadyRevoked` when a batch
+/// index was revoked by a previous call, rolling back the current batch entirely.
+#[test]
+fn test_require_revocation_state_batch_revoke_preexisting_revocation_rolls_back() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+    client.append_attestation_digest(&digest(&env, 0x02));
+    client.revoke_attestation_digest(&1); // index 1 already revoked
+
+    let indices = soroban_sdk::vec![&env, 0u32, 1u32];
+    assert_contract_error(
+        client.try_revoke_attestation_digests(&indices),
+        EscrowError::AttestationAlreadyRevoked,
+    );
+
+    // Index 0 (valid in this batch) must be rolled back; index 1 stays revoked.
+    assert!(!client.is_attestation_revoked(&0));
+    assert!(client.is_attestation_revoked(&1));
+}
+
+/// `unrevoke_attestation_digest` surfaces `AttestationNotRevoked` when the entry
+/// is not currently revoked (helper called with `expected_revoked == true`).
+#[test]
+fn test_require_revocation_state_unrevoke_not_revoked() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&0),
+        EscrowError::AttestationNotRevoked,
+    );
+
+    // Still not revoked.
+    assert!(!client.is_attestation_revoked(&0));
+}
+
+/// The revocation-state guard runs *before* `require_auth` in `unrevoke`
+/// (ADR-002 ordering): an unauthenticated call on a not-revoked index still fails
+/// with `AttestationNotRevoked`, not an auth error.
+#[test]
+fn test_require_revocation_state_unrevoke_guard_precedes_auth() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+
+    // No `mock_auths` — the state guard must reject before auth is required.
+    assert_contract_error(
+        client.try_unrevoke_attestation_digest(&0),
+        EscrowError::AttestationNotRevoked,
+    );
+}
+
+/// A full revoke → unrevoke → revoke cycle succeeds, proving the helper reads
+/// current storage each time (marker set, cleared, then set again).
+#[test]
+fn test_require_revocation_state_revoke_unrevoke_cycle() {
+    let env = Env::default();
+    let (client, _) = setup_with_init(&env);
+    client.append_attestation_digest(&digest(&env, 0x01));
+
+    client.revoke_attestation_digest(&0);
+    assert!(client.is_attestation_revoked(&0));
+
+    client.unrevoke_attestation_digest(&0);
+    assert!(!client.is_attestation_revoked(&0));
+
+    // Re-revoking after unrevoke must succeed (guard sees not-revoked again).
+    client.revoke_attestation_digest(&0);
+    assert!(client.is_attestation_revoked(&0));
+}
+
 #[test]
 fn test_revoke_attestation_digests_empty_batch_returns_typed_error() {
     let env = Env::default();


### PR DESCRIPTION
## Summary

Extracts the repeated inline attestation revocation-state validation into a single shared helper that surfaces a **typed `EscrowError`**, and reuses it at every call site. Behaviour is identical — same rejections, same guard ordering.

closes #1014

## Change

New helper in `escrow/src/lib.rs`:

```rust
fn require_attestation_revocation_state(
    env: &Env,
    index: u32,
    expected_revoked: bool,
    error: EscrowError,
) {
    let is_revoked = env
        .storage()
        .instance()
        .has(&DataKey::AttestationRevoked(index));
    ensure(env, is_revoked == expected_revoked, error);
}
```

Reused at:
- `revoke_attestation_digest` → `(false, AttestationAlreadyRevoked)`
- `revoke_attestation_digests` (batch loop) → same, after the in-range check
- `unrevoke_attestation_digest` → `(true, AttestationNotRevoked)`, preserving ADR-002 guard order (range → revocation-state → `require_auth` → storage mutation)

## Tests

Added 6 targeted tests in `escrow/src/tests/attestations.rs` covering:
- revoke of an already-revoked index → `AttestationAlreadyRevoked`
- batch revoke with a duplicate index → rolls back
- batch revoke over a pre-existing revocation → rolls back
- unrevoke of a non-revoked index → `AttestationNotRevoked`
- unrevoke guard precedes `require_auth`
- full revoke → unrevoke cycle

## Scope

Diff is exactly two files (`git diff upstream/main --stat`):

```
 escrow/src/lib.rs                |  45 +++++++++----
 escrow/src/tests/attestations.rs | 117 +++++++++++++++++++++++++++++++
 2 files changed, 150 insertions(+), 12 deletions(-)
```

No behavioural change to any entrypoint; the refactor is purely a de-duplication that centralises the typed-error path.
