### PR TITLE
feat(yield-tier): add admin parameter setter

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -687,6 +687,10 @@ pub enum EscrowError {
     BumpTtlBatchEmpty = 234,
     /// [`LiquifactEscrow::bump_ttl_batch`] exceeded [`MAX_BUMP_TTL_BATCH`].
     BumpTtlBatchTooLarge = 235,
+    /// The yield-tier table supplied to [`LiquifactEscrow::set_yield_tiers`] violates an
+    /// invariant: the table is empty, a `yield_bps` falls outside `0..=10_000`,
+    /// `min_lock_secs` is not strictly increasing, or `yield_bps` decreases between tiers.
+    YieldTierTableInvalid = 236,
 }
 
 #[inline(always)]
@@ -1734,6 +1738,25 @@ pub struct LegalHoldClearDelayUpdated {
     pub invoice_id: Symbol,
     pub old_delay: u64,
     pub new_delay: u64,
+}
+/// Yield-tier table replaced by the admin.
+///
+/// Emitted by [`LiquifactEscrow::set_yield_tiers`] once the replacement table has passed
+/// every `init`-equivalent invariant and has been written to [`DataKey::YieldTierTable`].
+/// A rejected call emits nothing, so the presence of this event is a reliable signal that
+/// the stored ladder actually changed.
+///
+/// # Fields
+/// - `name`: Hardcoded `yt_upd` symbol.
+/// - `invoice_id`: Invoice identifier of the escrow whose table changed.
+/// - `tier_count`: Number of tiers in the newly stored table.
+#[contractevent]
+pub struct YieldTierTableUpdated {
+    #[topic]
+    pub name: Symbol,
+    #[topic]
+    pub invoice_id: String,
+    pub tier_count: u32,
 }
 
 /// SME collateral commitment metadata recorded.
@@ -3681,6 +3704,84 @@ impl LiquifactEscrow {
             result.push_back(tiers.get(i).unwrap());
         }
         result
+    }
+    /// Admin-only setter that replaces the entire yield-tier ladder.
+    ///
+    /// Before this entrypoint existed the ladder was fixed at [`LiquifactEscrow::init`] with
+    /// no update path, so correcting a mis-configured tier required redeploying the escrow.
+    /// `set_yield_tiers` closes that gap while enforcing exactly the invariants `init`
+    /// enforces, so no ladder reachable through this setter is unreachable through `init`.
+    ///
+    /// # Invariants
+    ///
+    /// 1. The table must be non-empty.
+    /// 2. Every `yield_bps` must satisfy `0 <= yield_bps <= 10_000`.
+    /// 3. `min_lock_secs` must be **strictly increasing** across tiers.
+    /// 4. `yield_bps` must be **non-decreasing** across tiers.
+    ///
+    /// Validation runs over the whole table **before** any storage write, so a rejected
+    /// call leaves the previously stored ladder byte-for-byte untouched. There is no
+    /// partial application.
+    ///
+    /// # Authorization
+    ///
+    /// [`InvoiceEscrow::admin`], enforced via [`Self::load_escrow_require_admin`]. A caller
+    /// without the admin authorization is rejected before any validation runs.
+    ///
+    /// # Errors
+    ///
+    /// - [`EscrowError::YieldTierTableInvalid`] (236) if any invariant above is violated.
+    ///
+    /// # Events
+    ///
+    /// Emits [`YieldTierTableUpdated`] carrying the new `tier_count` on success.
+    pub fn set_yield_tiers(env: Env, tiers: Vec<YieldTier>) {
+        let escrow = Self::load_escrow_require_admin(&env);
+
+        let n = tiers.len();
+        ensure(&env, n > 0, EscrowError::YieldTierTableInvalid);
+
+        // `prev_lock` starts at 0 so the first tier must declare a positive lock, and
+        // `prev_bps` starts at -1 so a first tier of 0 bps is accepted.
+        let mut prev_lock: u64 = 0;
+        let mut prev_bps: i64 = -1;
+
+        for i in 0..n {
+            let tier = tiers.get(i).unwrap();
+            ensure(
+                &env,
+                tier.yield_bps >= 0,
+                EscrowError::YieldTierTableInvalid,
+            );
+            ensure(
+                &env,
+                tier.yield_bps <= 10_000,
+                EscrowError::YieldTierTableInvalid,
+            );
+            ensure(
+                &env,
+                tier.min_lock_secs > prev_lock,
+                EscrowError::YieldTierTableInvalid,
+            );
+            ensure(
+                &env,
+                tier.yield_bps >= prev_bps,
+                EscrowError::YieldTierTableInvalid,
+            );
+            prev_lock = tier.min_lock_secs;
+            prev_bps = tier.yield_bps;
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::YieldTierTable, &tiers);
+
+        YieldTierTableUpdated {
+            name: symbol_short!("yt_upd"),
+            invoice_id: escrow.invoice_id.clone(),
+            tier_count: n,
+        }
+        .publish(&env);
     }
 
     /// Pure read — no auth, no storage writes, safe for simulation.

--- a/escrow/src/tests/yield_tier_setter.rs
+++ b/escrow/src/tests/yield_tier_setter.rs
@@ -1,0 +1,256 @@
+#![cfg(test)]
+//! Tests for the admin-guarded yield-tier setter (issue #1090).
+//!
+//! Coverage:
+//! - an in-bounds ladder is accepted, persisted, and read back through `get_yield_tiers`
+//! - each individual bound is rejected with `EscrowError::YieldTierTableInvalid`
+//! - a rejected call leaves the previously stored ladder untouched
+//! - a caller without admin authorization is rejected
+
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+
+use super::{assert_contract_error, default_init, setup, YieldTier};
+use crate::EscrowError;
+
+/// A well-formed two-tier ladder: strictly increasing locks, non-decreasing bps, in range.
+fn valid_tiers(env: &Env) -> soroban_sdk::Vec<YieldTier> {
+    vec![
+        env,
+        YieldTier {
+            min_lock_secs: 30 * 86_400,
+            yield_bps: 500,
+        },
+        YieldTier {
+            min_lock_secs: 90 * 86_400,
+            yield_bps: 900,
+        },
+    ]
+}
+
+#[test]
+fn set_yield_tiers_accepts_in_bounds_table() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let tiers = valid_tiers(&env);
+    client.set_yield_tiers(&tiers);
+
+    let stored = client.get_yield_tiers();
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored.get(0).unwrap().min_lock_secs, 30 * 86_400);
+    assert_eq!(stored.get(0).unwrap().yield_bps, 500);
+    assert_eq!(stored.get(1).unwrap().min_lock_secs, 90 * 86_400);
+    assert_eq!(stored.get(1).unwrap().yield_bps, 900);
+}
+
+#[test]
+fn set_yield_tiers_replaces_the_whole_table() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    client.set_yield_tiers(&valid_tiers(&env));
+    assert_eq!(client.get_yield_tiers().len(), 2);
+
+    // A shorter ladder must replace, not merge with, the previous one.
+    client.set_yield_tiers(&vec![
+        &env,
+        YieldTier {
+            min_lock_secs: 1,
+            yield_bps: 0,
+        },
+    ]);
+
+    let stored = client.get_yield_tiers();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored.get(0).unwrap().min_lock_secs, 1);
+    assert_eq!(stored.get(0).unwrap().yield_bps, 0);
+}
+
+#[test]
+fn set_yield_tiers_accepts_boundary_values() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    // yield_bps == 0 and yield_bps == 10_000 are both inclusive bounds.
+    client.set_yield_tiers(&vec![
+        &env,
+        YieldTier {
+            min_lock_secs: 1,
+            yield_bps: 0,
+        },
+        YieldTier {
+            min_lock_secs: 2,
+            yield_bps: 10_000,
+        },
+    ]);
+
+    let stored = client.get_yield_tiers();
+    assert_eq!(stored.get(0).unwrap().yield_bps, 0);
+    assert_eq!(stored.get(1).unwrap().yield_bps, 10_000);
+}
+
+#[test]
+fn set_yield_tiers_rejects_empty_table() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    assert_contract_error(
+        client.try_set_yield_tiers(&vec![&env]),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn set_yield_tiers_rejects_yield_bps_above_max() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    assert_contract_error(
+        client.try_set_yield_tiers(&vec![
+            &env,
+            YieldTier {
+                min_lock_secs: 1,
+                yield_bps: 10_001,
+            },
+        ]),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn set_yield_tiers_rejects_negative_yield_bps() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    assert_contract_error(
+        client.try_set_yield_tiers(&vec![
+            &env,
+            YieldTier {
+                min_lock_secs: 1,
+                yield_bps: -1,
+            },
+        ]),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn set_yield_tiers_rejects_zero_first_lock() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    // prev_lock starts at 0, so the first tier must declare a strictly positive lock.
+    assert_contract_error(
+        client.try_set_yield_tiers(&vec![
+            &env,
+            YieldTier {
+                min_lock_secs: 0,
+                yield_bps: 100,
+            },
+        ]),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn set_yield_tiers_rejects_non_increasing_locks() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    assert_contract_error(
+        client.try_set_yield_tiers(&vec![
+            &env,
+            YieldTier {
+                min_lock_secs: 100,
+                yield_bps: 100,
+            },
+            YieldTier {
+                min_lock_secs: 100,
+                yield_bps: 200,
+            },
+        ]),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn set_yield_tiers_rejects_decreasing_yield_bps() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    assert_contract_error(
+        client.try_set_yield_tiers(&vec![
+            &env,
+            YieldTier {
+                min_lock_secs: 100,
+                yield_bps: 900,
+            },
+            YieldTier {
+                min_lock_secs: 200,
+                yield_bps: 500,
+            },
+        ]),
+        EscrowError::YieldTierTableInvalid,
+    );
+}
+
+#[test]
+fn rejected_set_leaves_previous_table_intact() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    client.set_yield_tiers(&valid_tiers(&env));
+
+    // Second tier is out of range, so the whole call must be rejected atomically.
+    assert_contract_error(
+        client.try_set_yield_tiers(&vec![
+            &env,
+            YieldTier {
+                min_lock_secs: 10,
+                yield_bps: 100,
+            },
+            YieldTier {
+                min_lock_secs: 20,
+                yield_bps: 10_001,
+            },
+        ]),
+        EscrowError::YieldTierTableInvalid,
+    );
+
+    let stored = client.get_yield_tiers();
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored.get(0).unwrap().yield_bps, 500);
+    assert_eq!(stored.get(1).unwrap().yield_bps, 900);
+}
+
+#[test]
+fn set_yield_tiers_rejects_non_admin_caller() {
+    let env = Env::default();
+    let (client, admin, sme) = setup(&env);
+    default_init(&client, &env, &admin, &sme);
+
+    let _intruder = Address::generate(&env);
+
+    // Drop every mocked authorization so the admin require_auth gate is actually exercised.
+    env.set_auths(&[]);
+
+    let result = client.try_set_yield_tiers(&valid_tiers(&env));
+    assert!(
+        result.is_err(),
+        "set_yield_tiers must reject a caller lacking admin authorization"
+    );
+
+    // And the ladder configured at init must be unchanged.
+    env.mock_all_auths();
+    assert!(client.get_yield_tiers().is_empty());
+}


### PR DESCRIPTION
Closes #1090

Rebuilt from scratch on top of current `main` (`e061527`). The previous revision of this PR was branched off a stale fork SHA, conflicted, and shipped docs and tests for behaviour that did not exist. It has been replaced by a single commit that actually implements the setter.

## Changes

Three additions to `escrow/src/lib.rs` and one new test module. Nothing else in the repository is touched.

### 1. `LiquifactEscrow::set_yield_tiers(env, tiers)`

Admin-guarded entrypoint that replaces the entire yield-tier ladder, which was previously fixed at `init` with no update path.

Authorization goes through the existing `Self::load_escrow_require_admin(&env)` helper, so a caller without the admin authorization is rejected before any validation runs.

Validated invariants, identical to those `init` enforces:

| # | Rule |
|---|------|
| 1 | The table must be non-empty |
| 2 | Every `yield_bps` must satisfy `0 <= yield_bps <= 10_000` |
| 3 | `min_lock_secs` must be strictly increasing across tiers |
| 4 | `yield_bps` must be non-decreasing across tiers |

Validation runs over the whole table **before** any storage write, so a rejected call leaves the previously stored ladder byte-for-byte untouched. There is no partial application.

### 2. `EscrowError::YieldTierTableInvalid = 236`

Typed error returned for every out-of-range or mis-ordered table. 236 was the next free discriminant (the enum previously ended at 235).

### 3. `YieldTierTableUpdated` event

```rust
#[contractevent]
pub struct YieldTierTableUpdated {
    #[topic] pub name: Symbol,        // symbol_short!("yt_upd")
    #[topic] pub invoice_id: String,
    pub tier_count: u32,
}
```

Emitted only on success, so its presence is a reliable signal that the stored ladder actually changed.

### 4. `escrow/src/tests/yield_tier_setter.rs`

This file existed but was empty. It now contains 11 tests:

| Test | Covers |
|---|---|
| `set_yield_tiers_accepts_in_bounds_table` | happy path, values read back through `get_yield_tiers` |
| `set_yield_tiers_replaces_the_whole_table` | replacement semantics, not merge |
| `set_yield_tiers_accepts_boundary_values` | inclusive `0` and `10_000` bounds |
| `set_yield_tiers_rejects_empty_table` | invariant 1 |
| `set_yield_tiers_rejects_yield_bps_above_max` | invariant 2, upper |
| `set_yield_tiers_rejects_negative_yield_bps` | invariant 2, lower |
| `set_yield_tiers_rejects_zero_first_lock` | invariant 3, first tier |
| `set_yield_tiers_rejects_non_increasing_locks` | invariant 3, equal locks |
| `set_yield_tiers_rejects_decreasing_yield_bps` | invariant 4 |
| `rejected_set_leaves_previous_table_intact` | atomicity |
| `set_yield_tiers_rejects_non_admin_caller` | admin guard |

Every rejection path asserts the specific `EscrowError::YieldTierTableInvalid` code via the existing `assert_contract_error` helper, not a bare panic.

## Test output

I am not able to attach `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, or `cargo test` output, because **`main` has not compiled since `464abb5` ("Merge PR #1164 (took PR side)", 29 Jul 2026)** — this is pre-existing and unrelated to this PR.

On pristine `upstream/main` at `e061527`, with no local changes:

```
$ cargo check --all-targets
    Checking liquifact_escrow v0.1.0
error: this file contains an unclosed delimiter
 --> escrow/src/lib.rs:7194:3
2042 | impl LiquifactEscrow {
     |                      - unclosed delimiter
5039 | pub fn lower_min_contribution_floor(env: Env, new_floor: i128) -> i128 {
     |                                                                        - unclosed delimiter
5075 |     pub fn clear_legal_hold_after_delay(env: Env) {
     |                                                   - unclosed delimiter
6324 | pub fn partial_settle(env: Env, caller: Address) -> InvoiceEscrow {
     |                                                                   - unclosed delimiter
6459 |     pub fn claim_investor_payout(env: Env, investor: Address) {
     |                                                               - unclosed delimiter
7194 | }
     |  ^
error: could not compile `liquifact_escrow` (lib) due to 1 previous error
```

What I found while investigating, in case it is useful:

- A bisect over the last 15 commits touching `lib.rs` isolates `464abb5` as the first broken commit. Its parents are `46864f6` (main side) and `5cd7de8` (PR side); the merge took the PR side and dropped 1,129 lines from `lib.rs`.
- The result contains 18 duplicated function definitions in 4 clusters, with interleaved bodies — for example `MinContributionFloorLowered { ... }` at line 5061 is followed immediately by the doc comment for `clear_legal_hold_after_delay`, and `claim_investor_payout` runs straight into the doc comment for `settle_batch` at line 6499. The brace depth inside `impl LiquifactEscrow` ends at 5 instead of 0.
- `escrow/src/tests.rs` and `escrow/src/tests/mod.rs` both exist, which is a separate `E0761` conflict, and `tests/mod.rs` declares 26 modules against 50 files on disk.
- Head commit `e061527` is a docs-only merge, which suggests CI is not gating Rust builds.

I deliberately left all of that alone so this PR stays scoped to #1090. Happy to open a separate issue or PR for the `main` breakage if that would help.

## Scope

Only `escrow/src/lib.rs` (+101) and `escrow/src/tests/yield_tier_setter.rs` (+256). No changes to `main`'s duplicate-block corruption, the `tests.rs` / `tests/mod.rs` conflict, or any unrelated module.