### PR TITLE
Add a version/metadata view to fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ liquifact-contracts/
 | `cancel_pending_admin` | Admin | Admin withdraws an unaccepted proposal. |
 | `get_escrow` | — | Read current escrow state. |
 | `get_version` | — | Read stored `DataKey::Version`. |
+| `get_fees_version` | — | Read the fees subsystem's schema version (`DataKey::Version`). Returns `0` before `init`. Consistent with `get_version`; named separately for integrators scoped to the fees API. |
 | `get_collateral_version` | — | Read the collateral subsystem's schema version (`DataKey::Version`). Returns `0` before `init`. Consistent with `get_version`; named separately for integrators scoped to the collateral API. |
 | `get_pauser_version` | — | Read the pauser subsystem's schema version (`DataKey::Version`). Returns `0` before `init`. Consistent with `get_version`; named separately for integrators scoped to the pauser API. |
 | `get_remaining_investor_slots` | — | Read remaining unique investor capacity before reaching the cap. |

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -2917,6 +2917,15 @@ impl LiquifactEscrow {
         env.storage().instance().get(&DataKey::Version).unwrap_or(0)
     }
 
+    /// Read-only fees-specific version view.
+    ///
+    /// Returns the deployed schema version exposed via [`DataKey::Version`], keeping the
+    /// fees subsystem aligned with the rest of the contract's version/metadata read APIs.
+    /// Before [`LiquifactEscrow::init`] it returns the same sane default as [`get_version`]: `0`.
+    pub fn get_fees_version(env: Env) -> u32 {
+        Self::get_version(env)
+    }
+
     /// Get the optional funding deadline (ledger timestamp), returns None if not set.
     pub fn get_funding_deadline(env: Env) -> Option<u64> {
         env.storage().instance().get(&keys::funding_deadline())

--- a/escrow/src/tests/fees.rs
+++ b/escrow/src/tests/fees.rs
@@ -1,0 +1,96 @@
+//! Tests for [`LiquifactEscrow::get_fees_version`].
+//!
+//! Covers:
+//! - Default value (`0`) returned before [`LiquifactEscrow::init`] is called.
+//! - Correct [`SCHEMA_VERSION`] returned after [`LiquifactEscrow::init`].
+//! - Consistency with [`LiquifactEscrow::get_version`].
+//! - Read-only semantics: no auth is required and fee updates do not alter the version.
+
+use super::super::{LiquifactEscrow, LiquifactEscrowClient, SCHEMA_VERSION};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn deploy(env: &Env) -> LiquifactEscrowClient<'_> {
+    let id = env.register(LiquifactEscrow, ());
+    LiquifactEscrowClient::new(env, &id)
+}
+
+fn deploy_and_init(env: &Env) -> LiquifactEscrowClient<'_> {
+    let client = deploy(env);
+    let admin = Address::generate(env);
+    let sme = Address::generate(env);
+    let token = Address::generate(env);
+    let treasury = Address::generate(env);
+
+    client.init(
+        &admin,
+        &soroban_sdk::String::from_str(env, "FEES001"),
+        &sme,
+        &10_000i128,
+        &800i64,
+        &0u64,
+        &token,
+        &None,
+        &treasury,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None::<i64>,
+    );
+
+    client
+}
+
+#[test]
+fn test_get_fees_version_default_before_init() {
+    let env = Env::default();
+    let client = deploy(&env);
+
+    assert_eq!(client.get_fees_version(), 0);
+}
+
+#[test]
+fn test_get_fees_version_after_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy_and_init(&env);
+
+    assert_eq!(client.get_fees_version(), SCHEMA_VERSION);
+}
+
+#[test]
+fn test_get_fees_version_matches_global_version_before_and_after_init() {
+    let env = Env::default();
+    let client = deploy(&env);
+    assert_eq!(client.get_fees_version(), client.get_version());
+
+    env.mock_all_auths();
+    let client = deploy_and_init(&env);
+    assert_eq!(client.get_fees_version(), client.get_version());
+}
+
+#[test]
+fn test_get_fees_version_requires_no_auth() {
+    let env = Env::default();
+    let client = deploy(&env);
+
+    assert_eq!(client.get_fees_version(), 0);
+}
+
+#[test]
+fn test_get_fees_version_unchanged_after_set_protocol_fee_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy_and_init(&env);
+
+    let before = client.get_fees_version();
+    client.set_protocol_fee_bps(&2500i64);
+    let after = client.get_fees_version();
+
+    assert_eq!(before, after);
+    assert_eq!(after, SCHEMA_VERSION);
+}


### PR DESCRIPTION
##closes #1032 


## PR Title
feat(fees): add version view

## PR Description
### Summary
Adds a read-only fees-specific version view to the escrow contract so callers can query the deployed schema/version metadata without mutating storage.

### What changed
- Added `get_fees_version(env) -> u32`
- Returns the stored schema version from `DataKey::Version`
- Returns `0` before initialization, matching the existing sane-default behavior for version views
- Added regression tests covering:
  - default before init
  - value after init
  - consistency with `get_version`
  - no-auth read behavior
  - stability after fee-setting mutations
- Documented the new API in the README

### Verification
- Static editor checks reported no errors for the touched Rust files
- Full `cargo fmt`, `cargo clippy`, and `cargo test` could not be run in this container because the Rust toolchain was not installed here

### Notes
- Commit: `dee3790`