### PR TITLE
fix(tests): restore orphaned test module declarations in escrow/src/tests.rs

### DIFF
--- a/escrow/src/tests.rs
+++ b/escrow/src/tests.rs
@@ -58,35 +58,40 @@ pub(crate) fn assert_contract_error<T, E>(
 // Focused test tree for escrow behavior. Shared helpers live here so feature
 // modules stay assertion-focused and each test still owns a fresh Env.
 mod admin;
+mod allowlist_event_payloads;
 mod attestation_event_schema;
 mod attestations;
 mod auth_matrix;
 mod cap_validation;
+mod collateral_boundary_tests;
+mod collateral_config_view;
+mod collateral_limit_setter;
 #[rustfmt::skip]
 mod coverage;
 mod external_calls;
 mod external_calls_mocked;
+mod fee_split_proptest;
 mod fees;
+mod fees_setter_tests;
 mod funding;
 mod funding_state_view;
+mod funding_upgrade_auth;
 mod init;
 mod integration;
 mod integration_status_guards;
 mod legal_hold;
 mod migration_errors;
+mod paginated_views;
 mod pause;
 mod properties;
 mod reconciliation_lifecycle;
 mod settlement;
 mod settlement_batch_tests;
+mod settlement_config_view;
 mod settlement_limit;
+mod yield_tier_boundaries;
 mod yield_tier_overflow;
-
-mod allowlist_event_payloads;
-mod collateral_config_view;
 mod yield_tier_setter;
-mod yield_tier_struct;
-
 /// Registers a new escrow contract instance and returns its contract id.
 pub fn deploy_id(env: &Env) -> Address {
     env.register(LiquifactEscrow, ())


### PR DESCRIPTION
## Summary

`escrow/src/tests.rs` currently declares a module that does not exist and fails to declare eight modules whose files **are** present in the repository. This PR realigns the module tree with the files on disk.

This is a self-reported cleanup: the drift was introduced by my own PRs #1165 and #1168, which each rewrote the same contiguous block of `escrow/src/tests.rs`. Because they were reviewed in parallel and merged sequentially, the second merge silently discarded the first one's additions and neither restored the declarations both had removed.

## What is wrong on `main` today

**Declared but has no file:**

| Module | Status |
|---|---|
| `yield_tier_struct` | No `escrow/src/tests/yield_tier_struct.rs` exists anywhere in the repo history |

**File exists but is not declared (dead code, never compiled):**

| Module | Introduced / removed by |
|---|---|
| `fee_split_proptest` | Added by #1165, declaration dropped by #1168 |
| `fees_setter_tests` | Added by #1168, declaration absent on `main` |
| `paginated_views` | Declaration removed by #1165 |
| `settlement_config_view` | Declaration removed by #1165 |
| `funding_upgrade_auth` | Declaration removed by #1165 |
| `yield_tier_boundaries` | Declaration removed by #1165 |
| `collateral_limit_setter` | Declaration removed by #1165 |
| `collateral_boundary_tests` | Declaration removed by #1165 (and was duplicated before that) |

The practical impact is that the test suites added by #1165 and #1168 — the fee-split property tests and the `set_protocol_fee_bps` setter tests — are **not currently part of the build at all**, alongside six pre-existing suites.

## Changes

- Remove `mod yield_tier_struct;`
- Add the eight missing declarations listed above
- Collapse the previously duplicated `mod collateral_boundary_tests;` to a single entry
- Sort the block alphabetically so future edits conflict textually instead of silently overwriting each other

No test bodies, assertions, or contract code are touched. The diff is confined to the `mod` block of `escrow/src/tests.rs` (+10 / −5).

## Note on verification

I was not able to attach `cargo test` output for this PR. `escrow/src/lib.rs` on `main` has not parsed since `464abb5` ("Merge PR #1164 (took PR side)", 2026-07-29), which fails with:

```
error: this file contains an unclosed delimiter
 --> escrow/src/lib.rs:7194:3
2042 | impl LiquifactEscrow {
     |                      - unclosed delimiter
```

That merge resolved a conflict by interleaving function bodies inside `impl LiquifactEscrow`, leaving 18 duplicated function definitions and four unbalanced braces. It is entirely separate from this change and I have deliberately left it alone rather than widen this PR's scope — but it does mean the crate cannot be compiled on `main` right now, so this module-tree fix cannot be validated by a build until that is addressed. Bisect narrowed it precisely: `46864f6` (the main-side parent) parses cleanly, `464abb5` does not.

Happy to split, reorder, or drop any part of this if maintainers would rather handle the module tree differently.