### PR TITLE
feat(funding): add read view

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1150,6 +1150,40 @@ pub enum EscrowCloseSnapshot {
     Some(FundingCloseSnapshot),
 }
 
+/// Live funding progress assembled at read time (issue #688).
+///
+/// Unlike [`FundingCloseSnapshot`], which is written once at the first transition to
+/// `status == 1`, this view reflects the **current** ledger state and is safe to call at
+/// any point in the lifecycle -- including before [`LiquifactEscrow::init`], where every
+/// field returns its zero/default value rather than panicking.
+///
+/// Every field is sourced from the same storage keys as the standalone getters
+/// ([`LiquifactEscrow::get_unique_funder_count`], [`LiquifactEscrow::is_funding_expired`],
+/// [`LiquifactEscrow::get_funding_close_snapshot`]), so this view cannot drift from them.
+#[contracttype]
+#[derive(Debug, PartialEq)]
+pub struct FundingStateView {
+    /// [`InvoiceEscrow::funding_target`] as currently configured; adjustable while `status == 0`.
+    pub funding_target: i128,
+    /// [`InvoiceEscrow::funded_amount`] credited so far, including over-funding past target.
+    pub funded_amount: i128,
+    /// `funding_target - funded_amount`, saturating at `0` once the target is met or exceeded.
+    pub remaining_to_target: i128,
+    /// True once a positive target exists and `funded_amount >= funding_target`.
+    pub target_reached: bool,
+    /// Distinct investor addresses credited so far ([`DataKey::UniqueFunderCount`]).
+    pub unique_funder_count: u32,
+    /// Deadline as a ledger timestamp; `0` when unset (see `has_funding_deadline`).
+    pub funding_deadline: u64,
+    /// Whether [`DataKey::FundingDeadline`] is present; separates "unset" from a `0` timestamp.
+    pub has_funding_deadline: bool,
+    /// True when a deadline is set and the current ledger timestamp is past it.
+    pub is_expired: bool,
+    /// Lifecycle status: `0` open, `1` funded, `2` settled, `3` withdrawn.
+    pub status: u32,
+    /// Write-once pro-rata snapshot; [`EscrowCloseSnapshot::None`] until `status` first reaches `1`.
+    pub close_snapshot: EscrowCloseSnapshot,
+}
 /// Custom option-like enum to represent the SME collateral commitment.
 /// Models standard option semantics as a contracttype to avoid standard library
 /// blanket trait limitations in Soroban SDK testutils.
@@ -2947,6 +2981,47 @@ impl LiquifactEscrow {
             .unwrap_or(0)
     }
 
+    /// Read-only snapshot of the **current** funding state (issue #688).
+    ///
+    /// Never panics: on an uninitialised instance every field returns its zero/default
+    /// value, consistent with the additive-key policy in ADR-007.
+    ///
+    /// Composed entirely from existing accessors and storage keys -- no new [`DataKey`]
+    /// variant and no `SCHEMA_VERSION` bump.
+    pub fn get_funding_state(env: Env) -> FundingStateView {
+        let escrow: Option<InvoiceEscrow> = env.storage().instance().get(&DataKey::Escrow);
+        let deadline_opt: Option<u64> = env.storage().instance().get(&DataKey::FundingDeadline);
+        let close_snapshot = match Self::get_funding_close_snapshot(env.clone()) {
+            Some(snapshot) => EscrowCloseSnapshot::Some(snapshot),
+            None => EscrowCloseSnapshot::None,
+        };
+        let unique_funder_count = Self::get_unique_funder_count(env.clone());
+        let is_expired = Self::is_funding_expired(env.clone());
+
+        let (funding_target, funded_amount, status) = match escrow {
+            Some(escrow) => (escrow.funding_target, escrow.funded_amount, escrow.status),
+            None => (0i128, 0i128, 0u32),
+        };
+
+        let remaining_to_target = if funded_amount >= funding_target {
+            0i128
+        } else {
+            funding_target - funded_amount
+        };
+
+        FundingStateView {
+            funding_target,
+            funded_amount,
+            remaining_to_target,
+            target_reached: funding_target > 0 && funded_amount >= funding_target,
+            unique_funder_count,
+            funding_deadline: deadline_opt.unwrap_or(0),
+            has_funding_deadline: deadline_opt.is_some(),
+            is_expired,
+            status,
+            close_snapshot,
+        }
+    }
     /// Bundles multiple read-only values to return a comprehensive summary of the escrow state
     /// in a single host invocation.
     pub fn get_escrow_summary(env: Env) -> EscrowSummary {

--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -68,6 +68,7 @@ mod external_calls;
 mod external_calls_mocked;
 mod fees;
 mod funding;
+mod funding_state_view;
 mod init;
 mod integration;
 mod integration_status_guards;

--- a/escrow/src/tests/funding_state_view.rs
+++ b/escrow/src/tests/funding_state_view.rs
@@ -1,0 +1,75 @@
+//! Read-only funding-state view coverage (issue #688).
+//!
+//! Scope: assertions against `get_funding_state` only. No existing behavior is modified.
+
+use super::{default_init, init_and_fund_with_real_token, setup, TARGET};
+use crate::EscrowCloseSnapshot;
+use soroban_sdk::Env;
+
+#[test]
+fn funding_state_defaults_before_init() {
+    let env = Env::default();
+    let (client, _admin, _sme) = setup(&env);
+
+    let state = client.get_funding_state();
+
+    assert_eq!(state.funding_target, 0);
+    assert_eq!(state.funded_amount, 0);
+    assert_eq!(state.remaining_to_target, 0);
+    assert!(!state.target_reached);
+    assert_eq!(state.unique_funder_count, 0);
+    assert_eq!(state.funding_deadline, 0);
+    assert!(!state.has_funding_deadline);
+    assert!(!state.is_expired);
+    assert_eq!(state.status, 0);
+    assert_eq!(state.close_snapshot, EscrowCloseSnapshot::None);
+}
+
+#[test]
+fn funding_state_after_init_is_open_and_unfunded() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let state = client.get_funding_state();
+
+    assert_eq!(state.funding_target, TARGET);
+    assert_eq!(state.funded_amount, 0);
+    assert_eq!(state.remaining_to_target, TARGET);
+    assert!(!state.target_reached);
+    assert_eq!(state.status, 0);
+    assert!(!state.has_funding_deadline);
+    assert_eq!(state.close_snapshot, EscrowCloseSnapshot::None);
+}
+
+#[test]
+fn funding_state_agrees_with_standalone_getters() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, TARGET, "INV688");
+
+    let state = client.get_funding_state();
+    let escrow = client.get_escrow();
+
+    assert_eq!(state.unique_funder_count, client.get_unique_funder_count());
+    assert_eq!(state.is_expired, client.is_funding_expired());
+    assert_eq!(state.status, escrow.status);
+    assert_eq!(state.funded_amount, escrow.funded_amount);
+    assert_eq!(state.funding_target, escrow.funding_target);
+}
+
+#[test]
+fn funding_state_reports_target_reached_and_snapshot_once_funded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _escrow_id, _sme) = init_and_fund_with_real_token(&env, TARGET, "INV689");
+
+    let state = client.get_funding_state();
+
+    assert_eq!(state.funded_amount, TARGET);
+    assert_eq!(state.remaining_to_target, 0);
+    assert!(state.target_reached);
+    assert_eq!(state.status, 1);
+    assert_ne!(state.close_snapshot, EscrowCloseSnapshot::None);
+    assert_eq!(state.unique_funder_count, 1);
+}


### PR DESCRIPTION
## What

There is no O(1) read view for the funding state, so callers have to reconstruct it from several separate getters and can observe a torn picture across calls.

- **New** `FundingStateView` (`#[contracttype]`, `#[derive(Debug, PartialEq)]`) in `escrow/src/lib.rs`.
- **New** `LiquifactEscrow::get_funding_state(env) -> FundingStateView`, a single bounded read returning `funding_target`, `funded_amount`, `remaining_to_target`, `target_reached`, `unique_funder_count`, `funding_deadline`, `has_funding_deadline`, `is_expired`, `status` and `close_snapshot`.

### Implementation notes for the reviewer

- **No new `DataKey` variant and no `SCHEMA_VERSION` bump.** Every field is composed from existing storage keys and existing accessors (`get_unique_funder_count`, `is_funding_expired`, `get_funding_close_snapshot`), so the view cannot drift from the standalone getters, and `funding_state_agrees_with_standalone_getters` asserts exactly that.
- **Never panics before `init`.** On an uninitialised instance every field returns its zero/default value rather than trapping, consistent with the additive-key policy in ADR-007. This is what makes the view safe to call at any point in the lifecycle.
- **`funding_deadline: u64` plus `has_funding_deadline: bool` instead of `Option<u64>`.** This crate avoids `Option<T>` inside `#[contracttype]` structs, and the boolean also distinguishes "unset" from a legitimate `0` timestamp.
- `remaining_to_target` saturates at `0` rather than going negative when the escrow is over-funded.

## New coverage

`escrow/src/tests/funding_state_view.rs` — 4 tests, all additive:

- `funding_state_defaults_before_init` — every field zero/default, no panic.
- `funding_state_after_init_is_open_and_unfunded` — target set, nothing funded, `status == 0`.
- `funding_state_agrees_with_standalone_getters` — cross-checks the view against `get_unique_funder_count`, `is_funding_expired` and `get_escrow` (`INV688`).
- `funding_state_reports_target_reached_and_snapshot_once_funded` — `target_reached`, `status == 1`, and a populated `close_snapshot` (`INV689`).

## Scope

Purely additive: **151 insertions, 0 deletions.** One new struct, one new function, one new test module, and the single `mod funding_state_view;` line registering it. No existing function, storage key, event or test is modified.

Rebased onto `e19f34aa` after the test-tree cleanup on `main`; an earlier revision of this branch carried incidental `cargo fmt` reformatting of unrelated `ensure(...)` calls, which has been dropped so the diff is additions only.

### Related work, deliberately disjoint

- **#1115** adds `FundingConfig` / `get_funding_config()` — configuration at rest. This PR covers live state. No overlap in fields, keys or functions.
- `main` currently fails to build for reasons unrelated to this branch (see #1138): 20 pre-existing errors in `liquifact_escrow` spanning `E0034`, `E0081`, `E0277`, `E0428`, `E0592` and `E0599`, including a duplicated `mod` declaration in the test tree. Any red CI here that names those codes predates this change.

Closes #688