### PR TITLE
docs(settlement): document error codes

### DIFF
--- a/docs/escrow-error-messages.md
+++ b/docs/escrow-error-messages.md
@@ -4,9 +4,34 @@ This document contains reference codes for typed `EscrowError` values emitted by
 
 ## Settlement & Bounds Errors
 
+Codes raised by the settlement-family entrypoints (`partial_settle`, `settle`, `withdraw`,
+`claim_investor_payout`). For the exact condition that triggers each one, guard ordering, and how
+to avoid it, see [`docs/settlement-errors.md`](settlement-errors.md) — this table is a stable
+code/name summary only.
+
 | Error Name | Code | Description |
 |---|---|---|
-| `SettlementAmountInvalid` | 100 | The settlement amount is non-positive or exceeds remaining unsettled principal. |
-| `MaturityNotReached` | 101 | Settlement attempted before contract maturity timestamp. |
-| `EscrowNotInFundedState` | 102 | Operation requires the escrow to be in `Funded` status. |
-| `WithdrawAmountInvalid` | 103 | The withdrawal amount is non-positive or exceeds available funded balance. |
+| `PartialSettleUnauthorizedCaller` | 200 | `caller` passed to `partial_settle` is neither the SME address nor the admin. |
+| `LegalHoldBlocksPartialSettle` | 201 | A legal hold is active when `partial_settle` is called. |
+| `PartialSettleNotOpen` | 202 | `partial_settle` called while escrow status is not `Open` (0). |
+| `LegalHoldBlocksSettlement` | 120 | A legal hold is active when `settle` is called. |
+| `SettlementNotFunded` | 121 | `settle` called before the escrow reached `Funded` status (1). |
+| `MaturityNotReached` | 122 | `settle` called before the configured maturity timestamp. |
+| `LegalHoldBlocksWithdrawal` | 123 | A legal hold is active when `withdraw` is called. |
+| `WithdrawalNotFunded` | 124 | `withdraw` called before the escrow reached `Funded` status (1). |
+| `LegalHoldBlocksInvestorClaims` | 125 | A legal hold is active when `claim_investor_payout` is called. |
+| `NoContributionToClaim` | 126 | `claim_investor_payout` called for an investor with zero recorded contribution. |
+| `InvestorClaimNotSettled` | 127 | `claim_investor_payout` called before the escrow reached `Settled` status (2). |
+| `InvestorCommitmentLockNotExpired` | 128 | `claim_investor_payout` called before the investor's tiered-commitment lock expires. |
+| `ComputePayoutArithmeticOverflow` | 129 | Checked arithmetic overflowed while computing the settlement pool or investor payout. |
+| `InsufficientContractBalance` | 165 | The contract's funding-token balance is below `funded_amount` at `withdraw` time. |
+| `PayoutZero` | 170 | The computed investor payout is zero. |
+| `PausedBlocksSettlement` | 211 | The operational pause is active when `settle` is called. |
+| `PausedBlocksWithdrawal` | 212 | The operational pause is active when `withdraw` is called. |
+| `PausedBlocksInvestorClaims` | 213 | The operational pause is active when `claim_investor_payout` is called. |
+| `WithdrawFeeArithmeticOverflow` | 216 | `funded_amount * fee_bps` overflowed `i128` while computing the protocol fee at `withdraw`. |
+| `WithdrawNetArithmeticUnderflow` | 217 | `funded_amount - fee` underflowed while computing the net SME payout at `withdraw`. |
+
+Codes 36–41 (SEP-41 transfer-wrapper guards, also raised by `withdraw` and
+`claim_investor_payout`) are documented in
+[`docs/escrow-token-safety.md`](escrow-token-safety.md).

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -61,10 +61,9 @@ mod admin;
 mod attestations;
 mod auth_matrix;
 mod cap_validation;
+mod collateral_boundary_tests;
 mod collateral_config_view;
 mod collateral_limit_setter;
-mod collateral_boundary_tests;
-mod collateral_boundary_tests;
 #[rustfmt::skip]
 mod coverage;
 mod external_calls;

--- a/escrow/src/tests/mod.rs
+++ b/escrow/src/tests/mod.rs
@@ -1,1 +1,0 @@
-mod collateral_boundary_tests;


### PR DESCRIPTION
## Summary

- Fixes `docs/escrow-error-messages.md`'s "Settlement & Bounds Errors" table, which listed codes/names (`SettlementAmountInvalid`=100, `MaturityNotReached`=101, `EscrowNotInFundedState`=102, `WithdrawAmountInvalid`=103) that do not exist anywhere in the current `EscrowError` enum. Replaced with an accurate code/name summary matching `escrow/src/lib.rs`, cross-referenced against `docs/settlement-errors.md` (the detailed settlement-error doc, which was already accurate and merged in #879) so the two files don't drift again.
- Fixes an unrelated build blocker discovered while verifying: `escrow/src/tests.rs` declared `mod collateral_boundary_tests;` twice, and a stray `escrow/src/tests/mod.rs` collided with `tests.rs` as the root of the same module — `cargo fmt`/`build`/`clippy`/`test` all failed immediately with `file for module 'tests' found at both tests.rs and tests/mod.rs`, before compiling a single line of the crate. Removed the redundant file and the duplicate declaration.

Note on #1073 / #879: this repo already has issue #879 with the identical title/body, already closed by a merged PR (`50ac7df`) that created `docs/settlement-errors.md`. #1073 appears to be a duplicate of #879 filed later. This PR closes #1073 for tracking purposes since it's the open one, but the substantive settlement-error documentation work was already done in #879 — this PR's real contribution is fixing the stale cross-referenced table and the build blocker.

## Known pre-existing failures out of scope for this PR

While verifying, I found `main` (`38c7197`) currently fails to build for several reasons **unrelated to this PR and not touched by it** (confirmed via `git diff` against `escrow/src/lib.rs`, which this PR does not modify):

- `get_version` is defined twice as a contract entrypoint (`E0428`/`E0592`), likely from `#1127` colliding with an existing version getter.
- That `get_version` reads `DataKey::SchemaVersion`, which doesn't exist in the `DataKey` enum (`E0599`) — `init`/`migrate` use `DataKey::Version` instead.
- Duplicate discriminant `72` in `EscrowError` (`E0081`) — `AllowlistParametersOutOfRange = 72` collides with `TargetNotPositive = 72`.
- Several Soroban symbol-length-limit violations ("symbol too long", "argument name too long", "event field name too long").
- Once the module conflict here is fixed, `cargo test`/`cargo clippy --all-targets` additionally surface ~87 compile errors in the test suite (e.g. `escrow/src/tests/yield_tier_boundaries.rs` still expects `preview_yield_tier` to return a tuple, but it now returns a `YieldTierPreview` struct per `#1112`), plus pre-existing `cargo fmt` drift across `lib.rs`, `keys.rs`, `funding.rs`, `settlement.rs`, and others.

These are real, multi-file, unrelated bugs that need maintainer triage (e.g. picking a new discriminant, given the "stable and append-only" error-code policy) — flagging here rather than bundling an unrelated fix into a docs PR. CI on this PR is expected to fail on the `Build`/`Clippy`/`Run tests` steps for these pre-existing reasons, not because of anything changed here.

## Test plan

- [x] `cargo fmt -p liquifact_escrow -- --check` on the specific file this PR modifies (`escrow/src/tests.rs`) is clean; the file no longer contributes to the fmt-check failure.
- [ ] `cargo fmt -p liquifact_escrow -- --check` (whole crate) — fails due to pre-existing drift in files not touched here (see above).
- [ ] `cargo clippy -p liquifact_escrow --all-targets -- -D warnings` — fails due to pre-existing, unrelated compile errors (see above).
- [ ] `cargo test` — fails to compile for the same pre-existing, unrelated reasons.
- [x] Manually cross-checked every code/name in the updated `docs/escrow-error-messages.md` table and in `docs/settlement-errors.md` against the live `EscrowError` enum and the four settlement entrypoints (`partial_settle`, `settle`, `withdraw`, `claim_investor_payout`) in `escrow/src/lib.rs`.

Closes #1073