### PR TITLE
feat(attestation): admin-configurable limit

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -18,7 +18,23 @@ pub const SCHEMA_VERSION: u32 = 6;
 
 /// Upper bound on [`LiquifactEscrow::append_attestation_digest`] entries to keep storage bounded.
 /// Revocation via [`LiquifactEscrow::revoke_attestation_digest`] does not consume a slot.
+/// This constant is also the **default** used when no explicit
+/// [`LiquifactEscrow::set_attestation_limit`] call has been made.
 pub const MAX_ATTESTATION_APPEND_ENTRIES: u32 = 32;
+
+/// Default attestation append-log limit (= [`MAX_ATTESTATION_APPEND_ENTRIES`]).
+/// Returned by [`LiquifactEscrow::get_attestation_limit`] when the admin has not configured a
+/// custom value.
+pub const DEFAULT_ATTESTATION_LIMIT: u32 = MAX_ATTESTATION_APPEND_ENTRIES;
+
+/// Minimum value accepted by [`LiquifactEscrow::set_attestation_limit`].
+/// Must be at least 1 so the log is always usable.
+pub const MIN_ATTESTATION_LIMIT: u32 = 1;
+
+/// Maximum value accepted by [`LiquifactEscrow::set_attestation_limit`].
+/// Mirrors [`MAX_ATTESTATION_APPEND_ENTRIES`] so the hard upper bound cannot be
+/// exceeded via configuration.
+pub const MAX_ATTESTATION_LIMIT: u32 = MAX_ATTESTATION_APPEND_ENTRIES;
 
 /// Maximum number of indices that can be revoked in a single batch call.
 pub const MAX_ATTESTATION_REVOKE_BATCH: u32 = 32;
@@ -491,6 +507,10 @@ pub enum EscrowError {
     /// [`LiquifactEscrow::set_yield_tiers`] received an invalid tier table.
     YieldTierTableInvalid = 301,
 
+    /// [`LiquifactEscrow::set_attestation_limit`] received a limit outside
+    /// `[MIN_ATTESTATION_LIMIT, MAX_ATTESTATION_LIMIT]`.
+    AttestationLimitOutOfRange = 302,
+
     /// [`LiquifactEscrow::set_paused`] exceeded the configured rate limit for pause toggles.
     PauseToggleRateLimitExceeded = 227,
 
@@ -952,6 +972,10 @@ pub enum DataKey {
     /// **Additive key (ADR-007):** absent ⇒ [`DEFAULT_SETTLEMENT_LIMIT`]. Updatable via
     /// [`LiquifactEscrow::set_settlement_limit`].
     SettlementLimit,
+    /// Admin-configured cap on the attestation append log length.
+    /// **Additive key (ADR-007):** absent ⇒ [`DEFAULT_ATTESTATION_LIMIT`] (= [`MAX_ATTESTATION_APPEND_ENTRIES`]).
+    /// Updatable via [`LiquifactEscrow::set_attestation_limit`].
+    AttestationLimit,
 }
 
 // --- Data types ---
@@ -1795,6 +1819,24 @@ pub struct AttestationDigestUnrevoked {
     pub name: Symbol,
     pub invoice_id: Symbol,
     pub index: u32,
+}
+
+/// Emitted by [`LiquifactEscrow::set_attestation_limit`] when the admin updates the
+/// attestation append-log capacity.
+///
+/// # Fields
+/// - `name`: Hardcoded `att_lim` symbol.
+/// - `invoice_id`: Symbol representation of the invoice.
+/// - `old_limit`: Previously effective limit ([`DEFAULT_ATTESTATION_LIMIT`] if never configured).
+/// - `new_limit`: Newly configured limit.
+#[contractevent]
+pub struct AttestationLimitUpdated {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: Symbol,
+    pub old_limit: u32,
+    pub new_limit: u32,
 }
 
 #[contractevent]
@@ -2948,15 +2990,19 @@ impl LiquifactEscrow {
     /// Append a digest to a bounded on-chain log (see [`MAX_ATTESTATION_APPEND_ENTRIES`]) for **versioned**
     /// or incremental attestation updates. Does not replace [`LiquifactEscrow::bind_primary_attestation_hash`].
     ///
+    /// The effective capacity is governed by the admin-configurable
+    /// [`LiquifactEscrow::set_attestation_limit`] (defaults to [`DEFAULT_ATTESTATION_LIMIT`]).
+    ///
     /// # Errors
     /// Emits typed [`EscrowError`] codes when the escrow is uninitialized or the append log is full.
     pub fn append_attestation_digest(env: Env, digest: BytesN<32>) {
         let escrow = Self::load_escrow_require_admin(&env);
 
         let mut log: Vec<BytesN<32>> = Self::load_attestation_log(&env);
+        let limit = Self::get_attestation_limit(env.clone());
         ensure(
             &env,
-            log.len() < MAX_ATTESTATION_APPEND_ENTRIES,
+            log.len() < limit,
             EscrowError::AttestationAppendLogCapacityReached,
         );
         let idx = log.len();
@@ -3028,11 +3074,12 @@ impl LiquifactEscrow {
         let escrow = Self::load_escrow_require_admin(&env);
 
         let mut log: Vec<BytesN<32>> = Self::load_attestation_log(&env);
+        let limit = Self::get_attestation_limit(env.clone());
 
         // Pre-flight capacity check: reject the whole batch atomically if it would overflow.
         ensure(
             &env,
-            log.len() + n <= MAX_ATTESTATION_APPEND_ENTRIES,
+            log.len() + n <= limit,
             EscrowError::AttestationAppendLogCapacityReached,
         );
 
@@ -3702,6 +3749,63 @@ impl LiquifactEscrow {
         env.storage()
             .instance()
             .set(&DataKey::SettlementLimit, &new_limit);
+    }
+
+    /// Retrieve the admin-configured attestation append-log capacity.
+    ///
+    /// Returns [`DEFAULT_ATTESTATION_LIMIT`] (= [`MAX_ATTESTATION_APPEND_ENTRIES`] = 32)
+    /// when no explicit [`LiquifactEscrow::set_attestation_limit`] call has been made.
+    /// This preserves current on-chain behavior for deployments that predate this key
+    /// (additive key, ADR-007).
+    ///
+    /// # Read-only
+    /// Pure view: no `require_auth`, no storage writes, and no TTL bump.
+    pub fn get_attestation_limit(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::AttestationLimit)
+            .unwrap_or(DEFAULT_ATTESTATION_LIMIT)
+    }
+
+    /// Admin-only setter for the attestation append-log capacity.
+    ///
+    /// Allows the admin to lower (or raise, within bounds) the maximum number of digests
+    /// that may accumulate in the append log. The new limit applies on the **next** call to
+    /// [`LiquifactEscrow::append_attestation_digest`] or
+    /// [`LiquifactEscrow::append_attestation_digests`]; it does **not** retroactively
+    /// truncate an already-full log.
+    ///
+    /// # Authorization
+    /// Requires `InvoiceEscrow::admin` auth (via [`LiquifactEscrow::load_escrow_require_admin`]).
+    ///
+    /// # Bounds
+    /// `new_limit` must fall within `[MIN_ATTESTATION_LIMIT, MAX_ATTESTATION_LIMIT]`, else
+    /// [`EscrowError::AttestationLimitOutOfRange`] (302).
+    ///
+    /// # Events
+    /// Emits [`AttestationLimitUpdated`] with the previous effective limit and the new value.
+    pub fn set_attestation_limit(env: Env, new_limit: u32) {
+        let escrow = Self::load_escrow_require_admin(&env);
+
+        ensure(
+            &env,
+            (MIN_ATTESTATION_LIMIT..=MAX_ATTESTATION_LIMIT).contains(&new_limit),
+            EscrowError::AttestationLimitOutOfRange,
+        );
+
+        let old_limit = Self::get_attestation_limit(env.clone());
+
+        env.storage()
+            .instance()
+            .set(&DataKey::AttestationLimit, &new_limit);
+
+        AttestationLimitUpdated {
+            name: symbol_short!("att_lim"),
+            invoice_id: escrow.invoice_id.clone(),
+            old_limit,
+            new_limit,
+        }
+        .publish(&env);
     }
 
     /// Read-only snapshot of the settlement subsystem configuration.

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -19,12 +19,14 @@
 #[allow(unused_imports)]
 use super::{
     AttestationDigestAppended, AttestationDigestRevoked, AttestationDigestUnrevoked,
-    CollateralRecordedEvt, ContractUpgraded, DataKey, DeprecatedTransferAdminUsed, EscrowError,
-    EscrowFunded, EscrowInitialized, EscrowUnfunded, FundingCancelled, FundingStateChanged,
-    FundingTargetUpdated, InvestorRefundedEvt, LiquifactEscrow, LiquifactEscrowClient,
-    MaturityMaxHorizonUpdated, MaxUniqueInvestorsCapLowered, PrimaryAttestationBound,
-    RegistryRefRebound, TreasuryDustSwept, YieldTier, MAX_ATTESTATION_APPEND_BATCH,
-    MAX_ATTESTATION_APPEND_ENTRIES, MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH, SCHEMA_VERSION,
+    AttestationLimitUpdated, CollateralRecordedEvt, ContractUpgraded, DataKey,
+    DeprecatedTransferAdminUsed, EscrowError, EscrowFunded, EscrowInitialized, EscrowUnfunded,
+    FundingCancelled, FundingStateChanged, FundingTargetUpdated, InvestorRefundedEvt,
+    LiquifactEscrow, LiquifactEscrowClient, MaturityMaxHorizonUpdated,
+    MaxUniqueInvestorsCapLowered, PrimaryAttestationBound, RegistryRefRebound, TreasuryDustSwept,
+    YieldTier, DEFAULT_ATTESTATION_LIMIT, MAX_ATTESTATION_APPEND_BATCH,
+    MAX_ATTESTATION_APPEND_ENTRIES, MAX_ATTESTATION_LIMIT, MAX_DUST_SWEEP_AMOUNT, MAX_FUND_BATCH,
+    MIN_ATTESTATION_LIMIT, SCHEMA_VERSION,
 };
 use soroban_sdk::{
     symbol_short,
@@ -64,7 +66,6 @@ mod cap_validation;
 mod collateral_config_view;
 mod collateral_limit_setter;
 mod collateral_boundary_tests;
-mod collateral_boundary_tests;
 #[rustfmt::skip]
 mod coverage;
 mod external_calls;
@@ -83,6 +84,7 @@ mod reconciliation_lifecycle;
 mod settlement;
 mod settlement_config_view;
 mod settlement_limit;
+mod attestation_limit;
 
 /// Registers a new escrow contract instance and returns its contract id.
 pub fn deploy_id(env: &Env) -> Address {

--- a/escrow/src/tests/attestation_limit.rs
+++ b/escrow/src/tests/attestation_limit.rs
@@ -1,0 +1,356 @@
+// Tests for the admin-only `set_attestation_limit` / `get_attestation_limit` setters:
+// default value, in-bounds set, out-of-bounds rejection, non-admin rejection, event emission,
+// and enforcement by `append_attestation_digest` / `append_attestation_digests`.
+
+use crate::tests::{assert_contract_error, setup};
+use crate::{
+    AttestationLimitUpdated, EscrowError, DEFAULT_ATTESTATION_LIMIT, MAX_ATTESTATION_LIMIT,
+    MIN_ATTESTATION_LIMIT,
+};
+use soroban_sdk::{
+    symbol_short, testutils::Address as _, testutils::Events as _, Address, BytesN, Env, IntoVal,
+    Vec as SorobanVec,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn init_escrow(env: &Env, client: &crate::LiquifactEscrowClient, admin: &Address, sme: &Address) {
+    let token = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.init(
+        admin,
+        &soroban_sdk::String::from_str(env, "ATTLIM01"),
+        sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+}
+
+fn digest(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+// ---------------------------------------------------------------------------
+// Default
+// ---------------------------------------------------------------------------
+
+/// Before any `set_attestation_limit` call the getter returns `DEFAULT_ATTESTATION_LIMIT`.
+#[test]
+fn default_attestation_limit_before_init() {
+    let env = Env::default();
+    let (client, _admin, _sme) = setup(&env);
+    assert_eq!(client.get_attestation_limit(), DEFAULT_ATTESTATION_LIMIT);
+}
+
+/// Default holds even after init (key is absent until explicitly set).
+#[test]
+fn default_attestation_limit_after_init() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+    assert_eq!(client.get_attestation_limit(), DEFAULT_ATTESTATION_LIMIT);
+}
+
+// ---------------------------------------------------------------------------
+// In-bounds set
+// ---------------------------------------------------------------------------
+
+#[test]
+fn admin_sets_attestation_limit_min() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    client.set_attestation_limit(&MIN_ATTESTATION_LIMIT);
+    assert_eq!(client.get_attestation_limit(), MIN_ATTESTATION_LIMIT);
+}
+
+#[test]
+fn admin_sets_attestation_limit_max() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    client.set_attestation_limit(&MAX_ATTESTATION_LIMIT);
+    assert_eq!(client.get_attestation_limit(), MAX_ATTESTATION_LIMIT);
+}
+
+#[test]
+fn admin_sets_attestation_limit_mid_value() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    let mid = (MIN_ATTESTATION_LIMIT + MAX_ATTESTATION_LIMIT) / 2;
+    client.set_attestation_limit(&mid);
+    assert_eq!(client.get_attestation_limit(), mid);
+}
+
+/// A second in-bounds update overwrites the first.
+#[test]
+fn admin_can_update_attestation_limit_multiple_times() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    client.set_attestation_limit(&5);
+    assert_eq!(client.get_attestation_limit(), 5);
+
+    client.set_attestation_limit(&10);
+    assert_eq!(client.get_attestation_limit(), 10);
+
+    client.set_attestation_limit(&MIN_ATTESTATION_LIMIT);
+    assert_eq!(client.get_attestation_limit(), MIN_ATTESTATION_LIMIT);
+}
+
+// ---------------------------------------------------------------------------
+// Event emission
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_attestation_limit_emits_event_with_old_and_new_limit() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+    let contract_id = client.address.clone();
+
+    client.set_attestation_limit(&5);
+
+    let all_events = env.events().all();
+    assert_eq!(
+        all_events.events().last().unwrap().clone(),
+        AttestationLimitUpdated {
+            name: symbol_short!("att_lim"),
+            invoice_id: client.get_escrow().invoice_id,
+            old_limit: DEFAULT_ATTESTATION_LIMIT,
+            new_limit: 5,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+/// Second call emits old_limit = previously configured value, not the default.
+#[test]
+fn set_attestation_limit_event_old_limit_tracks_previous_config() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+    let contract_id = client.address.clone();
+
+    client.set_attestation_limit(&10);
+    client.set_attestation_limit(&5);
+
+    let all_events = env.events().all();
+    assert_eq!(
+        all_events.events().last().unwrap().clone(),
+        AttestationLimitUpdated {
+            name: symbol_short!("att_lim"),
+            invoice_id: client.get_escrow().invoice_id,
+            old_limit: 10,
+            new_limit: 5,
+        }
+        .to_xdr(&env, &contract_id)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Out-of-bounds rejection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_attestation_limit_rejects_zero() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    assert_contract_error(
+        client.try_set_attestation_limit(&0),
+        EscrowError::AttestationLimitOutOfRange,
+    );
+    // Limit unchanged
+    assert_eq!(client.get_attestation_limit(), DEFAULT_ATTESTATION_LIMIT);
+}
+
+#[test]
+fn set_attestation_limit_rejects_above_max() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    assert_contract_error(
+        client.try_set_attestation_limit(&(MAX_ATTESTATION_LIMIT + 1)),
+        EscrowError::AttestationLimitOutOfRange,
+    );
+    assert_eq!(client.get_attestation_limit(), DEFAULT_ATTESTATION_LIMIT);
+}
+
+#[test]
+fn set_attestation_limit_rejects_u32_max() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    assert_contract_error(
+        client.try_set_attestation_limit(&u32::MAX),
+        EscrowError::AttestationLimitOutOfRange,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Non-admin rejection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_admin_cannot_set_attestation_limit() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+    let non_admin = Address::generate(&env);
+
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &non_admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "set_attestation_limit",
+            args: SorobanVec::from_array(&env, [5u32.into_val(&env)]),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_set_attestation_limit(&5u32);
+    assert!(result.is_err());
+    // Limit unchanged
+    assert_eq!(client.get_attestation_limit(), DEFAULT_ATTESTATION_LIMIT);
+}
+
+// ---------------------------------------------------------------------------
+// Enforcement by append_attestation_digest
+// ---------------------------------------------------------------------------
+
+/// When limit is lowered to 1, the second append is rejected.
+#[test]
+fn append_attestation_digest_respects_configured_limit() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    client.set_attestation_limit(&1);
+    assert_eq!(client.get_attestation_limit(), 1);
+
+    // First append: succeeds.
+    client.append_attestation_digest(&digest(&env, 0xAA));
+    assert_eq!(client.get_attestation_append_log().len(), 1);
+
+    // Second append: exceeds limit.
+    assert_contract_error(
+        client.try_append_attestation_digest(&digest(&env, 0xBB)),
+        EscrowError::AttestationAppendLogCapacityReached,
+    );
+    assert_eq!(client.get_attestation_append_log().len(), 1);
+}
+
+/// Default limit (32) still allows all 32 appends.
+#[test]
+fn append_attestation_digest_default_limit_allows_full_log() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    for i in 0..DEFAULT_ATTESTATION_LIMIT {
+        client.append_attestation_digest(&digest(&env, i as u8));
+    }
+    assert_eq!(client.get_attestation_append_log().len(), DEFAULT_ATTESTATION_LIMIT);
+
+    // One more is rejected.
+    assert_contract_error(
+        client.try_append_attestation_digest(&digest(&env, 0xFF)),
+        EscrowError::AttestationAppendLogCapacityReached,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Enforcement by append_attestation_digests (batch)
+// ---------------------------------------------------------------------------
+
+/// Batch append is also gated by the configured limit.
+#[test]
+fn append_attestation_digests_batch_respects_configured_limit() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    client.set_attestation_limit(&2);
+
+    // Batch of 2 fits.
+    let batch = SorobanVec::from_array(&env, [digest(&env, 1), digest(&env, 2)]);
+    client.append_attestation_digests(&batch);
+    assert_eq!(client.get_attestation_append_log().len(), 2);
+
+    // One more (single) is over the limit.
+    assert_contract_error(
+        client.try_append_attestation_digest(&digest(&env, 3)),
+        EscrowError::AttestationAppendLogCapacityReached,
+    );
+}
+
+/// Raising the limit after appends allows more entries.
+#[test]
+fn raising_limit_allows_additional_appends() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    init_escrow(&env, &client, &admin, &sme);
+
+    // Start at limit 2, fill it.
+    client.set_attestation_limit(&2);
+    client.append_attestation_digest(&digest(&env, 1));
+    client.append_attestation_digest(&digest(&env, 2));
+
+    // Full — next append rejected.
+    assert_contract_error(
+        client.try_append_attestation_digest(&digest(&env, 3)),
+        EscrowError::AttestationAppendLogCapacityReached,
+    );
+
+    // Raise limit to 4; now two more are allowed.
+    client.set_attestation_limit(&4);
+    client.append_attestation_digest(&digest(&env, 3));
+    client.append_attestation_digest(&digest(&env, 4));
+    assert_eq!(client.get_attestation_append_log().len(), 4);
+}
+
+// ---------------------------------------------------------------------------
+// Fuzz (proptest)
+// ---------------------------------------------------------------------------
+
+use proptest::prelude::*;
+proptest! {
+    #[test]
+    fn fuzz_set_attestation_limit(limit in 0u32..=64u32) {
+        let env = Env::default();
+        let (client, admin, sme) = setup(&env);
+        init_escrow(&env, &client, &admin, &sme);
+
+        let result = client.try_set_attestation_limit(&limit);
+        if limit >= MIN_ATTESTATION_LIMIT && limit <= MAX_ATTESTATION_LIMIT {
+            assert!(result.is_ok(), "expected ok for limit={limit}");
+            assert_eq!(client.get_attestation_limit(), limit);
+        } else {
+            assert_contract_error(result, EscrowError::AttestationLimitOutOfRange);
+        }
+    }
+}


### PR DESCRIPTION
Add set_attestation_limit / get_attestation_limit entrypoints so the admin can tune the attestation append-log cap within safe bounds, replacing the hard-coded MAX_ATTESTATION_APPEND_ENTRIES constant.

Changes
-------
* escrow/src/lib.rs
  - New constants: DEFAULT_ATTESTATION_LIMIT (= 32), MIN_ATTESTATION_LIMIT (= 1), MAX_ATTESTATION_LIMIT (= 32).
  - New DataKey::AttestationLimit (additive, ADR-007; absent => default).
  - New EscrowError::AttestationLimitOutOfRange = 302.
  - New contractevent AttestationLimitUpdated (topic: att_lim, old/new limit).
  - get_attestation_limit: pure view, returns stored value or default.
  - set_attestation_limit: admin-auth, bounds-checked, emits event.
  - append_attestation_digest: now reads configurable limit via get_attestation_limit instead of MAX_ATTESTATION_APPEND_ENTRIES.
  - append_attestation_digests: same — pre-flight capacity check uses the configured limit.

* escrow/src/tests.rs
  - Added mod attestation_limit.
  - Removed duplicate mod collateral_boundary_tests declaration.
  - Re-exported AttestationLimitUpdated, DEFAULT/MIN/MAX_ATTESTATION_LIMIT.

* escrow/src/tests/attestation_limit.rs (new)
  - default_attestation_limit_before_init
  - default_attestation_limit_after_init
  - admin_sets_attestation_limit_min / max / mid
  - admin_can_update_attestation_limit_multiple_times
  - set_attestation_limit_emits_event_with_old_and_new_limit
  - set_attestation_limit_event_old_limit_tracks_previous_config
  - set_attestation_limit_rejects_zero / above_max / u32_max
  - non_admin_cannot_set_attestation_limit
  - append_attestation_digest_respects_configured_limit
  - append_attestation_digest_default_limit_allows_full_log
  - append_attestation_digests_batch_respects_configured_limit
  - raising_limit_allows_additional_appends
  - fuzz_set_attestation_limit (proptest)
  - closes #799